### PR TITLE
feat(loop): add iteration-aware task generation guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,20 +19,41 @@ task install           # Install goralph to ~/.local/bin/
 ```bash
 goralph build          # Run agentic loop in build mode
 goralph plan           # Run agentic loop in plan mode
-goralph build -n 5     # Run with max 5 iterations
-goralph plan --max 10  # Run with max 10 iterations
+goralph build -n 5     # Run with max 5 iterations (tasks broken into ~5 pieces)
+goralph plan --max 10  # Run with max 10 iterations (tasks broken into ~10 pieces)
 ```
+
+## How It Works
+
+1. **Reads prompt file** from `.ralph/PROMPT_build.md` or `.ralph/PROMPT_plan.md`
+2. **Appends implementation plan** from `.ralph/IMPLEMENTATION_PLAN.md` with instructions
+3. **Runs Claude Code** with the combined prompt, streaming output in real-time
+4. **Claude completes one task**, updates the implementation plan, and commits
+5. **Pushes changes** to the remote branch
+6. **Loops** until max iterations reached or all tasks complete
+
+### Iteration-Aware Task Generation
+
+When using `--max`/`-n` flag:
+- Claude is instructed to break work into approximately N tasks (one per iteration)
+- Without the flag, Claude creates a comprehensive task list
 
 ## Project Structure
 
 - `cmd/` - Cobra CLI commands (root, build, plan)
-- `internal/loop/` - Core loop logic, output formatting, and types
-- `.ralph/` - Prompt files for build and plan modes
+- `internal/loop/` - Core loop logic
+  - `loop.go` - Main loop execution and Claude iteration
+  - `output.go` - Terminal output formatting with lipgloss
+  - `types.go` - Message types for JSON stream parsing
+- `internal/version/` - Version info (populated via ldflags at build time)
+- `.ralph/` - Prompt files and implementation plan
+- `.ralph/logs/` - Timestamped JSONL logs of each Claude session
 
 ## Required Files
 
 - `.ralph/PROMPT_build.md` - Build mode prompt for the agentic loop
 - `.ralph/PROMPT_plan.md` - Plan mode prompt for the agentic loop
+- `.ralph/IMPLEMENTATION_PLAN.md` - Task tracking file (auto-created if missing)
 - `taskfile.yml` - Task runner configuration
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Reference: [Ralph Wiggum Technique](https://github.com/ghuntley/how-to-ralph-wig
 ## Features
 
 - **Build and Plan Modes** - Two execution modes with dedicated prompt files for different workflows
+- **Implementation Plan Tracking** - Auto-manages `.ralph/IMPLEMENTATION_PLAN.md` for task tracking across iterations
+- **Iteration-Aware Task Generation** - When using `-n`/`--max`, Claude breaks work into approximately N tasks
 - **Configurable Iteration Limits** - Set maximum iterations with `-n`/`--max` flag or run unlimited
 - **Automatic Git Pushes** - Pushes changes to remote after each iteration, auto-creates remote branches
 - **Styled Terminal Output** - Simple terminal UI with lipgloss styling, colored status indicators, and boxed summaries
@@ -83,3 +85,4 @@ Before running, ensure these prompt files exist in your `.ralph/` directory:
 
 - `.ralph/PROMPT_build.md` - Prompt used for build mode
 - `.ralph/PROMPT_plan.md` - Prompt used for plan mode
+- `.ralph/IMPLEMENTATION_PLAN.md` - Task tracking file (auto-created if missing)


### PR DESCRIPTION
## Summary

When using `--max`/`-n` flag to limit iterations, the implementation plan instructions now tell Claude to break work into approximately N tasks (one per iteration). Without the flag, it generates a comprehensive task list as before.

## Changes

- Updated `buildPromptWithPlan` to accept `maxIterations` parameter
- Added conditional task guidance based on iteration limit:
  - With `--max N`: "break the work into approximately N tasks (one per iteration)"
  - Without limit: "add a comprehensive list of implementation tasks"
- Refactored `runClaudeIteration` to accept `Config` struct for better extensibility

## Breaking Changes

None

## Test Plan

- [ ] Build the project: `task build`
- [ ] Test with max iterations: `goralph build -n 3` - verify instructions mention "break the work into approximately 3 tasks"
- [ ] Test without max iterations: `goralph build` - verify instructions say "add a comprehensive list of implementation tasks"

## Release Notes

The agentic loop now provides smarter task generation guidance. When running with `--max`/`-n` flag, Claude is instructed to break work into approximately that many tasks, enabling more predictable iteration-based workflows.

## Checklist

- [x] Build passes (`task build`)
- [x] Conventional commit format followed