### PR TITLE
feat(cli): add --no-push flag to skip pushing after iterations

### DIFF
--- a/.ralph/IMPLEMENTATION_PLAN.md
+++ b/.ralph/IMPLEMENTATION_PLAN.md
@@ -29,6 +29,7 @@ When using `--json`, Codex outputs newline-delimited JSON with these event types
   - Add `CLI` field to `Config` struct in `internal/loop/loop.go`
   - Add `--cli` flag to both `cmd/build.go` and `cmd/plan.go` (default: `claude`)
   - Support `GORALPH_CLI` environment variable as fallback using `cobra` flag binding
+  - Validate CLI provider value and return error for unknown providers
 
 - [ ] **Task 2: Create provider-specific command builders**
   - Create `internal/loop/provider.go` with `Provider` interface:
@@ -36,23 +37,59 @@ When using `--json`, Codex outputs newline-delimited JSON with these event types
     type Provider interface {
         Name() string
         BuildCommand(prompt []byte) (*exec.Cmd, error)
+        ParseOutput(r io.Reader, w io.Writer, logFile io.Writer) (*ResultMessage, error)
     }
     ```
-  - Implement `ClaudeProvider` that builds: `claude -p --dangerously-skip-permissions --output-format=stream-json --verbose`
-  - Implement `CodexProvider` that builds: `codex exec --json --dangerously-bypass-approvals-and-sandbox -`
-  - Refactor `runClaudeIteration` → `runIteration` to accept a `Provider`
-  - Add `GetProvider(cfg Config) Provider` factory function
+  - Implement `ClaudeProvider`:
+    - `BuildCommand`: `claude -p --dangerously-skip-permissions --output-format=stream-json --verbose`
+    - `ParseOutput`: existing `parseClaudeOutput` logic
+  - Implement `CodexProvider`:
+    - `BuildCommand`: `codex exec --json --dangerously-bypass-approvals-and-sandbox -`
+    - `ParseOutput`: new Codex-specific parser (see Task 3)
+  - Add `NewProvider(cli CLIProvider) (Provider, error)` factory function
+  - Refactor `runClaudeIteration` → `runIteration` to use `Provider` interface
+  - Update `Run()` to instantiate provider once at start
 
-- [ ] **Task 3: Adapt output parsing for Codex JSON format**
+- [ ] **Task 3: Implement Codex output parsing**
   - Add Codex-specific message types to `types.go`:
-    - `CodexEvent` with `type` field (`thread.started`, `turn.*`, `item.*`, `error`)
-    - `CodexItemEvent` for item-specific payloads
-  - Create `parseCodexOutput` function that:
-    - Handles `turn.started`/`turn.completed` for iteration tracking
-    - Extracts text content from `item.*` events
+    ```go
+    type CodexEvent struct {
+        Type string `json:"type"`  // thread.started, turn.*, item.*, error
+    }
+    type CodexItemEvent struct {
+        Type    string `json:"type"`
+        Content any    `json:"content,omitempty"`
+        // Additional fields based on item type
+    }
+    ```
+  - Implement `CodexProvider.ParseOutput` that:
+    - Handles `turn.started`/`turn.completed`/`turn.failed` for turn tracking
+    - Extracts text from `item.message` and `item.reasoning` events
+    - Shows tool invocations from `item.command_*` and `item.mcp_tool_*` events
     - Handles `error` events gracefully
-  - Update `parseOutput` to dispatch to correct parser based on provider
-  - Update `FormatHeader` in `output.go` to display which CLI is being used
+    - Returns a `ResultMessage` equivalent for summary display
+  - Update `FormatHeader` in `output.go` to display CLI provider name
+  - Add `FormatIterationSummary` variant or adapter for Codex stats
+
+## Implementation Notes
+
+### File Changes Summary
+
+| File | Changes |
+|------|---------|
+| `internal/loop/types.go` | Add `CLIProvider` type, Codex event types |
+| `internal/loop/loop.go` | Add `CLI` to Config, refactor to use Provider |
+| `internal/loop/provider.go` | New file with Provider interface and implementations |
+| `internal/loop/output.go` | Update `FormatHeader` to show CLI |
+| `cmd/build.go` | Add `--cli` flag |
+| `cmd/plan.go` | Add `--cli` flag |
+
+### Testing Strategy
+
+- Test with both `claude` and `codex` CLI values
+- Verify JSON parsing with sample output from each CLI
+- Test environment variable fallback (`GORALPH_CLI`)
+- Ensure graceful error handling for missing CLI executables
 
 ## Completed
 

--- a/.ralph/IMPLEMENTATION_PLAN.md
+++ b/.ralph/IMPLEMENTATION_PLAN.md
@@ -1,39 +1,41 @@
-# Implementation Plan: Add Codex CLI Support
+# Implementation Plan
 
 ## Overview
 
-Add support for OpenAI's Codex CLI as an alternative to Claude Code. Users will be able to choose between `claude` and `codex` as the AI backend for the agentic loop.
+Add support for OpenAI Codex CLI as an alternative to Claude Code CLI. Users can choose which CLI to use via a `--cli` flag or environment variable.
 
-### Key Differences Between CLIs
+## Key Differences Between CLIs
 
-| Feature | Claude | Codex |
-|---------|--------|-------|
+| Feature | Claude Code | Codex CLI |
+|---------|-------------|-----------|
 | Command | `claude` | `codex exec` |
-| Prompt flag | `-p` (stdin) | positional or stdin |
-| Skip permissions | `--dangerously-skip-permissions` | `--yolo` or `--dangerously-bypass-approvals-and-sandbox` |
-| JSON output | `--output-format=stream-json` | `--json` (newline-delimited JSON events) |
-| Verbose | `--verbose` | (not needed for JSON mode) |
+| Piped input | `-p` flag + stdin | stdin with `-` |
+| Skip permissions | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` or `--yolo` |
+| JSON output | `--output-format=stream-json` | `--json` (newline-delimited) |
+| Verbose | `--verbose` | (default behavior) |
 
 ## Tasks
 
-- [ ] **2. Implement ClaudeRunner** - Move Claude-specific logic from `loop.go` into `internal/runner/claude.go`. Implement the `Runner` interface for Claude. Extract `runClaudeIteration` logic into the runner, including command construction and output parsing.
+- [ ] **Task 1: Add CLI provider type and configuration**
+  - Add `CLIProvider` type (`claude`, `codex`) in `internal/loop/types.go`
+  - Add `CLI` field to `Config` struct in `internal/loop/loop.go`
+  - Add `--cli` flag to both `build.go` and `plan.go` commands (default: `claude`)
+  - Support `GORALPH_CLI` environment variable as fallback
 
-- [ ] **3. Implement CodexRunner** - Create `internal/runner/codex.go` implementing the `Runner` interface for Codex CLI. Use `codex exec` with `--json` for structured output. Parse Codex JSON events and map to common `Result` struct. Handle Codex-specific flags (`--yolo`, `--full-auto`).
+- [ ] **Task 2: Create provider-specific command builders**
+  - Create `internal/loop/provider.go` with `Provider` interface
+  - Implement `ClaudeProvider` that builds Claude CLI command
+  - Implement `CodexProvider` that builds Codex CLI command
+  - Refactor `runClaudeIteration` to use provider interface
+  - Handle different JSON output formats between providers
 
-- [ ] **4. Add runner selection to Config** - Add `Runner` field to `loop.Config` struct (type `runner.Runner`). Update `loop.Run()` to use the configured runner instead of hardcoded Claude. Keep backward compatibility by defaulting to Claude if no runner specified.
-
-- [ ] **5. Add --runner flag to CLI commands** - Add `--runner` or `-r` flag to `build` and `plan` commands accepting "claude" or "codex". Create runner factory function in `cmd/` package that instantiates the correct runner. Update both command files to pass the runner to `loop.Config`.
-
-- [ ] **6. Add runner display to header output** - Update `FormatHeader()` to show which runner is being used. Add runner name to the `Config` struct or pass it separately.
-
-- [ ] **7. Create runner-specific output types** - Define Codex-specific JSON message types in `internal/runner/codex_types.go`. Map Codex events to the existing streaming display format where possible. Handle differences in tool invocation reporting.
-
-- [ ] **8. Add configuration file support for default runner** - Create optional config file support (e.g., `.ralph/config.toml` or environment variable `GORALPH_RUNNER`). Allow users to set their preferred default runner without CLI flags.
-
-- [ ] **9. Update documentation and help text** - Update root command long description to mention both CLI options. Add runner information to `--help` output for build and plan commands. Update CLAUDE.md with new CLI usage examples.
-
-- [ ] **10. Add runner validation** - Verify the selected runner CLI is installed and accessible before starting the loop. Provide helpful error messages if the CLI is not found (e.g., "codex not found, install with: npm i -g @openai/codex").
+- [ ] **Task 3: Adapt output parsing for Codex JSON format**
+  - Research Codex CLI's newline-delimited JSON event format
+  - Add Codex-specific message types to `types.go` if needed
+  - Create `parseCodexOutput` function or extend `parseClaudeOutput` to handle both formats
+  - Update `FormatHeader` to show which CLI is being used
+  - Test with both CLIs and ensure consistent output formatting
 
 ## Completed
 
-- [x] **1. Define Runner interface** - Created `internal/runner/runner.go` with a `Runner` interface that abstracts the AI CLI execution. Defined methods: `Name() string`, `Command() *exec.Cmd`, `ParseOutput(io.Reader, io.Writer, io.Writer) (*Result, error)`. Created `Result` and `Usage` structs with common fields.
+<!-- Completed tasks will be moved here as: - [x] Task description -->

--- a/.ralph/IMPLEMENTATION_PLAN.md
+++ b/.ralph/IMPLEMENTATION_PLAN.md
@@ -9,32 +9,50 @@ Add support for OpenAI Codex CLI as an alternative to Claude Code CLI. Users can
 | Feature | Claude Code | Codex CLI |
 |---------|-------------|-----------|
 | Command | `claude` | `codex exec` |
-| Piped input | `-p` flag + stdin | stdin with `-` |
-| Skip permissions | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` or `--yolo` |
-| JSON output | `--output-format=stream-json` | `--json` (newline-delimited) |
-| Verbose | `--verbose` | (default behavior) |
+| Piped input | `-p` flag + stdin | `-` argument reads from stdin |
+| Skip permissions | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` (alias: `--yolo`) |
+| JSON output | `--output-format=stream-json` | `--json` (newline-delimited JSONL) |
+| Verbose | `--verbose` | (streams progress to stderr by default) |
+
+### Codex CLI JSON Event Types (from [OpenAI docs](https://developers.openai.com/codex/noninteractive/))
+
+When using `--json`, Codex outputs newline-delimited JSON with these event types:
+- `thread.started` - Session initialization
+- `turn.started` / `turn.completed` / `turn.failed` - Turn lifecycle
+- `item.*` - Agent messages, reasoning, command executions, file changes, MCP tool calls, web searches, plan updates
+- `error` - Error events
 
 ## Tasks
 
 - [ ] **Task 1: Add CLI provider type and configuration**
   - Add `CLIProvider` type (`claude`, `codex`) in `internal/loop/types.go`
   - Add `CLI` field to `Config` struct in `internal/loop/loop.go`
-  - Add `--cli` flag to both `build.go` and `plan.go` commands (default: `claude`)
-  - Support `GORALPH_CLI` environment variable as fallback
+  - Add `--cli` flag to both `cmd/build.go` and `cmd/plan.go` (default: `claude`)
+  - Support `GORALPH_CLI` environment variable as fallback using `cobra` flag binding
 
 - [ ] **Task 2: Create provider-specific command builders**
-  - Create `internal/loop/provider.go` with `Provider` interface
-  - Implement `ClaudeProvider` that builds Claude CLI command
-  - Implement `CodexProvider` that builds Codex CLI command
-  - Refactor `runClaudeIteration` to use provider interface
-  - Handle different JSON output formats between providers
+  - Create `internal/loop/provider.go` with `Provider` interface:
+    ```go
+    type Provider interface {
+        Name() string
+        BuildCommand(prompt []byte) (*exec.Cmd, error)
+    }
+    ```
+  - Implement `ClaudeProvider` that builds: `claude -p --dangerously-skip-permissions --output-format=stream-json --verbose`
+  - Implement `CodexProvider` that builds: `codex exec --json --dangerously-bypass-approvals-and-sandbox -`
+  - Refactor `runClaudeIteration` → `runIteration` to accept a `Provider`
+  - Add `GetProvider(cfg Config) Provider` factory function
 
 - [ ] **Task 3: Adapt output parsing for Codex JSON format**
-  - Research Codex CLI's newline-delimited JSON event format
-  - Add Codex-specific message types to `types.go` if needed
-  - Create `parseCodexOutput` function or extend `parseClaudeOutput` to handle both formats
-  - Update `FormatHeader` to show which CLI is being used
-  - Test with both CLIs and ensure consistent output formatting
+  - Add Codex-specific message types to `types.go`:
+    - `CodexEvent` with `type` field (`thread.started`, `turn.*`, `item.*`, `error`)
+    - `CodexItemEvent` for item-specific payloads
+  - Create `parseCodexOutput` function that:
+    - Handles `turn.started`/`turn.completed` for iteration tracking
+    - Extracts text content from `item.*` events
+    - Handles `error` events gracefully
+  - Update `parseOutput` to dispatch to correct parser based on provider
+  - Update `FormatHeader` in `output.go` to display which CLI is being used
 
 ## Completed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ goralph build          # Run agentic loop in build mode
 goralph plan           # Run agentic loop in plan mode
 goralph build -n 5     # Run with max 5 iterations (tasks broken into ~5 pieces)
 goralph plan --max 10  # Run with max 10 iterations (tasks broken into ~10 pieces)
+goralph build --no-push  # Run without pushing changes after each iteration
 ```
 
 ## How It Works
@@ -29,7 +30,7 @@ goralph plan --max 10  # Run with max 10 iterations (tasks broken into ~10 piece
 2. **Appends implementation plan** from `.ralph/IMPLEMENTATION_PLAN.md` with instructions
 3. **Runs Claude Code** with the combined prompt, streaming output in real-time
 4. **Claude completes one task**, updates the implementation plan, and commits
-5. **Pushes changes** to the remote branch
+5. **Pushes changes** to the remote branch (unless `--no-push` is set)
 6. **Loops** until max iterations reached or all tasks complete
 
 ### Iteration-Aware Task Generation

--- a/README.md
+++ b/README.md
@@ -72,12 +72,18 @@ goralph build
 goralph build --max 20
 goralph build -n 20
 
+# Run without pushing changes after each iteration
+goralph build --no-push
+
 # Run the agentic loop in plan mode
 goralph plan
 
 # Run in plan mode with max 5 iterations
 goralph plan --max 5
 goralph plan -n 5
+
+# Combine flags
+goralph build -n 10 --no-push
 ```
 
 ### Options
@@ -85,6 +91,7 @@ goralph plan -n 5
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--max` | `-n` | Maximum number of iterations (0 = unlimited) |
+| `--no-push` | | Skip pushing changes after each iteration |
 
 ### Required Files
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -6,6 +6,7 @@ import (
 )
 
 var buildMaxIterations int
+var buildNoPush bool
 
 var buildCmd = &cobra.Command{
 	Use:   "build",
@@ -16,6 +17,7 @@ var buildCmd = &cobra.Command{
 			Mode:          loop.ModeBuild,
 			PromptFile:    ".ralph/PROMPT_build.md",
 			MaxIterations: buildMaxIterations,
+			NoPush:        buildNoPush,
 			Output:        cmd.OutOrStdout(),
 		})
 	},
@@ -23,5 +25,6 @@ var buildCmd = &cobra.Command{
 
 func init() {
 	buildCmd.Flags().IntVarP(&buildMaxIterations, "max", "n", 0, "Maximum number of iterations (0 = unlimited)")
+	buildCmd.Flags().BoolVar(&buildNoPush, "no-push", false, "Skip pushing changes after each iteration")
 	rootCmd.AddCommand(buildCmd)
 }

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -6,6 +6,7 @@ import (
 )
 
 var planMaxIterations int
+var planNoPush bool
 
 var planCmd = &cobra.Command{
 	Use:   "plan",
@@ -16,6 +17,7 @@ var planCmd = &cobra.Command{
 			Mode:          loop.ModePlan,
 			PromptFile:    ".ralph/PROMPT_plan.md",
 			MaxIterations: planMaxIterations,
+			NoPush:        planNoPush,
 			Output:        cmd.OutOrStdout(),
 		})
 	},
@@ -23,5 +25,6 @@ var planCmd = &cobra.Command{
 
 func init() {
 	planCmd.Flags().IntVarP(&planMaxIterations, "max", "n", 0, "Maximum number of iterations (0 = unlimited)")
+	planCmd.Flags().BoolVar(&planNoPush, "no-push", false, "Skip pushing changes after each iteration")
 	rootCmd.AddCommand(planCmd)
 }


### PR DESCRIPTION
## Summary

Adds a `--no-push` flag to both `build` and `plan` commands, allowing users to run the agentic loop without automatically pushing changes to the remote after each iteration.

## Changes

- Add `NoPush` field to `loop.Config` struct
- Add `--no-push` boolean flag to both `build` and `plan` commands
- Conditionally skip `pushChanges()` when the flag is set
- Add system context with iteration info to prompts sent to Claude
- Update README.md and CLAUDE.md with usage documentation

## Commits

- `5cfd41f` feat(cli): add --no-push flag to skip pushing after iterations
- `48f0a2f` docs: update documentation for --no-push flag

## Breaking Changes

None

## Test Plan

- [x] Build the binary: `task build`
- [x] Verify flag appears in help:
  ```bash
  ./goralph build --help
  ./goralph plan --help
  ```
- [x] Test that `--no-push` skips the push step (requires .ralph/ setup)
- [x] Verify combining flags works: `goralph build -n 5 --no-push`

## Related Issues

None

## Release Notes

Users can now use the `--no-push` flag to run the agentic loop without automatically pushing changes after each iteration. This is useful for local development, testing, or working offline.

## Checklist

- [x] Build passes (`task build`)
- [x] Documentation updated
- [x] Conventional commit format followed