### PR TITLE
feat(loop): add session-scoped implementation plan files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ debug
 *.log
 
 # AI
+ai_docs/
 .claude/
 .qbit/
 .ralph/

--- a/.ralph/plans/implementation_plan_20260122T171858.md
+++ b/.ralph/plans/implementation_plan_20260122T171858.md
@@ -1,0 +1,11 @@
+# Implementation Plan
+
+## Tasks
+
+- [ ] Summarize repository purpose, features, and core workflow for users
+- [ ] Outline setup requirements and basic usage commands (build/plan, flags)
+- [ ] Note operational considerations (prompts, logs, safety, agent providers)
+
+## Completed
+
+- [x] Summarize repository purpose, features, and core workflow for users

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ GORALPH_AGENT=codex  # Set default agent provider (claude or codex)
 ## How It Works
 
 1. **Reads prompt file** from `.ralph/PROMPT_build.md` or `.ralph/PROMPT_plan.md`
-2. **Appends implementation plan** from `.ralph/IMPLEMENTATION_PLAN.md` with instructions
+2. **Creates session-scoped plan** in `.ralph/plans/implementation_plan_{timestamp}.md`
 3. **Runs the selected agent** (Claude Code or Codex) with the combined prompt, streaming output in real-time
 4. **Agent completes one task**, updates the implementation plan, and commits
 5. **Pushes changes** to the remote branch (unless `--no-push` is set)
@@ -56,14 +56,15 @@ When using `--max`/`-n` flag:
   - `prompt.go` - Prompt file reading and construction
   - `git.go` - Git operations (push, branch management)
 - `internal/version/` - Version info (populated via ldflags at build time)
-- `.ralph/` - Prompt files and implementation plan
+- `.ralph/` - Prompt files and session data
+- `.ralph/plans/` - Session-scoped implementation plans (timestamped)
 - `.ralph/logs/` - Timestamped JSONL logs of each agent session
 
 ## Required Files
 
 - `.ralph/PROMPT_build.md` - Build mode prompt for the agentic loop
 - `.ralph/PROMPT_plan.md` - Plan mode prompt for the agentic loop
-- `.ralph/IMPLEMENTATION_PLAN.md` - Task tracking file (auto-created if missing)
+- `.ralph/plans/` - Directory for session-scoped implementation plans (auto-created)
 - `taskfile.yml` - Task runner configuration
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Reference: [Ralph Wiggum Technique](https://github.com/ghuntley/how-to-ralph-wig
 
 - **Multi-Agent Support** - Choose between Claude Code and OpenAI Codex CLI as your agent provider
 - **Build and Plan Modes** - Two execution modes with dedicated prompt files for different workflows
-- **Implementation Plan Tracking** - Auto-manages `.ralph/IMPLEMENTATION_PLAN.md` for task tracking across iterations
+- **Session-Scoped Implementation Plans** - Creates timestamped plan files in `.ralph/plans/` for each session
 - **Iteration-Aware Task Generation** - When using `-n`/`--max`, the agent breaks work into approximately N tasks
 - **Configurable Iteration Limits** - Set maximum iterations with `-n`/`--max` flag or run unlimited
 - **Automatic Git Pushes** - Pushes changes to remote after each iteration, auto-creates remote branches
@@ -111,7 +111,7 @@ Before running, ensure these prompt files exist in your `.ralph/` directory:
 
 - `.ralph/PROMPT_build.md` - Prompt used for build mode
 - `.ralph/PROMPT_plan.md` - Prompt used for plan mode
-- `.ralph/IMPLEMENTATION_PLAN.md` - Task tracking file (auto-created if missing)
+- `.ralph/plans/` - Directory for session-scoped implementation plans (auto-created)
 
 ### Warning
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -25,6 +25,7 @@ var buildCmd = &cobra.Command{
 		return loop.Run(loop.Config{
 			Mode:          loop.ModeBuild,
 			PromptFile:    ".ralph/PROMPT_build.md",
+			PlanFile:      loop.GeneratePlanPath(),
 			MaxIterations: buildMaxIterations,
 			NoPush:        buildNoPush,
 			Agent:         agentProvider,

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -25,6 +25,7 @@ var planCmd = &cobra.Command{
 		return loop.Run(loop.Config{
 			Mode:          loop.ModePlan,
 			PromptFile:    ".ralph/PROMPT_plan.md",
+			PlanFile:      loop.GeneratePlanPath(),
 			MaxIterations: planMaxIterations,
 			NoPush:        planNoPush,
 			Agent:         agentProvider,

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -31,8 +31,13 @@ func Run(cfg Config) error {
 		return fmt.Errorf("prompt file not found: %s", cfg.PromptFile)
 	}
 
+	// Create plans directory if it doesn't exist
+	if err := os.MkdirAll(PlansDir, 0755); err != nil {
+		return fmt.Errorf("failed to create plans directory: %w", err)
+	}
+
 	// Reset implementation plan to initial template
-	if err := resetImplementationPlan(); err != nil {
+	if err := resetImplementationPlan(cfg.PlanFile); err != nil {
 		return err
 	}
 
@@ -70,7 +75,7 @@ func Run(cfg Config) error {
 
 func runIteration(cfg Config, provider Provider, iteration int) error {
 	// Build prompt with implementation plan
-	promptContent, err := buildPromptWithPlan(cfg.PromptFile, cfg.Mode, iteration, cfg.MaxIterations)
+	promptContent, err := buildPromptWithPlan(cfg.PromptFile, cfg.PlanFile, cfg.Mode, iteration, cfg.MaxIterations)
 	if err != nil {
 		return err
 	}

--- a/internal/loop/prompt.go
+++ b/internal/loop/prompt.go
@@ -6,7 +6,7 @@ import (
 )
 
 // resetImplementationPlan resets the implementation plan file to the initial template
-func resetImplementationPlan() error {
+func resetImplementationPlan(planFile string) error {
 	template := `# Implementation Plan
 
 ## Tasks
@@ -17,14 +17,14 @@ func resetImplementationPlan() error {
 
 <!-- Completed tasks will be moved here as: - [x] Task description -->
 `
-	if err := os.WriteFile(ImplementationPlanFile, []byte(template), 0644); err != nil {
+	if err := os.WriteFile(planFile, []byte(template), 0644); err != nil {
 		return fmt.Errorf("failed to reset implementation plan: %w", err)
 	}
 	return nil
 }
 
 // buildPromptWithPlan reads the prompt file and appends the implementation plan with instructions
-func buildPromptWithPlan(promptFile string, mode Mode, iteration int, maxIterations int) ([]byte, error) {
+func buildPromptWithPlan(promptFile string, planFile string, mode Mode, iteration int, maxIterations int) ([]byte, error) {
 	// Read the prompt file
 	promptContent, err := os.ReadFile(promptFile)
 	if err != nil {
@@ -32,7 +32,7 @@ func buildPromptWithPlan(promptFile string, mode Mode, iteration int, maxIterati
 	}
 
 	// Read the implementation plan
-	planContent, err := os.ReadFile(ImplementationPlanFile)
+	planContent, err := os.ReadFile(planFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read implementation plan: %w", err)
 	}
@@ -89,7 +89,7 @@ Study the implementation plan below. Pick the most important uncompleted task.
 ` + taskGuidance + `
 
 Complete ONE task, then:
-1. Update ` + "`" + ImplementationPlanFile + "`" + ` to mark the task as completed (move to Completed section)
+1. Update ` + "`" + planFile + "`" + ` to mark the task as completed (move to Completed section)
 2. Commit your changes with a descriptive message
 3. Exit
 

--- a/internal/loop/types.go
+++ b/internal/loop/types.go
@@ -29,9 +29,10 @@ type Config struct {
 	Output        io.Writer
 }
 
-// GeneratePlanPath returns a timestamped path for a new session-scoped plan file
+// GeneratePlanPath returns a timestamped path for a new session-scoped plan file.
+// Uses millisecond precision to ensure uniqueness for parallel invocations.
 func GeneratePlanPath() string {
-	timestamp := time.Now().Format("20060102T150405")
+	timestamp := time.Now().Format("20060102T150405.000")
 	return filepath.Join(PlansDir, fmt.Sprintf("implementation_plan_%s.md", timestamp))
 }
 

--- a/internal/loop/types.go
+++ b/internal/loop/types.go
@@ -3,6 +3,8 @@ package loop
 import (
 	"fmt"
 	"io"
+	"path/filepath"
+	"time"
 )
 
 // Mode represents the execution mode
@@ -12,18 +14,25 @@ const (
 	ModeBuild Mode = "build"
 	ModePlan  Mode = "plan"
 
-	// ImplementationPlanFile is the path to the implementation plan
-	ImplementationPlanFile = ".ralph/IMPLEMENTATION_PLAN.md"
+	// PlansDir is the directory for session-scoped implementation plans
+	PlansDir = ".ralph/plans"
 )
 
 // Config holds the loop configuration
 type Config struct {
 	Mode          Mode
 	PromptFile    string
+	PlanFile      string // Session-scoped plan file path
 	MaxIterations int
 	NoPush        bool
 	Agent         AgentProvider
 	Output        io.Writer
+}
+
+// GeneratePlanPath returns a timestamped path for a new session-scoped plan file
+func GeneratePlanPath() string {
+	timestamp := time.Now().Format("20060102T150405")
+	return filepath.Join(PlansDir, fmt.Sprintf("implementation_plan_%s.md", timestamp))
 }
 
 // AgentProvider represents the agent provider to use


### PR DESCRIPTION
## Summary
Refactors goralph to create unique implementation plan files per session in `.ralph/plans/` instead of using a single shared `.ralph/IMPLEMENTATION_PLAN.md` file. Each session now generates a timestamped plan file (e.g., `implementation_plan_20260122T143052.md`).

## Changes
- Replaced `ImplementationPlanFile` constant with `PlansDir` constant and `GeneratePlanPath()` function
- Added `PlanFile` field to `Config` struct for session-specific plan paths
- Updated `resetImplementationPlan()` and `buildPromptWithPlan()` to accept plan file path as parameter
- Added automatic creation of `.ralph/plans/` directory on startup
- Updated both `build` and `plan` commands to generate unique plan paths per session
- Updated documentation in CLAUDE.md and README.md

## Breaking Changes
None - `.ralph/` is already gitignored, so no migration of existing plans is needed.

## Test Plan
- [x] Run `task build` to verify compilation
- [ ] Run `goralph build -n 1` and verify:
  - New plan file is created in `.ralph/plans/`
  - Filename uses ISO 8601 compact format (YYYYMMDDTHHMMSS)
  - Plan file path is correctly referenced in agent prompt
- [ ] Verify no references to `IMPLEMENTATION_PLAN.md` remain in codebase

## Release Notes
Implementation plans are now session-scoped with unique timestamped files in `.ralph/plans/`. This prevents conflicts when running multiple sessions and provides better organization of plan history.

## Checklist
- [x] Tests pass locally (`task build`)
- [x] Documentation updated
- [x] Conventional commit format followed