### PR TITLE
feat(loop): add completion promise detection for early loop termination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,16 @@ GORALPH_AGENT=codex  # Set default agent provider (claude or codex)
 3. **Runs the selected agent** (Claude Code or Codex) with the combined prompt, streaming output in real-time
 4. **Agent completes one task**, updates the implementation plan, and commits
 5. **Pushes changes** to the remote branch (unless `--no-push` is set)
-6. **Loops** until max iterations reached or all tasks complete
+6. **Loops** until max iterations reached, all tasks complete, or agent signals completion
+
+### Completion Promise
+
+Agents can signal that all tasks are complete by outputting the exact string:
+```
+<promise>COMPLETE</promise>
+```
+
+When detected, the loop exits gracefully with a "Session Complete" message instead of continuing to the next iteration. This saves tokens by avoiding unnecessary iterations when work is done.
 
 ### Iteration-Aware Task Generation
 

--- a/internal/loop/output.go
+++ b/internal/loop/output.go
@@ -142,6 +142,14 @@ func FormatMaxIterations(w io.Writer, max int) {
 	fmt.Fprintln(w, dimStyle.Render(msg))
 }
 
+// FormatSessionComplete renders the session complete message
+func FormatSessionComplete(w io.Writer) {
+	content := successStyle.Render("Session Complete") + "\n" +
+		dimStyle.Render("All tasks marked complete by agent")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, boxStyle.Render(content))
+}
+
 // formatNumber adds commas to large numbers for readability
 func formatNumber(n int) string {
 	if n < 1000 {

--- a/internal/loop/prompt.go
+++ b/internal/loop/prompt.go
@@ -93,6 +93,11 @@ Complete ONE task, then:
 2. Commit your changes with a descriptive message
 3. Exit
 
+**Completion Promise:**
+When ALL tasks in the plan are complete and there is no more work to do, output this exact line:
+` + "`" + CompletionPromise + "`" + `
+This signals the loop to exit gracefully instead of continuing to the next iteration.
+
 The loop will automatically restart with a fresh context window.
 
 ---

--- a/internal/loop/types.go
+++ b/internal/loop/types.go
@@ -3,6 +3,7 @@ package loop
 import (
 	"fmt"
 	"io"
+	"strings"
 )
 
 // Mode represents the execution mode
@@ -14,6 +15,9 @@ const (
 
 	// ImplementationPlanFile is the path to the implementation plan
 	ImplementationPlanFile = ".ralph/IMPLEMENTATION_PLAN.md"
+
+	// CompletionPromise is the pattern agents emit to signal all tasks are complete
+	CompletionPromise = "<promise>COMPLETE</promise>"
 )
 
 // Config holds the loop configuration
@@ -69,8 +73,9 @@ type ResultMessage struct {
 	NumTurns     int     `json:"num_turns"`
 	Result       string  `json:"result"`
 	TotalCostUSD float64 `json:"total_cost_usd"`
-	Usage        Usage   `json:"usage"`
-	HasCost      bool    `json:"-"` // Internal field: true if provider supplies cost data
+	Usage           Usage   `json:"usage"`
+	HasCost         bool    `json:"-"` // Internal field: true if provider supplies cost data
+	SessionComplete bool    `json:"-"` // Internal: true if agent emitted completion promise
 }
 
 // Usage represents token usage statistics
@@ -120,9 +125,10 @@ type ToolResultBlock struct {
 
 // StreamState tracks the state during streaming output
 type StreamState struct {
-	LastTextLen    int
-	ActiveTools    map[string]string // tool ID -> tool name
-	CompletedTools map[string]bool
+	LastTextLen     int
+	ActiveTools     map[string]string // tool ID -> tool name
+	CompletedTools  map[string]bool
+	AccumulatedText strings.Builder // All text content for pattern detection
 }
 
 // NewStreamState creates a new StreamState with initialized maps


### PR DESCRIPTION
## Summary

Add a completion promise mechanism that allows agents to signal session completion by outputting `<promise>COMPLETE</promise>`, enabling early loop termination to save tokens when all tasks are done.

## Changes

- Add `CompletionPromise` constant (`<promise>COMPLETE</promise>`) to `types.go`
- Add `SessionComplete` field to `ResultMessage` struct
- Add `AccumulatedText` field to `StreamState` for pattern detection during streaming
- Update `ClaudeProvider` to accumulate text and detect completion promise
- Update `CodexProvider` to accumulate text and detect completion promise  
- Change `runIteration()` signature to return `(bool, error)` for completion status
- Update main loop to exit gracefully when completion detected
- Add `FormatSessionComplete()` function for styled output
- Add completion promise instructions to agent prompts in `prompt.go`
- Document feature in `CLAUDE.md`

## Breaking Changes

None

## Test Plan

- [x] Build the project: `task build`
- [x] Run `go vet ./...` - no issues
- [x] Verify binary works: `./goralph --version`
- [ ] Test with agent that outputs `<promise>COMPLETE</promise>` - loop should exit with "Session Complete" message
- [ ] Test normal operation without promise - loop should continue as before
- [ ] Test with both `--agent claude` and `--agent codex`

## Related Issues

None

## Release Notes

Agents can now signal that all tasks are complete by outputting `<promise>COMPLETE</promise>`. When detected, the loop exits gracefully with a "Session Complete" message, saving tokens by avoiding unnecessary iterations.

## Checklist

- [x] Tests pass locally (`task build`)
- [x] Linting passes (`go vet ./...`)
- [x] Documentation updated (CLAUDE.md)
- [x] Conventional commit format followed