### PR TITLE
refactor(prompt): consolidate to single PROMPT.md file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ GORALPH_AGENT=codex  # Set default agent provider (claude or codex)
 
 ## How It Works
 
-1. **Reads prompt file** from `.ralph/PROMPT_build.md` or `.ralph/PROMPT_plan.md`
+1. **Reads prompt file** from `.ralph/PROMPT.md`
 2. **Creates session-scoped plan** in `.ralph/plans/implementation_plan_{timestamp}.md`
 3. **Runs the selected agent** (Claude Code or Codex) with the combined prompt, streaming output in real-time
 4. **Agent completes one task**, updates the implementation plan, and commits
@@ -71,8 +71,7 @@ When using `--max`/`-n` flag:
 
 ## Required Files
 
-- `.ralph/PROMPT_build.md` - Build mode prompt for the agentic loop
-- `.ralph/PROMPT_plan.md` - Plan mode prompt for the agentic loop
+- `.ralph/PROMPT.md` - Prompt file for the agentic loop (used by both build and plan modes)
 - `.ralph/plans/` - Directory for session-scoped implementation plans (auto-created)
 - `taskfile.yml` - Task runner configuration
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,13 @@ Download the latest release for your platform from the [Releases page](https://g
    go install
    ```
 
-3. Create the required prompt files in your target project:
+3. Create the required prompt file in your target project:
    ```bash
    mkdir -p .ralph
-   touch .ralph/PROMPT_build.md
-   touch .ralph/PROMPT_plan.md
+   touch .ralph/PROMPT.md
    ```
 
-4. Add your prompts to the files created above. These prompts will be used by Claude Code during the agentic loop.
+4. Add your prompt to the file created above. This prompt will be used by the agentic loop.
 
 ## Usage
 
@@ -107,10 +106,9 @@ goralph build -n 10 --no-push --agent codex
 
 ### Required Files
 
-Before running, ensure these prompt files exist in your `.ralph/` directory:
+Before running, ensure this prompt file exists in your `.ralph/` directory:
 
-- `.ralph/PROMPT_build.md` - Prompt used for build mode
-- `.ralph/PROMPT_plan.md` - Prompt used for plan mode
+- `.ralph/PROMPT.md` - Prompt used for both build and plan modes
 - `.ralph/plans/` - Directory for session-scoped implementation plans (auto-created)
 
 ### Warning

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -14,7 +14,7 @@ var buildAgent string
 var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Run the agentic loop in build mode",
-	Long:  `Run Claude Code in build mode using .ralph/PROMPT_build.md as the prompt file.`,
+	Long:  `Run the agentic loop in build mode using .ralph/PROMPT.md as the prompt file.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Validate agent provider
 		agentProvider, err := loop.ValidateAgentProvider(buildAgent)
@@ -24,7 +24,7 @@ var buildCmd = &cobra.Command{
 
 		return loop.Run(loop.Config{
 			Mode:          loop.ModeBuild,
-			PromptFile:    ".ralph/PROMPT_build.md",
+			PromptFile:    loop.PromptFile,
 			PlanFile:      loop.GeneratePlanPath(),
 			MaxIterations: buildMaxIterations,
 			NoPush:        buildNoPush,

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -14,7 +14,7 @@ var planAgent string
 var planCmd = &cobra.Command{
 	Use:   "plan",
 	Short: "Run the agentic loop in plan mode",
-	Long:  `Run Claude Code in plan mode using .ralph/PROMPT_plan.md as the prompt file.`,
+	Long:  `Run the agentic loop in plan mode using .ralph/PROMPT.md as the prompt file.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Validate agent provider
 		agentProvider, err := loop.ValidateAgentProvider(planAgent)
@@ -24,7 +24,7 @@ var planCmd = &cobra.Command{
 
 		return loop.Run(loop.Config{
 			Mode:          loop.ModePlan,
-			PromptFile:    ".ralph/PROMPT_plan.md",
+			PromptFile:    loop.PromptFile,
 			PlanFile:      loop.GeneratePlanPath(),
 			MaxIterations: planMaxIterations,
 			NoPush:        planNoPush,

--- a/internal/loop/types.go
+++ b/internal/loop/types.go
@@ -15,6 +15,8 @@ const (
 	ModeBuild Mode = "build"
 	ModePlan  Mode = "plan"
 
+	// PromptFile is the path to the prompt file used by both build and plan modes
+	PromptFile = ".ralph/PROMPT.md"
 	// CompletionPromise is the pattern agents emit to signal all tasks are complete
 	CompletionPromise = "<promise>COMPLETE</promise>"
 	// PlansDir is the directory for session-scoped implementation plans


### PR DESCRIPTION
## Summary
Simplifies prompt file structure by using a single `.ralph/PROMPT.md` file for both build and plan modes instead of separate `PROMPT_build.md` and `PROMPT_plan.md` files.

## Changes
- Added `PromptFile` constant in `internal/loop/types.go` for the shared prompt path
- Updated `cmd/build.go` and `cmd/plan.go` to use the shared constant
- Updated `Long` descriptions in both commands to reference the new prompt file
- Updated documentation in `CLAUDE.md` and `README.md` to reflect single prompt file

## Breaking Changes
**Breaking**: Users with existing `.ralph/PROMPT_build.md` or `.ralph/PROMPT_plan.md` files must rename them to `.ralph/PROMPT.md`.

## Test Plan
- [x] Run `task build` - compiles successfully
- [x] Run `go vet ./...` - no issues
- [x] Verify `goralph build --help` shows updated description
- [x] Verify `goralph plan --help` shows updated description

## Related Issues
None

## Release Notes
Go Ralph now uses a single prompt file (`.ralph/PROMPT.md`) for both build and plan modes. Users should rename their existing `PROMPT_build.md` or `PROMPT_plan.md` to `PROMPT.md`.

## Checklist
- [x] Tests pass locally (`task build`)
- [x] Linting passes (`go vet ./...`)
- [x] Documentation updated
- [x] Breaking changes documented
- [x] Conventional commit format followed