### PR TITLE
chore(cli): disable default completion command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ Reference: https://github.com/ghuntley/how-to-ralph-wiggum`,
 func init() {
 	rootCmd.Version = version.Version
 	rootCmd.SetVersionTemplate(fmt.Sprintf("goralph %s\n", version.String()))
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }
 
 // Execute runs the root command


### PR DESCRIPTION
## Summary
Disables the default Cobra `completion` subcommand to simplify the CLI interface by removing a rarely-used command.

## Changes
- Set `rootCmd.CompletionOptions.DisableDefaultCmd = true` in the root command initialization

## Breaking Changes
None

## Test Plan
- [ ] Run `task build` to verify the binary builds successfully
- [ ] Run `goralph --help` and verify the `completion` command no longer appears
- [ ] Verify core commands (`build`, `plan`) still work as expected

## Release Notes
The `completion` subcommand has been removed from the CLI to simplify the command interface.

## Checklist
- [x] Tests pass locally
- [x] Conventional commit format followed