### PR TITLE
feat(loop): add RLM mode with structured phase-based execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ goralph run -n 5         # Run with max 5 iterations (tasks broken into ~5 piece
 goralph run --max 10     # Run with max 10 iterations (tasks broken into ~10 pieces)
 goralph run --no-push    # Run without pushing changes after each iteration
 goralph run --agent codex  # Use OpenAI Codex instead of Claude
+goralph run --rlm        # Enable RLM (Recursive Language Model) mode
+goralph run --verify     # Run build/test verification before commit
+goralph run --rlm --verify  # RLM mode with verification
+goralph run --max-depth 5   # Set max recursion depth for RLM (default: 3)
 ```
 
 ### Environment variables
@@ -53,6 +57,34 @@ When using `--max`/`-n` flag:
 - The agent is instructed to break work into approximately N tasks (one per iteration)
 - Without the flag, the agent creates a comprehensive task list
 
+## RLM Mode
+
+RLM (Recursive Language Model) mode uses a structured approach where state is persisted to files rather than relying on context window. Each iteration follows the RLM cycle: PLAN → SEARCH → NARROW → ACT → VERIFY.
+
+### RLM State Directory
+
+When RLM mode is enabled, state is persisted in `.ralph/state/`:
+- `session.json` - Session metadata (iteration, depth, phase)
+- `context.json` - Context manifest (discoveries, key files, focus)
+- `history.jsonl` - Conversation history across iterations
+- `search/` - Search operation results
+- `narrow/` - Narrowed context subsets
+- `verification/` - Verification reports
+
+### RLM Markers
+
+Agents signal state transitions using markers:
+- `<rlm:phase>PHASE</rlm:phase>` - Signal phase transition (PLAN, SEARCH, NARROW, ACT, VERIFY)
+- `<rlm:verified>true</rlm:verified>` - Signal verification passed
+- `<promise>COMPLETE</promise>` - Signal all tasks complete
+
+### Verification
+
+When `--verify` is enabled:
+- Project type is auto-detected (Go, Node.js, Rust, Python)
+- Build and test commands run before commit
+- Failed verification skips push and continues to next iteration
+
 ## Project Structure
 
 - `cmd/` - Cobra CLI commands (root, run)
@@ -60,6 +92,10 @@ When using `--max`/`-n` flag:
   - `loop.go` - Main loop execution and agent iteration
   - `providers.go` - Agent provider implementations (Claude, Codex)
   - `types.go` - Message types and agent provider constants
+  - `rlm_types.go` - RLM-specific type definitions
+  - `state.go` - StateManager for RLM state persistence
+  - `phases.go` - Phase routing and inference logic
+  - `verify.go` - Verification runner for build/test checks
   - `output.go` - Terminal output formatting with lipgloss
   - `prompt.go` - Prompt file reading and construction
   - `git.go` - Git operations (push, branch management)
@@ -67,6 +103,7 @@ When using `--max`/`-n` flag:
 - `.ralph/` - Prompt files and session data
 - `.ralph/plans/` - Session-scoped implementation plans (timestamped)
 - `.ralph/logs/` - Timestamped JSONL logs of each agent session
+- `.ralph/state/` - RLM state files (when RLM mode is enabled)
 
 ## Required Files
 
@@ -78,3 +115,4 @@ When using `--max`/`-n` flag:
 
 - `github.com/spf13/cobra` - CLI framework
 - `github.com/charmbracelet/lipgloss` - Terminal styling
+- `github.com/google/uuid` - UUID generation for RLM sessions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ task install           # Install goralph to ~/.local/bin/
 goralph run              # Run the agentic loop (uses Claude by default)
 goralph run -n 5         # Run with max 5 iterations (tasks broken into ~5 pieces)
 goralph run --max 10     # Run with max 10 iterations (tasks broken into ~10 pieces)
-goralph run --no-push    # Run without pushing changes after each iteration
+goralph run --no-push    # Run without committing or pushing changes
 goralph run --agent codex  # Use OpenAI Codex instead of Claude
 goralph run --rlm        # Enable RLM (Recursive Language Model) mode
 goralph run --verify     # Run build/test verification before commit

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ Reference: [Ralph Wiggum Technique](https://github.com/ghuntley/how-to-ralph-wig
 - **Iteration Summaries** - Displays duration, token usage, cost, and status after each iteration
 - **JSON Logging** - Saves full agent output to timestamped JSONL files in `.ralph/logs/`
 - **Stream JSON Parsing** - Parses streaming JSON output from agents in real-time
+- **RLM Mode** - Recursive Language Model support for structured, stateful agent iterations
+
+## RLM Mode
+
+Go Ralph supports RLM (Recursive Language Model) mode, based on the research paper [arXiv:2512.24601](https://arxiv.org/abs/2512.24601). RLM mode uses a structured approach where state is persisted to files rather than relying on context window limits.
+
+Each iteration follows the RLM cycle: **PLAN → SEARCH → NARROW → ACT → VERIFY**
+
+```bash
+# Enable RLM mode
+goralph run --rlm
+
+# RLM mode with verification (runs build/test before commit)
+goralph run --rlm --verify
+
+# Set max recursion depth (default: 3)
+goralph run --rlm --max-depth 5
+```
+
+When RLM mode is enabled, state is persisted in `.ralph/state/` including session metadata, context manifests, and verification reports.
 
 ## Requirements
 
@@ -88,6 +108,9 @@ goralph run -n 10 --no-push --agent codex
 | `--max` | `-n` | Maximum number of iterations (0 = unlimited) |
 | `--no-push` | | Skip pushing changes after each iteration |
 | `--agent` | | Agent provider to use: `claude` (default) or `codex` |
+| `--rlm` | | Enable RLM (Recursive Language Model) mode |
+| `--verify` | | Run build/test verification before commit |
+| `--max-depth` | | Maximum recursion depth for RLM (default: 3) |
 
 ### Environment Variables
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,6 +10,9 @@ import (
 var maxIterations int
 var noPush bool
 var agent string
+var rlmEnabled bool
+var verifyEnabled bool
+var maxDepth int
 
 var runCmd = &cobra.Command{
 	Use:   "run",
@@ -29,6 +32,11 @@ var runCmd = &cobra.Command{
 			NoPush:        noPush,
 			Agent:         agentProvider,
 			Output:        cmd.OutOrStdout(),
+			RLM: loop.RLMConfig{
+				Enabled:  rlmEnabled,
+				MaxDepth: maxDepth,
+			},
+			VerifyEnabled: verifyEnabled,
 		})
 	},
 }
@@ -43,6 +51,11 @@ func init() {
 		defaultAgent = envAgent
 	}
 	runCmd.Flags().StringVar(&agent, "agent", defaultAgent, "Agent provider to use (claude, codex)")
+
+	// RLM mode flags
+	runCmd.Flags().BoolVar(&rlmEnabled, "rlm", false, "Enable RLM (Recursive Language Model) mode")
+	runCmd.Flags().BoolVar(&verifyEnabled, "verify", false, "Run verification (build/test) before commit")
+	runCmd.Flags().IntVar(&maxDepth, "max-depth", 3, "Maximum recursion depth for RLM mode")
 
 	rootCmd.AddCommand(runCmd)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -43,7 +43,7 @@ var runCmd = &cobra.Command{
 
 func init() {
 	runCmd.Flags().IntVarP(&maxIterations, "max", "n", 0, "Maximum number of iterations (0 = unlimited)")
-	runCmd.Flags().BoolVar(&noPush, "no-push", false, "Skip pushing changes after each iteration")
+	runCmd.Flags().BoolVar(&noPush, "no-push", false, "Skip committing and pushing changes after each iteration")
 
 	// Agent provider flag with env var fallback
 	defaultAgent := "claude"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.4
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod 
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -74,12 +74,10 @@ func Run(cfg Config) error {
 
 		// Show loop banner before iteration (with phase if RLM mode)
 		if cfg.RLM.Enabled && stateManager != nil {
-			session, _ := stateManager.LoadSession()
-			if session != nil {
-				FormatLoopBannerWithPhase(cfg.Output, iteration, session.Phase)
-			} else {
-				FormatLoopBanner(cfg.Output, iteration)
-			}
+			// Use inferred phase (same as what prompt receives) for consistent display
+			router := NewPhaseRouter(stateManager)
+			inferredPhase, _ := router.InferPhase()
+			FormatLoopBannerWithPhase(cfg.Output, iteration, inferredPhase)
 		} else {
 			FormatLoopBanner(cfg.Output, iteration)
 		}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -240,8 +240,13 @@ func runIterationWithRLM(cfg Config, provider Provider, iteration int, state *St
 		}
 	}
 
-	// Run verification if enabled and agent signaled verified
-	if verifier != nil && verifier.HasCommands() && resultMsg != nil && resultMsg.RLMVerified {
+	// Run verification if enabled (in RLM mode, also requires agent signal)
+	runVerification := verifier != nil && verifier.HasCommands()
+	if cfg.RLM.Enabled {
+		// In RLM mode, only run verification when agent signals <rlm:verified>
+		runVerification = runVerification && resultMsg != nil && resultMsg.RLMVerified
+	}
+	if runVerification {
 		fmt.Fprintln(cfg.Output)
 		fmt.Fprintln(cfg.Output, dimStyle.Render("Running verification..."))
 

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -36,13 +36,31 @@ func Run(cfg Config) error {
 		return fmt.Errorf("failed to create plans directory: %w", err)
 	}
 
-	// Reset implementation plan to initial template
-	if err := resetImplementationPlan(cfg.PlanFile); err != nil {
-		return err
+	// Initialize RLM state if RLM mode is enabled
+	var stateManager *StateManager
+	if cfg.RLM.Enabled {
+		stateManager = NewStateManager(StateDir)
+		if _, err := stateManager.InitSession(); err != nil {
+			return fmt.Errorf("failed to initialize RLM session: %w", err)
+		}
+	} else {
+		// Reset implementation plan to initial template (non-RLM mode)
+		if err := resetImplementationPlan(cfg.PlanFile); err != nil {
+			return err
+		}
 	}
 
 	// Print configuration
 	FormatHeader(cfg.Output, cfg, branch, provider.Model())
+
+	// Create verifier if verification is enabled
+	var verifier *Verifier
+	if cfg.VerifyEnabled {
+		verifier = NewVerifier(cfg.VerifyCommands)
+		if !verifier.HasCommands() {
+			fmt.Fprintln(cfg.Output, dimStyle.Render("Warning: No verification commands detected for project type"))
+		}
+	}
 
 	iteration := 0
 	for {
@@ -54,17 +72,32 @@ func Run(cfg Config) error {
 			break
 		}
 
-		// Show loop banner before iteration
-		FormatLoopBanner(cfg.Output, iteration)
+		// Show loop banner before iteration (with phase if RLM mode)
+		if cfg.RLM.Enabled && stateManager != nil {
+			session, _ := stateManager.LoadSession()
+			if session != nil {
+				FormatLoopBannerWithPhase(cfg.Output, iteration, session.Phase)
+			} else {
+				FormatLoopBanner(cfg.Output, iteration)
+			}
+		} else {
+			FormatLoopBanner(cfg.Output, iteration)
+		}
 
 		// Run iteration using the provider
-		completed, err := runIteration(cfg, provider, iteration)
+		completed, verifyFailed, err := runIterationWithRLM(cfg, provider, iteration, stateManager, verifier)
 		if err != nil {
 			return fmt.Errorf("%s iteration failed: %w", provider.Name(), err)
 		}
 		if completed {
 			FormatSessionComplete(cfg.Output)
 			break
+		}
+
+		// Skip push if verification failed
+		if verifyFailed {
+			fmt.Fprintln(cfg.Output, dimStyle.Render("Skipping push due to verification failure"))
+			continue
 		}
 
 		// Push changes unless --no-push is set
@@ -78,17 +111,39 @@ func Run(cfg Config) error {
 	return nil
 }
 
-func runIteration(cfg Config, provider Provider, iteration int) (bool, error) {
-	// Build prompt with implementation plan
-	promptContent, err := buildPromptWithPlan(cfg.PromptFile, cfg.PlanFile, iteration, cfg.MaxIterations)
-	if err != nil {
-		return false, err
+// runIterationWithRLM runs a single iteration with optional RLM state management and verification
+func runIterationWithRLM(cfg Config, provider Provider, iteration int, state *StateManager, verifier *Verifier) (completed bool, verifyFailed bool, err error) {
+	var promptContent []byte
+
+	// Build prompt based on mode
+	if cfg.RLM.Enabled && state != nil {
+		// Update session iteration
+		session, loadErr := state.LoadSession()
+		if loadErr != nil {
+			return false, false, fmt.Errorf("failed to load session: %w", loadErr)
+		}
+		session.Iteration = iteration
+		if saveErr := state.SaveSession(session); saveErr != nil {
+			return false, false, fmt.Errorf("failed to save session: %w", saveErr)
+		}
+
+		// Build RLM prompt
+		promptContent, err = buildRLMPrompt(cfg, state, iteration)
+		if err != nil {
+			return false, false, err
+		}
+	} else {
+		// Build standard prompt
+		promptContent, err = buildPromptWithPlan(cfg.PromptFile, cfg.PlanFile, iteration, cfg.MaxIterations)
+		if err != nil {
+			return false, false, err
+		}
 	}
 
 	// Create logs directory
 	logsDir := filepath.Join(".ralph", "logs")
 	if err := os.MkdirAll(logsDir, 0755); err != nil {
-		return false, fmt.Errorf("failed to create logs directory: %w", err)
+		return false, false, fmt.Errorf("failed to create logs directory: %w", err)
 	}
 
 	// Generate timestamped log filename
@@ -98,26 +153,26 @@ func runIteration(cfg Config, provider Provider, iteration int) (bool, error) {
 	// Create log file
 	logFile, err := os.Create(logPath)
 	if err != nil {
-		return false, fmt.Errorf("failed to create log file: %w", err)
+		return false, false, fmt.Errorf("failed to create log file: %w", err)
 	}
 	defer logFile.Close()
 
 	// Build the command using the provider
 	cmd, err := provider.BuildCommand(promptContent)
 	if err != nil {
-		return false, fmt.Errorf("failed to build command: %w", err)
+		return false, false, fmt.Errorf("failed to build command: %w", err)
 	}
 
 	// Set up stdin with prompt content
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return false, fmt.Errorf("failed to create stdin pipe: %w", err)
+		return false, false, fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
 
 	// Capture stdout for parsing
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return false, fmt.Errorf("failed to create stdout pipe: %w", err)
+		return false, false, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 
 	// Connect stderr to terminal
@@ -125,12 +180,12 @@ func runIteration(cfg Config, provider Provider, iteration int) (bool, error) {
 
 	// Start the command
 	if err := cmd.Start(); err != nil {
-		return false, fmt.Errorf("failed to start %s: %w", provider.Name(), err)
+		return false, false, fmt.Errorf("failed to start %s: %w", provider.Name(), err)
 	}
 
 	// Write prompt to stdin and close
 	if _, err := stdin.Write(promptContent); err != nil {
-		return false, fmt.Errorf("failed to write to stdin: %w", err)
+		return false, false, fmt.Errorf("failed to write to stdin: %w", err)
 	}
 	stdin.Close()
 
@@ -143,12 +198,12 @@ func runIteration(cfg Config, provider Provider, iteration int) (bool, error) {
 	// Parse output using the provider and write to log file
 	resultMsg, err := provider.ParseOutput(stdout, cfg.Output, logFile)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse output: %w", err)
+		return false, false, fmt.Errorf("failed to parse output: %w", err)
 	}
 
 	// Wait for completion
 	if err := cmd.Wait(); err != nil {
-		return false, fmt.Errorf("%s exited with error: %w", provider.Name(), err)
+		return false, false, fmt.Errorf("%s exited with error: %w", provider.Name(), err)
 	}
 
 	// Inject duration if provider didn't supply it
@@ -164,7 +219,50 @@ func runIteration(cfg Config, provider Provider, iteration int) (bool, error) {
 		fmt.Fprintln(cfg.Output, dimStyle.Render(fmt.Sprintf("Warning: No result message received from %s", provider.Name())))
 	}
 
+	// Update RLM state if enabled
+	if cfg.RLM.Enabled && state != nil && resultMsg != nil {
+		// Update phase if detected
+		if resultMsg.RLMPhase != "" {
+			if updateErr := state.UpdateIteration(resultMsg.RLMPhase); updateErr != nil {
+				fmt.Fprintln(cfg.Output, dimStyle.Render(fmt.Sprintf("Warning: Failed to update RLM phase: %v", updateErr)))
+			}
+		}
+
+		// Record iteration in history
+		historyEntry := HistoryEntry{
+			Iteration: iteration,
+			Role:      "assistant",
+			Content:   fmt.Sprintf("Iteration %d completed", iteration),
+			Phase:     resultMsg.RLMPhase,
+		}
+		if appendErr := state.AppendHistory(historyEntry); appendErr != nil {
+			fmt.Fprintln(cfg.Output, dimStyle.Render(fmt.Sprintf("Warning: Failed to append history: %v", appendErr)))
+		}
+	}
+
+	// Run verification if enabled and agent signaled verified
+	if verifier != nil && verifier.HasCommands() && resultMsg != nil && resultMsg.RLMVerified {
+		fmt.Fprintln(cfg.Output)
+		fmt.Fprintln(cfg.Output, dimStyle.Render("Running verification..."))
+
+		report := verifier.Run(iteration)
+
+		// Store verification report if state manager available
+		if state != nil {
+			if storeErr := state.StoreVerification(report); storeErr != nil {
+				fmt.Fprintln(cfg.Output, dimStyle.Render(fmt.Sprintf("Warning: Failed to store verification report: %v", storeErr)))
+			}
+		}
+
+		if report.Passed {
+			FormatVerificationPassed(cfg.Output)
+		} else {
+			FormatVerificationFailed(cfg.Output, report)
+			return false, true, nil // Continue loop but skip push
+		}
+	}
+
 	// Check if agent signaled session completion
 	sessionComplete := resultMsg != nil && resultMsg.SessionComplete
-	return sessionComplete, nil
+	return sessionComplete, false, nil
 }

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -134,7 +134,7 @@ func runIterationWithRLM(cfg Config, provider Provider, iteration int, state *St
 		}
 	} else {
 		// Build standard prompt
-		promptContent, err = buildPromptWithPlan(cfg.PromptFile, cfg.PlanFile, iteration, cfg.MaxIterations)
+		promptContent, err = buildPromptWithPlan(cfg.PromptFile, cfg.PlanFile, iteration, cfg.MaxIterations, cfg.NoPush)
 		if err != nil {
 			return false, false, err
 		}

--- a/internal/loop/phases.go
+++ b/internal/loop/phases.go
@@ -1,0 +1,215 @@
+package loop
+
+// PhaseRouter handles phase inference and guidance generation
+type PhaseRouter struct {
+	state *StateManager
+}
+
+// NewPhaseRouter creates a new PhaseRouter
+func NewPhaseRouter(state *StateManager) *PhaseRouter {
+	return &PhaseRouter{state: state}
+}
+
+// InferPhase determines the current phase based on session state
+func (pr *PhaseRouter) InferPhase() (Phase, error) {
+	session, err := pr.state.LoadSession()
+	if err != nil {
+		return PhasePlan, err
+	}
+
+	context, err := pr.state.GetContext()
+	if err != nil {
+		return PhasePlan, err
+	}
+
+	// First iteration always starts with PLAN
+	if session.Iteration == 0 {
+		return PhasePlan, nil
+	}
+
+	// If no discoveries yet, still in SEARCH/PLAN phase
+	if len(context.Discoveries) == 0 {
+		return PhaseSearch, nil
+	}
+
+	// If no focus files yet, need to NARROW
+	if len(context.Focus.Files) == 0 {
+		return PhaseNarrow, nil
+	}
+
+	// Check last verification result
+	lastVerify, _ := pr.state.GetLatestVerification()
+	if lastVerify != nil && !lastVerify.Passed {
+		// Last verification failed, need to fix and re-verify
+		return PhaseAct, nil
+	}
+
+	// Default progression based on previous phase
+	switch session.Phase {
+	case PhasePlan:
+		return PhaseSearch, nil
+	case PhaseSearch:
+		return PhaseNarrow, nil
+	case PhaseNarrow:
+		return PhaseAct, nil
+	case PhaseAct:
+		return PhaseVerify, nil
+	case PhaseVerify:
+		// After verify, loop back to search for next task or complete
+		return PhaseSearch, nil
+	default:
+		return PhasePlan, nil
+	}
+}
+
+// GetPhaseGuidance returns phase-specific instructions for the agent
+func (pr *PhaseRouter) GetPhaseGuidance(phase Phase) string {
+	switch phase {
+	case PhasePlan:
+		return planPhaseGuidance
+	case PhaseSearch:
+		return searchPhaseGuidance
+	case PhaseNarrow:
+		return narrowPhaseGuidance
+	case PhaseAct:
+		return actPhaseGuidance
+	case PhaseVerify:
+		return verifyPhaseGuidance
+	default:
+		return planPhaseGuidance
+	}
+}
+
+// Phase guidance templates
+const planPhaseGuidance = `## Phase: PLAN
+
+**Objective:** Understand the task and create an implementation approach.
+
+**Actions:**
+1. Read and analyze the task from PROMPT.md
+2. Identify key objectives and constraints
+3. Create high-level implementation steps
+4. Update context manifest with task summary
+
+**State updates:**
+- Write task summary to context.json
+- Record initial analysis in history
+
+**Exit criteria:**
+- Task objectives are clear
+- Implementation approach is documented
+- Ready to search for relevant code
+
+**Output:** Signal phase completion with:
+` + "`" + `<rlm:phase>SEARCH</rlm:phase>` + "`"
+
+const searchPhaseGuidance = `## Phase: SEARCH
+
+**Objective:** Explore the codebase to find relevant code and patterns.
+
+**Actions:**
+1. Use grep/glob to find files related to the task
+2. Read key files to understand existing patterns
+3. Identify dependencies and related code
+4. Record discoveries for future reference
+
+**State updates:**
+- Store search results in .ralph/state/search/
+- Add discoveries to context.json
+- Update history with findings
+
+**Exit criteria:**
+- Relevant files and functions identified
+- Understanding of existing patterns
+- Ready to narrow focus
+
+**Output:** Signal phase completion with:
+` + "`" + `<rlm:phase>NARROW</rlm:phase>` + "`"
+
+const narrowPhaseGuidance = `## Phase: NARROW
+
+**Objective:** Focus on specific files and functions for modification.
+
+**Actions:**
+1. Review discoveries from search phase
+2. Select specific files to modify
+3. Identify exact functions/locations for changes
+4. Validate approach against existing patterns
+
+**State updates:**
+- Store narrowed set in .ralph/state/narrow/
+- Update focus in context.json
+- Record rationale in history
+
+**Exit criteria:**
+- Specific files and functions identified
+- Clear understanding of required changes
+- Ready to implement
+
+**Output:** Signal phase completion with:
+` + "`" + `<rlm:phase>ACT</rlm:phase>` + "`"
+
+const actPhaseGuidance = `## Phase: ACT
+
+**Objective:** Implement the planned changes.
+
+**Actions:**
+1. Review focus set from narrow phase
+2. Implement changes in identified files
+3. Follow existing code patterns and conventions
+4. Write minimal, focused changes
+
+**State updates:**
+- Record changes made in history
+- Update any affected discoveries
+
+**Exit criteria:**
+- Changes implemented
+- Code follows existing patterns
+- Ready for verification
+
+**Output:** Signal phase completion with:
+` + "`" + `<rlm:phase>VERIFY</rlm:phase>` + "`"
+
+const verifyPhaseGuidance = `## Phase: VERIFY
+
+**Objective:** Validate changes work correctly.
+
+**Actions:**
+1. Run relevant build commands
+2. Run relevant test commands
+3. Check for any regressions
+4. Fix issues if found
+
+**State updates:**
+- Store verification results in .ralph/state/verification/
+- Update history with verification outcome
+
+**If verification passes:**
+1. Signal verification success with: ` + "`" + `<rlm:verified>true</rlm:verified>` + "`" + `
+2. Commit your changes
+3. If all tasks complete: ` + "`" + `<promise>COMPLETE</promise>` + "`" + `
+4. Otherwise signal next search: ` + "`" + `<rlm:phase>SEARCH</rlm:phase>` + "`" + `
+
+**If verification fails:**
+1. Analyze failure
+2. Return to ACT phase to fix: ` + "`" + `<rlm:phase>ACT</rlm:phase>` + "`" + `
+`
+
+// PhaseDisplayName returns a human-readable name for the phase
+func PhaseDisplayName(phase Phase) string {
+	switch phase {
+	case PhasePlan:
+		return "Planning"
+	case PhaseSearch:
+		return "Searching"
+	case PhaseNarrow:
+		return "Narrowing"
+	case PhaseAct:
+		return "Implementing"
+	case PhaseVerify:
+		return "Verifying"
+	default:
+		return string(phase)
+	}
+}

--- a/internal/loop/phases.go
+++ b/internal/loop/phases.go
@@ -23,7 +23,7 @@ func (pr *PhaseRouter) InferPhase() (Phase, error) {
 	}
 
 	// First iteration always starts with PLAN
-	if session.Iteration == 0 {
+	if session.Iteration <= 1 {
 		return PhasePlan, nil
 	}
 

--- a/internal/loop/phases.go
+++ b/internal/loop/phases.go
@@ -223,13 +223,29 @@ Update context.json focus set (read existing file first, update focus, then writ
 
 const actPhaseGuidance = `## Phase: ACT
 
-**Objective:** Implement the planned changes.
+**CRITICAL:** You are in the IMPLEMENTATION phase. DO NOT plan. DO NOT analyze. IMPLEMENT NOW.
+
+The planning phase is COMPLETE. Your focus set has been identified.
+
+**Your ONLY job in this phase:** Make the actual code changes.
+
+**DO NOT:**
+- Create more plans or task lists
+- Analyze or explore the codebase further
+- Discuss what you "would" do - DO IT
+- Ask questions or seek clarification
+- Say you need to "plan" or "continue planning"
+
+**DO:**
+- Use the Edit tool to modify files
+- Use the Write tool to create new files
+- Make real, concrete code changes NOW
 
 **Actions:**
-1. Review focus set from context.json
-2. Implement changes in identified files
-3. Follow existing code patterns and conventions
-4. Write minimal, focused changes
+1. Read the focus files from context.json
+2. WRITE CODE - Edit or create files as needed
+3. Follow existing patterns
+4. Keep changes minimal and focused
 
 **State File Updates:**
 

--- a/internal/loop/prompt.go
+++ b/internal/loop/prompt.go
@@ -193,7 +193,7 @@ func buildRLMPrompt(cfg Config, state *StateManager, iteration int) ([]byte, err
 	// Build RLM principle #3 based on noPush setting
 	var rlmPrinciple3 string
 	if cfg.NoPush {
-		rlmPrinciple3 = "3. **One task per iteration**: Complete ONE task, update state, exit."
+		rlmPrinciple3 = "3. **One task per iteration**: Complete ONE task, implement changes, update state, exit."
 	} else {
 		rlmPrinciple3 = "3. **One task per iteration**: Complete ONE task, update state, commit, exit."
 	}

--- a/internal/loop/prompt.go
+++ b/internal/loop/prompt.go
@@ -26,7 +26,7 @@ func resetImplementationPlan(planFile string) error {
 }
 
 // buildPromptWithPlan reads the prompt file and appends the implementation plan with instructions
-func buildPromptWithPlan(promptFile string, planFile string, iteration int, maxIterations int) ([]byte, error) {
+func buildPromptWithPlan(promptFile string, planFile string, iteration int, maxIterations int, noPush bool) ([]byte, error) {
 	// Read the prompt file
 	promptContent, err := os.ReadFile(promptFile)
 	if err != nil {
@@ -47,8 +47,32 @@ func buildPromptWithPlan(promptFile string, planFile string, iteration int, maxI
 		iterationStr = fmt.Sprintf("%d/unlimited", iteration)
 	}
 
-	// Build system context
-	systemContext := fmt.Sprintf(`# System Context
+	// Build system context based on noPush setting
+	var systemContext string
+	if noPush {
+		systemContext = fmt.Sprintf(`# System Context
+
+You are running in a **goralph agentic loop** - an automated iteration system that manages your context between runs.
+
+**Key facts:**
+- Iteration: %s
+- Each iteration runs with a fresh context window
+- Focus on completing ONE task per iteration
+- After completing a task: update the implementation plan, then exit
+- The loop will automatically restart
+
+**Workflow:**
+1. Study the implementation plan below
+2. Pick the most important uncompleted task
+3. Complete that single task
+4. Update the implementation plan to mark it complete
+5. Exit - the loop handles the rest
+
+---
+
+`, iterationStr)
+	} else {
+		systemContext = fmt.Sprintf(`# System Context
 
 You are running in a **goralph agentic loop** - an automated iteration system that manages your context between runs.
 
@@ -70,6 +94,7 @@ You are running in a **goralph agentic loop** - an automated iteration system th
 ---
 
 `, iterationStr)
+	}
 
 	// Build task guidance based on whether max iterations is set
 	var taskGuidance string
@@ -77,6 +102,19 @@ You are running in a **goralph agentic loop** - an automated iteration system th
 		taskGuidance = fmt.Sprintf(`If the Tasks section is empty, analyze the project and break the work into approximately %d tasks (one per iteration).`, maxIterations)
 	} else {
 		taskGuidance = `If the Tasks section is empty, analyze the project and add a comprehensive list of implementation tasks.`
+	}
+
+	// Build completion steps based on noPush setting
+	var completionSteps string
+	if noPush {
+		completionSteps = `Complete ONE task, then:
+1. Update ` + "`" + planFile + "`" + ` to mark the task as completed (move to Completed section)
+2. Exit`
+	} else {
+		completionSteps = `Complete ONE task, then:
+1. Update ` + "`" + planFile + "`" + ` to mark the task as completed (move to Completed section)
+2. Commit your changes with a descriptive message
+3. Exit`
 	}
 
 	// Build instructions to append
@@ -89,10 +127,7 @@ Study the implementation plan below. Pick the most important uncompleted task.
 
 ` + taskGuidance + `
 
-Complete ONE task, then:
-1. Update ` + "`" + planFile + "`" + ` to mark the task as completed (move to Completed section)
-2. Commit your changes with a descriptive message
-3. Exit
+` + completionSteps + `
 
 **Completion Promise:**
 When ALL tasks in the plan are complete and there is no more work to do, output this exact line:
@@ -155,6 +190,14 @@ func buildRLMPrompt(cfg Config, state *StateManager, iteration int) ([]byte, err
 		iterationStr = fmt.Sprintf("%d/unlimited", iteration)
 	}
 
+	// Build RLM principle #3 based on noPush setting
+	var rlmPrinciple3 string
+	if cfg.NoPush {
+		rlmPrinciple3 = "3. **One task per iteration**: Complete ONE task, update state, exit."
+	} else {
+		rlmPrinciple3 = "3. **One task per iteration**: Complete ONE task, update state, commit, exit."
+	}
+
 	// Build system context with RLM principles
 	systemContext := fmt.Sprintf(`# System Context
 
@@ -164,7 +207,7 @@ You are running in a **goralph RLM-enhanced agentic loop**.
 
 1. **Context is external**: The full codebase is NOT in your context. Use tools to explore.
 2. **State persists**: Discoveries are stored in %s. Reference previous findings.
-3. **One task per iteration**: Complete ONE task, update state, commit, exit.
+%s
 4. **Verify before commit**: Run relevant checks before marking complete.
 
 ## Session Info
@@ -184,7 +227,7 @@ You are running in a **goralph RLM-enhanced agentic loop**.
 
 ---
 
-`, StateDir, iterationStr, session.SessionID, phase, PhaseDisplayName(phase),
+`, StateDir, rlmPrinciple3, iterationStr, session.SessionID, phase, PhaseDisplayName(phase),
 		session.Depth, cfg.RLM.MaxDepth,
 		StateDir, StateDir, StateDir, StateDir, StateDir)
 
@@ -203,7 +246,7 @@ You are running in a **goralph RLM-enhanced agentic loop**.
 	systemContext += phaseGuidance + "\n\n---\n\n"
 
 	// Add RLM marker instructions
-	systemContext += rlmMarkerInstructions + "\n---\n\n"
+	systemContext += getRLMMarkerInstructions(cfg.NoPush) + "\n---\n\n"
 
 	// Add the user's task
 	systemContext += "# Task\n\n"
@@ -278,22 +321,24 @@ func formatHistorySection(entries []HistoryEntry) string {
 	return section
 }
 
-// rlmMarkerInstructions contains instructions for RLM output markers
-const rlmMarkerInstructions = `## RLM Output Markers
+// getRLMMarkerInstructions returns instructions for RLM output markers based on noPush setting
+func getRLMMarkerInstructions(noPush bool) string {
+	base := "## RLM Output Markers\n\n" +
+		"Use these markers to communicate state transitions:\n\n" +
+		"1. **Phase transition:** Signal which phase to enter next:\n" +
+		"   `<rlm:phase>PHASE_NAME</rlm:phase>`\n" +
+		"   Valid phases: PLAN, SEARCH, NARROW, ACT, VERIFY\n\n" +
+		"2. **Verification passed:** Signal that verification succeeded:\n" +
+		"   `<rlm:verified>true</rlm:verified>`\n\n" +
+		"3. **Session complete:** Signal all tasks are done:\n" +
+		"   `<promise>COMPLETE</promise>`"
 
-Use these markers to communicate state transitions:
+	if !noPush {
+		base += "\n\n**Important:** Always commit your changes before signaling completion."
+	}
 
-1. **Phase transition:** Signal which phase to enter next:
-   ` + "`" + `<rlm:phase>PHASE_NAME</rlm:phase>` + "`" + `
-   Valid phases: PLAN, SEARCH, NARROW, ACT, VERIFY
-
-2. **Verification passed:** Signal that verification succeeded:
-   ` + "`" + `<rlm:verified>true</rlm:verified>` + "`" + `
-
-3. **Session complete:** Signal all tasks are done:
-   ` + "`" + `<promise>COMPLETE</promise>` + "`" + `
-
-**Important:** Always commit your changes before signaling completion.`
+	return base
+}
 
 // saveContextToFile saves the context manifest to a JSON file for agent access
 func saveContextToFile(ctx *ContextManifest, stateDir string) error {

--- a/internal/loop/providers.go
+++ b/internal/loop/providers.go
@@ -192,6 +192,10 @@ func processClaudeUserMessage(line []byte, w io.Writer, state *StreamState) {
 			}
 		}
 	}
+
+	// Reset text tracking for the next assistant message turn
+	// This ensures new assistant text after tools is fully displayed
+	state.LastTextLen = 0
 }
 
 // CodexProvider implements Provider for OpenAI Codex agent

--- a/internal/loop/providers.go
+++ b/internal/loop/providers.go
@@ -169,7 +169,7 @@ func processClaudeAssistantMessage(line []byte, w io.Writer, state *StreamState)
 					fmt.Fprintln(w)
 					state.NeedsNewline = false
 				}
-				FormatToolStart(w, block.Name)
+				FormatToolStart(w, block.ID, block.Name, state)
 			}
 		}
 	}
@@ -187,7 +187,7 @@ func processClaudeUserMessage(line []byte, w io.Writer, state *StreamState) {
 			toolName := state.ActiveTools[block.ToolUseID]
 			if toolName != "" && !state.CompletedTools[block.ToolUseID] {
 				state.CompletedTools[block.ToolUseID] = true
-				FormatToolComplete(w, toolName)
+				FormatToolComplete(w, block.ToolUseID, toolName, state)
 				state.NeedsNewline = false // Tool complete ends with newline
 			}
 		}
@@ -333,7 +333,7 @@ func processCodexItemStarted(line []byte, w io.Writer, state *StreamState) {
 			toolName = cmd
 		}
 		state.ActiveTools[item.ID] = toolName
-		FormatToolStart(w, toolName)
+		FormatToolStart(w, item.ID, toolName, state)
 	case "mcp_tool_call":
 		// MCP tool invocation starting
 		toolName := item.Name
@@ -341,13 +341,13 @@ func processCodexItemStarted(line []byte, w io.Writer, state *StreamState) {
 			toolName = "mcp_tool"
 		}
 		state.ActiveTools[item.ID] = toolName
-		FormatToolStart(w, toolName)
+		FormatToolStart(w, item.ID, toolName, state)
 	case "file_change":
 		state.ActiveTools[item.ID] = "file_change"
-		FormatToolStart(w, "file_change")
+		FormatToolStart(w, item.ID, "file_change", state)
 	case "web_search":
 		state.ActiveTools[item.ID] = "web_search"
-		FormatToolStart(w, "web_search")
+		FormatToolStart(w, item.ID, "web_search", state)
 	}
 }
 
@@ -377,7 +377,7 @@ func processCodexItemCompleted(line []byte, w io.Writer, state *StreamState) {
 		toolName := state.ActiveTools[item.ID]
 		if toolName != "" && !state.CompletedTools[item.ID] {
 			state.CompletedTools[item.ID] = true
-			FormatToolComplete(w, toolName)
+			FormatToolComplete(w, item.ID, toolName, state)
 		}
 	case "plan_update":
 		// Plan updates can be displayed as text if desired

--- a/internal/loop/rlm_types.go
+++ b/internal/loop/rlm_types.go
@@ -1,0 +1,153 @@
+package loop
+
+import "time"
+
+// Phase represents the current phase in the RLM cycle
+type Phase string
+
+const (
+	// PhasePlan is the planning phase - analyze task and create approach
+	PhasePlan Phase = "PLAN"
+	// PhaseSearch is the search phase - explore codebase to find relevant code
+	PhaseSearch Phase = "SEARCH"
+	// PhaseNarrow is the narrow phase - focus on specific files/functions
+	PhaseNarrow Phase = "NARROW"
+	// PhaseAct is the action phase - make changes to code
+	PhaseAct Phase = "ACT"
+	// PhaseVerify is the verify phase - run tests and validate changes
+	PhaseVerify Phase = "VERIFY"
+)
+
+// RLMConfig holds RLM-specific configuration
+type RLMConfig struct {
+	Enabled      bool
+	MaxDepth     int
+	CurrentDepth int
+	Verify       bool
+}
+
+// SessionState represents the current RLM session state
+type SessionState struct {
+	SessionID   string    `json:"session_id"`
+	Iteration   int       `json:"iteration"`
+	Depth       int       `json:"depth"`
+	Phase       Phase     `json:"phase"`
+	StartedAt   time.Time `json:"started_at"`
+	LastUpdated time.Time `json:"last_updated"`
+}
+
+// ContextManifest tracks discovered context across iterations
+type ContextManifest struct {
+	// Task information from PROMPT.md
+	Task TaskInfo `json:"task"`
+
+	// Codebase information
+	Codebase CodebaseInfo `json:"codebase"`
+
+	// Discoveries made during exploration
+	Discoveries []Discovery `json:"discoveries"`
+
+	// Current focus - files/functions being worked on
+	Focus FocusSet `json:"focus"`
+
+	// Last updated timestamp
+	LastUpdated time.Time `json:"last_updated"`
+}
+
+// TaskInfo contains parsed task information
+type TaskInfo struct {
+	Summary     string   `json:"summary"`
+	Objectives  []string `json:"objectives"`
+	Constraints []string `json:"constraints"`
+}
+
+// CodebaseInfo contains discovered codebase structure
+type CodebaseInfo struct {
+	RootDir     string   `json:"root_dir"`
+	Language    string   `json:"language"`
+	BuildSystem string   `json:"build_system"`
+	KeyFiles    []string `json:"key_files"`
+	Patterns    []string `json:"patterns"`
+}
+
+// Discovery represents a finding during exploration
+type Discovery struct {
+	Iteration   int       `json:"iteration"`
+	Phase       Phase     `json:"phase"`
+	Type        string    `json:"type"` // file, function, pattern, dependency
+	Path        string    `json:"path"`
+	Description string    `json:"description"`
+	Relevance   string    `json:"relevance"` // high, medium, low
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+// FocusSet represents the current working context
+type FocusSet struct {
+	Files     []string `json:"files"`
+	Functions []string `json:"functions"`
+	Tests     []string `json:"tests"`
+}
+
+// HistoryEntry represents a single conversation entry in history
+type HistoryEntry struct {
+	Iteration int       `json:"iteration"`
+	Role      string    `json:"role"` // system, assistant, user
+	Content   string    `json:"content"`
+	Phase     Phase     `json:"phase"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// SearchQuery represents a recorded search operation
+type SearchQuery struct {
+	Iteration int       `json:"iteration"`
+	Query     string    `json:"query"`
+	Type      string    `json:"type"` // grep, glob, semantic
+	Results   []string  `json:"results"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// SearchResults aggregates search results for the session
+type SearchResults struct {
+	Queries []SearchQuery `json:"queries"`
+}
+
+// NarrowedSet represents a subset of context for focused work
+type NarrowedSet struct {
+	Iteration   int       `json:"iteration"`
+	Description string    `json:"description"`
+	Files       []string  `json:"files"`
+	Functions   []string  `json:"functions"`
+	Rationale   string    `json:"rationale"`
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+// VerificationReport contains the results of verification checks
+type VerificationReport struct {
+	Iteration int                 `json:"iteration"`
+	Passed    bool                `json:"passed"`
+	Checks    []VerificationCheck `json:"checks"`
+	Timestamp time.Time           `json:"timestamp"`
+}
+
+// VerificationCheck represents a single verification check
+type VerificationCheck struct {
+	Name    string `json:"name"`
+	Command string `json:"command"`
+	Passed  bool   `json:"passed"`
+	Output  string `json:"output"`
+	Error   string `json:"error,omitempty"`
+}
+
+// RLM marker patterns for output detection
+const (
+	// RLMPhaseMarkerStart is the start of a phase marker
+	RLMPhaseMarkerStart = "<rlm:phase>"
+	// RLMPhaseMarkerEnd is the end of a phase marker
+	RLMPhaseMarkerEnd = "</rlm:phase>"
+	// RLMVerifiedMarkerStart is the start of a verified marker
+	RLMVerifiedMarkerStart = "<rlm:verified>"
+	// RLMVerifiedMarkerEnd is the end of a verified marker
+	RLMVerifiedMarkerEnd = "</rlm:verified>"
+	// StateDir is the directory for RLM state files
+	StateDir = ".ralph/state"
+)

--- a/internal/loop/state.go
+++ b/internal/loop/state.go
@@ -211,7 +211,8 @@ func (sm *StateManager) GetRecentHistory(n int) ([]HistoryEntry, error) {
 // StoreSearchResult stores a search query and its results
 func (sm *StateManager) StoreSearchResult(query SearchQuery) error {
 	query.Timestamp = time.Now()
-	filename := fmt.Sprintf("search_%d_%d.json", query.Iteration, time.Now().UnixMilli())
+	// Use zero-padded iteration for correct lexicographic ordering
+	filename := fmt.Sprintf("search_%04d_%d.json", query.Iteration, time.Now().UnixMilli())
 	path := filepath.Join(sm.baseDir, "search", filename)
 
 	data, err := json.MarshalIndent(query, "", "  ")
@@ -229,7 +230,8 @@ func (sm *StateManager) StoreSearchResult(query SearchQuery) error {
 // StoreNarrowedSet stores a narrowed context set
 func (sm *StateManager) StoreNarrowedSet(set NarrowedSet) error {
 	set.Timestamp = time.Now()
-	filename := fmt.Sprintf("narrow_%d_%d.json", set.Iteration, time.Now().UnixMilli())
+	// Use zero-padded iteration for correct lexicographic ordering
+	filename := fmt.Sprintf("narrow_%04d_%d.json", set.Iteration, time.Now().UnixMilli())
 	path := filepath.Join(sm.baseDir, "narrow", filename)
 
 	data, err := json.MarshalIndent(set, "", "  ")
@@ -264,7 +266,8 @@ func (sm *StateManager) StoreResult(name string, data any) error {
 // StoreVerification stores a verification report
 func (sm *StateManager) StoreVerification(report VerificationReport) error {
 	report.Timestamp = time.Now()
-	filename := fmt.Sprintf("verify_%d_%d.json", report.Iteration, time.Now().UnixMilli())
+	// Use zero-padded iteration for correct lexicographic ordering
+	filename := fmt.Sprintf("verify_%04d_%d.json", report.Iteration, time.Now().UnixMilli())
 	path := filepath.Join(sm.baseDir, "verification", filename)
 
 	data, err := json.MarshalIndent(report, "", "  ")

--- a/internal/loop/state.go
+++ b/internal/loop/state.go
@@ -1,0 +1,357 @@
+package loop
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// StateManager handles RLM state persistence
+type StateManager struct {
+	baseDir string
+}
+
+// NewStateManager creates a new StateManager
+func NewStateManager(baseDir string) *StateManager {
+	return &StateManager{baseDir: baseDir}
+}
+
+// InitSession initializes a new RLM session, cleaning up any previous state
+func (sm *StateManager) InitSession() (*SessionState, error) {
+	// Clean up previous state
+	if err := os.RemoveAll(sm.baseDir); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to clean previous state: %w", err)
+	}
+
+	// Create state directories
+	dirs := []string{
+		sm.baseDir,
+		filepath.Join(sm.baseDir, "search"),
+		filepath.Join(sm.baseDir, "narrow"),
+		filepath.Join(sm.baseDir, "results"),
+		filepath.Join(sm.baseDir, "verification"),
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create state directory %s: %w", dir, err)
+		}
+	}
+
+	// Create initial session state
+	now := time.Now()
+	state := &SessionState{
+		SessionID:   uuid.New().String(),
+		Iteration:   0,
+		Depth:       0,
+		Phase:       PhasePlan,
+		StartedAt:   now,
+		LastUpdated: now,
+	}
+
+	if err := sm.SaveSession(state); err != nil {
+		return nil, err
+	}
+
+	// Create initial context manifest
+	context := &ContextManifest{
+		Task:        TaskInfo{},
+		Codebase:    CodebaseInfo{},
+		Discoveries: []Discovery{},
+		Focus:       FocusSet{},
+		LastUpdated: now,
+	}
+	if err := sm.saveContext(context); err != nil {
+		return nil, err
+	}
+
+	return state, nil
+}
+
+// LoadSession loads the current session state
+func (sm *StateManager) LoadSession() (*SessionState, error) {
+	path := filepath.Join(sm.baseDir, "session.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session state: %w", err)
+	}
+
+	var state SessionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to parse session state: %w", err)
+	}
+
+	return &state, nil
+}
+
+// SaveSession saves the session state
+func (sm *StateManager) SaveSession(state *SessionState) error {
+	state.LastUpdated = time.Now()
+	path := filepath.Join(sm.baseDir, "session.json")
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal session state: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write session state: %w", err)
+	}
+
+	return nil
+}
+
+// GetContext loads the context manifest
+func (sm *StateManager) GetContext() (*ContextManifest, error) {
+	path := filepath.Join(sm.baseDir, "context.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read context manifest: %w", err)
+	}
+
+	var context ContextManifest
+	if err := json.Unmarshal(data, &context); err != nil {
+		return nil, fmt.Errorf("failed to parse context manifest: %w", err)
+	}
+
+	return &context, nil
+}
+
+// UpdateContext updates the context manifest
+func (sm *StateManager) UpdateContext(context *ContextManifest) error {
+	return sm.saveContext(context)
+}
+
+func (sm *StateManager) saveContext(context *ContextManifest) error {
+	context.LastUpdated = time.Now()
+	path := filepath.Join(sm.baseDir, "context.json")
+
+	data, err := json.MarshalIndent(context, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal context manifest: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write context manifest: %w", err)
+	}
+
+	return nil
+}
+
+// AppendHistory appends a history entry to the history file
+func (sm *StateManager) AppendHistory(entry HistoryEntry) error {
+	entry.Timestamp = time.Now()
+	path := filepath.Join(sm.baseDir, "history.jsonl")
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open history file: %w", err)
+	}
+	defer f.Close()
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal history entry: %w", err)
+	}
+
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("failed to write history entry: %w", err)
+	}
+
+	return nil
+}
+
+// GetHistory reads all history entries
+func (sm *StateManager) GetHistory() ([]HistoryEntry, error) {
+	path := filepath.Join(sm.baseDir, "history.jsonl")
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []HistoryEntry{}, nil
+		}
+		return nil, fmt.Errorf("failed to open history file: %w", err)
+	}
+	defer f.Close()
+
+	var entries []HistoryEntry
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var entry HistoryEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue // Skip malformed entries
+		}
+		entries = append(entries, entry)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read history file: %w", err)
+	}
+
+	return entries, nil
+}
+
+// GetRecentHistory returns the last n history entries
+func (sm *StateManager) GetRecentHistory(n int) ([]HistoryEntry, error) {
+	entries, err := sm.GetHistory()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(entries) <= n {
+		return entries, nil
+	}
+	return entries[len(entries)-n:], nil
+}
+
+// StoreSearchResult stores a search query and its results
+func (sm *StateManager) StoreSearchResult(query SearchQuery) error {
+	query.Timestamp = time.Now()
+	filename := fmt.Sprintf("search_%d_%d.json", query.Iteration, time.Now().UnixMilli())
+	path := filepath.Join(sm.baseDir, "search", filename)
+
+	data, err := json.MarshalIndent(query, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal search result: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write search result: %w", err)
+	}
+
+	return nil
+}
+
+// StoreNarrowedSet stores a narrowed context set
+func (sm *StateManager) StoreNarrowedSet(set NarrowedSet) error {
+	set.Timestamp = time.Now()
+	filename := fmt.Sprintf("narrow_%d_%d.json", set.Iteration, time.Now().UnixMilli())
+	path := filepath.Join(sm.baseDir, "narrow", filename)
+
+	data, err := json.MarshalIndent(set, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal narrowed set: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write narrowed set: %w", err)
+	}
+
+	return nil
+}
+
+// StoreResult stores an intermediate computation result
+func (sm *StateManager) StoreResult(name string, data any) error {
+	filename := fmt.Sprintf("%s_%d.json", name, time.Now().UnixMilli())
+	path := filepath.Join(sm.baseDir, "results", filename)
+
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	if err := os.WriteFile(path, jsonData, 0644); err != nil {
+		return fmt.Errorf("failed to write result: %w", err)
+	}
+
+	return nil
+}
+
+// StoreVerification stores a verification report
+func (sm *StateManager) StoreVerification(report VerificationReport) error {
+	report.Timestamp = time.Now()
+	filename := fmt.Sprintf("verify_%d_%d.json", report.Iteration, time.Now().UnixMilli())
+	path := filepath.Join(sm.baseDir, "verification", filename)
+
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal verification report: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write verification report: %w", err)
+	}
+
+	return nil
+}
+
+// GetLatestVerification returns the most recent verification report
+func (sm *StateManager) GetLatestVerification() (*VerificationReport, error) {
+	dir := filepath.Join(sm.baseDir, "verification")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read verification directory: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	// Find most recent file (files are timestamped, so last alphabetically is most recent)
+	var latest string
+	for _, entry := range entries {
+		if !entry.IsDir() && entry.Name() > latest {
+			latest = entry.Name()
+		}
+	}
+
+	if latest == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, latest))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read verification report: %w", err)
+	}
+
+	var report VerificationReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("failed to parse verification report: %w", err)
+	}
+
+	return &report, nil
+}
+
+// AddDiscovery adds a discovery to the context manifest
+func (sm *StateManager) AddDiscovery(discovery Discovery) error {
+	context, err := sm.GetContext()
+	if err != nil {
+		return err
+	}
+
+	discovery.Timestamp = time.Now()
+	context.Discoveries = append(context.Discoveries, discovery)
+
+	return sm.UpdateContext(context)
+}
+
+// UpdateFocus updates the focus set in the context manifest
+func (sm *StateManager) UpdateFocus(focus FocusSet) error {
+	context, err := sm.GetContext()
+	if err != nil {
+		return err
+	}
+
+	context.Focus = focus
+	return sm.UpdateContext(context)
+}
+
+// UpdateIteration increments the iteration counter and optionally changes phase
+func (sm *StateManager) UpdateIteration(phase Phase) error {
+	state, err := sm.LoadSession()
+	if err != nil {
+		return err
+	}
+
+	state.Iteration++
+	state.Phase = phase
+
+	return sm.SaveSession(state)
+}

--- a/internal/loop/types.go
+++ b/internal/loop/types.go
@@ -19,12 +19,15 @@ const (
 
 // Config holds the loop configuration
 type Config struct {
-	PromptFile    string
-	PlanFile      string // Session-scoped plan file path
-	MaxIterations int
-	NoPush        bool
-	Agent         AgentProvider
-	Output        io.Writer
+	PromptFile     string
+	PlanFile       string // Session-scoped plan file path
+	MaxIterations  int
+	NoPush         bool
+	Agent          AgentProvider
+	Output         io.Writer
+	RLM            RLMConfig // RLM mode configuration
+	VerifyEnabled  bool      // Run verification before commit
+	VerifyCommands []string  // Custom verification commands (auto-detected if empty)
 }
 
 // GeneratePlanPath returns a timestamped path for a new session-scoped plan file.
@@ -80,6 +83,8 @@ type ResultMessage struct {
 	Usage           Usage   `json:"usage"`
 	HasCost         bool    `json:"-"` // Internal field: true if provider supplies cost data
 	SessionComplete bool    `json:"-"` // Internal: true if agent emitted completion promise
+	RLMPhase        Phase   `json:"-"` // Internal: detected phase from RLM markers
+	RLMVerified     bool    `json:"-"` // Internal: true if agent emitted verified marker
 }
 
 // Usage represents token usage statistics

--- a/internal/loop/types.go
+++ b/internal/loop/types.go
@@ -139,6 +139,7 @@ type StreamState struct {
 	CompletedTools  map[string]bool
 	AccumulatedText strings.Builder // All text content for pattern detection
 	NeedsNewline    bool            // Whether a newline is needed before next tool indicator
+	PendingToolIDs  []string        // Ordered list of tool IDs that are still running
 }
 
 // NewStreamState creates a new StreamState with initialized maps

--- a/internal/loop/verify.go
+++ b/internal/loop/verify.go
@@ -1,0 +1,173 @@
+package loop
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Verifier runs verification commands before commit
+type Verifier struct {
+	commands []string
+}
+
+// NewVerifier creates a new Verifier with the specified commands
+// If commands is empty, it will auto-detect project type
+func NewVerifier(commands []string) *Verifier {
+	if len(commands) == 0 {
+		commands = DetectProjectType()
+	}
+	return &Verifier{commands: commands}
+}
+
+// Run executes all verification commands and returns a report
+func (v *Verifier) Run(iteration int) VerificationReport {
+	report := VerificationReport{
+		Iteration: iteration,
+		Passed:    true,
+		Checks:    make([]VerificationCheck, 0, len(v.commands)),
+		Timestamp: time.Now(),
+	}
+
+	for _, cmd := range v.commands {
+		check := v.runCheck(cmd)
+		report.Checks = append(report.Checks, check)
+		if !check.Passed {
+			report.Passed = false
+		}
+	}
+
+	return report
+}
+
+// runCheck executes a single verification command
+func (v *Verifier) runCheck(cmdStr string) VerificationCheck {
+	check := VerificationCheck{
+		Name:    cmdStr,
+		Command: cmdStr,
+	}
+
+	// Parse command - simple split on spaces
+	parts := strings.Fields(cmdStr)
+	if len(parts) == 0 {
+		check.Error = "empty command"
+		return check
+	}
+
+	cmd := exec.Command(parts[0], parts[1:]...)
+
+	// Capture output
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	check.Output = stdout.String()
+	if stderr.Len() > 0 {
+		if check.Output != "" {
+			check.Output += "\n"
+		}
+		check.Output += stderr.String()
+	}
+
+	if err != nil {
+		check.Passed = false
+		check.Error = err.Error()
+	} else {
+		check.Passed = true
+	}
+
+	return check
+}
+
+// HasCommands returns true if the verifier has commands to run
+func (v *Verifier) HasCommands() bool {
+	return len(v.commands) > 0
+}
+
+// DetectProjectType analyzes the current directory and returns appropriate verification commands
+func DetectProjectType() []string {
+	// Check for Go project
+	if _, err := os.Stat("go.mod"); err == nil {
+		return []string{
+			"go build ./...",
+			"go test ./...",
+		}
+	}
+
+	// Check for Node.js project
+	if _, err := os.Stat("package.json"); err == nil {
+		commands := []string{}
+		// Check if build script exists
+		if hasPkgScript("build") {
+			commands = append(commands, "npm run build")
+		}
+		// Check if test script exists
+		if hasPkgScript("test") {
+			commands = append(commands, "npm test")
+		}
+		if len(commands) > 0 {
+			return commands
+		}
+	}
+
+	// Check for Rust project
+	if _, err := os.Stat("Cargo.toml"); err == nil {
+		return []string{
+			"cargo build",
+			"cargo test",
+		}
+	}
+
+	// Check for Python project
+	if _, err := os.Stat("pyproject.toml"); err == nil {
+		return []string{"pytest"}
+	}
+	if _, err := os.Stat("setup.py"); err == nil {
+		return []string{"pytest"}
+	}
+
+	// Check for Makefile
+	if _, err := os.Stat("Makefile"); err == nil {
+		// Check for common targets
+		if hasMakeTarget("test") {
+			return []string{"make test"}
+		}
+		if hasMakeTarget("check") {
+			return []string{"make check"}
+		}
+	}
+
+	// No recognized project type
+	return nil
+}
+
+// hasPkgScript checks if package.json contains a specific script
+func hasPkgScript(script string) bool {
+	data, err := os.ReadFile("package.json")
+	if err != nil {
+		return false
+	}
+	// Simple check - look for "script": in the JSON
+	searchStr := fmt.Sprintf(`"%s":`, script)
+	return bytes.Contains(data, []byte(searchStr))
+}
+
+// hasMakeTarget checks if Makefile contains a specific target
+func hasMakeTarget(target string) bool {
+	data, err := os.ReadFile("Makefile")
+	if err != nil {
+		return false
+	}
+	// Look for target: at the start of a line
+	searchStr := target + ":"
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if bytes.HasPrefix(bytes.TrimSpace(line), []byte(searchStr)) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds RLM (Recursive Language Model) mode to goralph, enabling a structured approach where state is persisted to files rather than relying on the context window. Each iteration follows the RLM cycle: PLAN → SEARCH → NARROW → ACT → VERIFY.

## Changes

- Add RLM type definitions including Phase enum, SessionState, ContextManifest, and verification types
- Implement StateManager for persisting RLM state across iterations (session.json, context.json, history.jsonl)
- Add PhaseRouter for phase inference and phase-specific agent guidance
- Implement Verifier for build/test validation with auto-detection of project types (Go, Node.js, Rust, Python, Makefile)
- Add RLM output marker detection (`<rlm:phase>`, `<rlm:verified>`)
- Integrate RLM mode and verification into the main loop with new CLI flags
- Add RLM-aware prompt builder that injects session context and phase guidance

## Breaking Changes

None

## Test Plan

- [x] Run `goralph run --rlm` to verify RLM mode initializes correctly
- [x] Verify state files are created in `.ralph/state/`
- [ ] Run `goralph run --verify` to verify project type detection
- [x] Run `goralph run --rlm --verify` to test combined mode
- [x] Test `--max-depth` flag is respected

## Release Notes

New RLM (Recursive Language Model) mode enables structured agentic execution with persistent state across iterations. Agents follow a PLAN → SEARCH → NARROW → ACT → VERIFY cycle, with state stored in `.ralph/state/`. New `--verify` flag runs build/test commands before commit, with automatic project type detection for Go, Node.js, Rust, and Python projects.

## Checklist

- [x] Tests pass locally (`task build`)
- [x] Conventional commit format followed
- [ ] Documentation updated