### PR TITLE
feat: add RLM mode with state persistence and PageIndex PDF processing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ goralph run -n 5         # Run with max 5 iterations (tasks broken into ~5 piece
 goralph run --max 10     # Run with max 10 iterations (tasks broken into ~10 pieces)
 goralph run --no-push    # Run without pushing changes after each iteration
 goralph run --agent codex  # Use OpenAI Codex instead of Claude
+goralph run --rlm        # Enable RLM (Recursive Language Model) mode
+goralph run --verify     # Run build/test verification before commit
+goralph run --rlm --verify  # RLM mode with verification
+goralph run --max-depth 5   # Set max recursion depth for RLM (default: 3)
 ```
 
 ### Environment variables
@@ -53,6 +57,34 @@ When using `--max`/`-n` flag:
 - The agent is instructed to break work into approximately N tasks (one per iteration)
 - Without the flag, the agent creates a comprehensive task list
 
+## RLM Mode
+
+RLM (Recursive Language Model) mode uses a structured approach where state is persisted to files rather than relying on context window. Each iteration follows the RLM cycle: PLAN → SEARCH → NARROW → ACT → VERIFY.
+
+### RLM State Directory
+
+When RLM mode is enabled, state is persisted in `.ralph/state/`:
+- `session.json` - Session metadata (iteration, depth, phase)
+- `context.json` - Context manifest (discoveries, key files, focus)
+- `history.jsonl` - Conversation history across iterations
+- `search/` - Search operation results
+- `narrow/` - Narrowed context subsets
+- `verification/` - Verification reports
+
+### RLM Markers
+
+Agents signal state transitions using markers:
+- `<rlm:phase>PHASE</rlm:phase>` - Signal phase transition (PLAN, SEARCH, NARROW, ACT, VERIFY)
+- `<rlm:verified>true</rlm:verified>` - Signal verification passed
+- `<promise>COMPLETE</promise>` - Signal all tasks complete
+
+### Verification
+
+When `--verify` is enabled:
+- Project type is auto-detected (Go, Node.js, Rust, Python)
+- Build and test commands run before commit
+- Failed verification skips push and continues to next iteration
+
 ## Project Structure
 
 - `cmd/` - Cobra CLI commands (root, run)
@@ -60,6 +92,10 @@ When using `--max`/`-n` flag:
   - `loop.go` - Main loop execution and agent iteration
   - `providers.go` - Agent provider implementations (Claude, Codex)
   - `types.go` - Message types and agent provider constants
+  - `rlm_types.go` - RLM-specific type definitions
+  - `state.go` - StateManager for RLM state persistence
+  - `phases.go` - Phase routing and inference logic
+  - `verify.go` - Verification runner for build/test checks
   - `output.go` - Terminal output formatting with lipgloss
   - `prompt.go` - Prompt file reading and construction
   - `git.go` - Git operations (push, branch management)
@@ -67,6 +103,7 @@ When using `--max`/`-n` flag:
 - `.ralph/` - Prompt files and session data
 - `.ralph/plans/` - Session-scoped implementation plans (timestamped)
 - `.ralph/logs/` - Timestamped JSONL logs of each agent session
+- `.ralph/state/` - RLM state files (when RLM mode is enabled)
 
 ## Required Files
 
@@ -78,3 +115,4 @@ When using `--max`/`-n` flag:
 
 - `github.com/spf13/cobra` - CLI framework
 - `github.com/charmbracelet/lipgloss` - Terminal styling
+- `github.com/google/uuid` - UUID generation for RLM sessions

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,6 +10,9 @@ import (
 var maxIterations int
 var noPush bool
 var agent string
+var rlmEnabled bool
+var verifyEnabled bool
+var maxDepth int
 
 var runCmd = &cobra.Command{
 	Use:   "run",
@@ -29,6 +32,11 @@ var runCmd = &cobra.Command{
 			NoPush:        noPush,
 			Agent:         agentProvider,
 			Output:        cmd.OutOrStdout(),
+			RLM: loop.RLMConfig{
+				Enabled:  rlmEnabled,
+				MaxDepth: maxDepth,
+			},
+			VerifyEnabled: verifyEnabled,
 		})
 	},
 }
@@ -43,6 +51,11 @@ func init() {
 		defaultAgent = envAgent
 	}
 	runCmd.Flags().StringVar(&agent, "agent", defaultAgent, "Agent provider to use (claude, codex)")
+
+	// RLM mode flags
+	runCmd.Flags().BoolVar(&rlmEnabled, "rlm", false, "Enable RLM (Recursive Language Model) mode")
+	runCmd.Flags().BoolVar(&verifyEnabled, "verify", false, "Run verification (build/test) before commit")
+	runCmd.Flags().IntVar(&maxDepth, "max-depth", 3, "Maximum recursion depth for RLM mode")
 
 	rootCmd.AddCommand(runCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.4
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod 
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -36,13 +36,31 @@ func Run(cfg Config) error {
 		return fmt.Errorf("failed to create plans directory: %w", err)
 	}
 
-	// Reset implementation plan to initial template
-	if err := resetImplementationPlan(cfg.PlanFile); err != nil {
-		return err
+	// Initialize RLM state if RLM mode is enabled
+	var stateManager *StateManager
+	if cfg.RLM.Enabled {
+		stateManager = NewStateManager(StateDir)
+		if _, err := stateManager.InitSession(); err != nil {
+			return fmt.Errorf("failed to initialize RLM session: %w", err)
+		}
+	} else {
+		// Reset implementation plan to initial template (non-RLM mode)
+		if err := resetImplementationPlan(cfg.PlanFile); err != nil {
+			return err
+		}
 	}
 
 	// Print configuration
 	FormatHeader(cfg.Output, cfg, branch, provider.Model())
+
+	// Create verifier if verification is enabled
+	var verifier *Verifier
+	if cfg.VerifyEnabled {
+		verifier = NewVerifier(cfg.VerifyCommands)
+		if !verifier.HasCommands() {
+			fmt.Fprintln(cfg.Output, dimStyle.Render("Warning: No verification commands detected for project type"))
+		}
+	}
 
 	iteration := 0
 	for {
@@ -54,17 +72,32 @@ func Run(cfg Config) error {
 			break
 		}
 
-		// Show loop banner before iteration
-		FormatLoopBanner(cfg.Output, iteration)
+		// Show loop banner before iteration (with phase if RLM mode)
+		if cfg.RLM.Enabled && stateManager != nil {
+			session, _ := stateManager.LoadSession()
+			if session != nil {
+				FormatLoopBannerWithPhase(cfg.Output, iteration, session.Phase)
+			} else {
+				FormatLoopBanner(cfg.Output, iteration)
+			}
+		} else {
+			FormatLoopBanner(cfg.Output, iteration)
+		}
 
 		// Run iteration using the provider
-		completed, err := runIteration(cfg, provider, iteration)
+		completed, verifyFailed, err := runIterationWithRLM(cfg, provider, iteration, stateManager, verifier)
 		if err != nil {
 			return fmt.Errorf("%s iteration failed: %w", provider.Name(), err)
 		}
 		if completed {
 			FormatSessionComplete(cfg.Output)
 			break
+		}
+
+		// Skip push if verification failed
+		if verifyFailed {
+			fmt.Fprintln(cfg.Output, dimStyle.Render("Skipping push due to verification failure"))
+			continue
 		}
 
 		// Push changes unless --no-push is set
@@ -78,17 +111,39 @@ func Run(cfg Config) error {
 	return nil
 }
 
-func runIteration(cfg Config, provider Provider, iteration int) (bool, error) {
-	// Build prompt with implementation plan
-	promptContent, err := buildPromptWithPlan(cfg.PromptFile, cfg.PlanFile, iteration, cfg.MaxIterations)
-	if err != nil {
-		return false, err
+// runIterationWithRLM runs a single iteration with optional RLM state management and verification
+func runIterationWithRLM(cfg Config, provider Provider, iteration int, state *StateManager, verifier *Verifier) (completed bool, verifyFailed bool, err error) {
+	var promptContent []byte
+
+	// Build prompt based on mode
+	if cfg.RLM.Enabled && state != nil {
+		// Update session iteration
+		session, loadErr := state.LoadSession()
+		if loadErr != nil {
+			return false, false, fmt.Errorf("failed to load session: %w", loadErr)
+		}
+		session.Iteration = iteration
+		if saveErr := state.SaveSession(session); saveErr != nil {
+			return false, false, fmt.Errorf("failed to save session: %w", saveErr)
+		}
+
+		// Build RLM prompt
+		promptContent, err = buildRLMPrompt(cfg, state, iteration)
+		if err != nil {
+			return false, false, err
+		}
+	} else {
+		// Build standard prompt
+		promptContent, err = buildPromptWithPlan(cfg.PromptFile, cfg.PlanFile, iteration, cfg.MaxIterations)
+		if err != nil {
+			return false, false, err
+		}
 	}
 
 	// Create logs directory
 	logsDir := filepath.Join(".ralph", "logs")
 	if err := os.MkdirAll(logsDir, 0755); err != nil {
-		return false, fmt.Errorf("failed to create logs directory: %w", err)
+		return false, false, fmt.Errorf("failed to create logs directory: %w", err)
 	}
 
 	// Generate timestamped log filename
@@ -98,26 +153,26 @@ func runIteration(cfg Config, provider Provider, iteration int) (bool, error) {
 	// Create log file
 	logFile, err := os.Create(logPath)
 	if err != nil {
-		return false, fmt.Errorf("failed to create log file: %w", err)
+		return false, false, fmt.Errorf("failed to create log file: %w", err)
 	}
 	defer logFile.Close()
 
 	// Build the command using the provider
 	cmd, err := provider.BuildCommand(promptContent)
 	if err != nil {
-		return false, fmt.Errorf("failed to build command: %w", err)
+		return false, false, fmt.Errorf("failed to build command: %w", err)
 	}
 
 	// Set up stdin with prompt content
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return false, fmt.Errorf("failed to create stdin pipe: %w", err)
+		return false, false, fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
 
 	// Capture stdout for parsing
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return false, fmt.Errorf("failed to create stdout pipe: %w", err)
+		return false, false, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 
 	// Connect stderr to terminal
@@ -125,12 +180,12 @@ func runIteration(cfg Config, provider Provider, iteration int) (bool, error) {
 
 	// Start the command
 	if err := cmd.Start(); err != nil {
-		return false, fmt.Errorf("failed to start %s: %w", provider.Name(), err)
+		return false, false, fmt.Errorf("failed to start %s: %w", provider.Name(), err)
 	}
 
 	// Write prompt to stdin and close
 	if _, err := stdin.Write(promptContent); err != nil {
-		return false, fmt.Errorf("failed to write to stdin: %w", err)
+		return false, false, fmt.Errorf("failed to write to stdin: %w", err)
 	}
 	stdin.Close()
 
@@ -143,12 +198,12 @@ func runIteration(cfg Config, provider Provider, iteration int) (bool, error) {
 	// Parse output using the provider and write to log file
 	resultMsg, err := provider.ParseOutput(stdout, cfg.Output, logFile)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse output: %w", err)
+		return false, false, fmt.Errorf("failed to parse output: %w", err)
 	}
 
 	// Wait for completion
 	if err := cmd.Wait(); err != nil {
-		return false, fmt.Errorf("%s exited with error: %w", provider.Name(), err)
+		return false, false, fmt.Errorf("%s exited with error: %w", provider.Name(), err)
 	}
 
 	// Inject duration if provider didn't supply it
@@ -164,7 +219,50 @@ func runIteration(cfg Config, provider Provider, iteration int) (bool, error) {
 		fmt.Fprintln(cfg.Output, dimStyle.Render(fmt.Sprintf("Warning: No result message received from %s", provider.Name())))
 	}
 
+	// Update RLM state if enabled
+	if cfg.RLM.Enabled && state != nil && resultMsg != nil {
+		// Update phase if detected
+		if resultMsg.RLMPhase != "" {
+			if updateErr := state.UpdateIteration(resultMsg.RLMPhase); updateErr != nil {
+				fmt.Fprintln(cfg.Output, dimStyle.Render(fmt.Sprintf("Warning: Failed to update RLM phase: %v", updateErr)))
+			}
+		}
+
+		// Record iteration in history
+		historyEntry := HistoryEntry{
+			Iteration: iteration,
+			Role:      "assistant",
+			Content:   fmt.Sprintf("Iteration %d completed", iteration),
+			Phase:     resultMsg.RLMPhase,
+		}
+		if appendErr := state.AppendHistory(historyEntry); appendErr != nil {
+			fmt.Fprintln(cfg.Output, dimStyle.Render(fmt.Sprintf("Warning: Failed to append history: %v", appendErr)))
+		}
+	}
+
+	// Run verification if enabled and agent signaled verified
+	if verifier != nil && verifier.HasCommands() && resultMsg != nil && resultMsg.RLMVerified {
+		fmt.Fprintln(cfg.Output)
+		fmt.Fprintln(cfg.Output, dimStyle.Render("Running verification..."))
+
+		report := verifier.Run(iteration)
+
+		// Store verification report if state manager available
+		if state != nil {
+			if storeErr := state.StoreVerification(report); storeErr != nil {
+				fmt.Fprintln(cfg.Output, dimStyle.Render(fmt.Sprintf("Warning: Failed to store verification report: %v", storeErr)))
+			}
+		}
+
+		if report.Passed {
+			FormatVerificationPassed(cfg.Output)
+		} else {
+			FormatVerificationFailed(cfg.Output, report)
+			return false, true, nil // Continue loop but skip push
+		}
+	}
+
 	// Check if agent signaled session completion
 	sessionComplete := resultMsg != nil && resultMsg.SessionComplete
-	return sessionComplete, nil
+	return sessionComplete, false, nil
 }

--- a/internal/loop/phases.go
+++ b/internal/loop/phases.go
@@ -1,0 +1,215 @@
+package loop
+
+// PhaseRouter handles phase inference and guidance generation
+type PhaseRouter struct {
+	state *StateManager
+}
+
+// NewPhaseRouter creates a new PhaseRouter
+func NewPhaseRouter(state *StateManager) *PhaseRouter {
+	return &PhaseRouter{state: state}
+}
+
+// InferPhase determines the current phase based on session state
+func (pr *PhaseRouter) InferPhase() (Phase, error) {
+	session, err := pr.state.LoadSession()
+	if err != nil {
+		return PhasePlan, err
+	}
+
+	context, err := pr.state.GetContext()
+	if err != nil {
+		return PhasePlan, err
+	}
+
+	// First iteration always starts with PLAN
+	if session.Iteration == 0 {
+		return PhasePlan, nil
+	}
+
+	// If no discoveries yet, still in SEARCH/PLAN phase
+	if len(context.Discoveries) == 0 {
+		return PhaseSearch, nil
+	}
+
+	// If no focus files yet, need to NARROW
+	if len(context.Focus.Files) == 0 {
+		return PhaseNarrow, nil
+	}
+
+	// Check last verification result
+	lastVerify, _ := pr.state.GetLatestVerification()
+	if lastVerify != nil && !lastVerify.Passed {
+		// Last verification failed, need to fix and re-verify
+		return PhaseAct, nil
+	}
+
+	// Default progression based on previous phase
+	switch session.Phase {
+	case PhasePlan:
+		return PhaseSearch, nil
+	case PhaseSearch:
+		return PhaseNarrow, nil
+	case PhaseNarrow:
+		return PhaseAct, nil
+	case PhaseAct:
+		return PhaseVerify, nil
+	case PhaseVerify:
+		// After verify, loop back to search for next task or complete
+		return PhaseSearch, nil
+	default:
+		return PhasePlan, nil
+	}
+}
+
+// GetPhaseGuidance returns phase-specific instructions for the agent
+func (pr *PhaseRouter) GetPhaseGuidance(phase Phase) string {
+	switch phase {
+	case PhasePlan:
+		return planPhaseGuidance
+	case PhaseSearch:
+		return searchPhaseGuidance
+	case PhaseNarrow:
+		return narrowPhaseGuidance
+	case PhaseAct:
+		return actPhaseGuidance
+	case PhaseVerify:
+		return verifyPhaseGuidance
+	default:
+		return planPhaseGuidance
+	}
+}
+
+// Phase guidance templates
+const planPhaseGuidance = `## Phase: PLAN
+
+**Objective:** Understand the task and create an implementation approach.
+
+**Actions:**
+1. Read and analyze the task from PROMPT.md
+2. Identify key objectives and constraints
+3. Create high-level implementation steps
+4. Update context manifest with task summary
+
+**State updates:**
+- Write task summary to context.json
+- Record initial analysis in history
+
+**Exit criteria:**
+- Task objectives are clear
+- Implementation approach is documented
+- Ready to search for relevant code
+
+**Output:** Signal phase completion with:
+` + "`" + `<rlm:phase>SEARCH</rlm:phase>` + "`"
+
+const searchPhaseGuidance = `## Phase: SEARCH
+
+**Objective:** Explore the codebase to find relevant code and patterns.
+
+**Actions:**
+1. Use grep/glob to find files related to the task
+2. Read key files to understand existing patterns
+3. Identify dependencies and related code
+4. Record discoveries for future reference
+
+**State updates:**
+- Store search results in .ralph/state/search/
+- Add discoveries to context.json
+- Update history with findings
+
+**Exit criteria:**
+- Relevant files and functions identified
+- Understanding of existing patterns
+- Ready to narrow focus
+
+**Output:** Signal phase completion with:
+` + "`" + `<rlm:phase>NARROW</rlm:phase>` + "`"
+
+const narrowPhaseGuidance = `## Phase: NARROW
+
+**Objective:** Focus on specific files and functions for modification.
+
+**Actions:**
+1. Review discoveries from search phase
+2. Select specific files to modify
+3. Identify exact functions/locations for changes
+4. Validate approach against existing patterns
+
+**State updates:**
+- Store narrowed set in .ralph/state/narrow/
+- Update focus in context.json
+- Record rationale in history
+
+**Exit criteria:**
+- Specific files and functions identified
+- Clear understanding of required changes
+- Ready to implement
+
+**Output:** Signal phase completion with:
+` + "`" + `<rlm:phase>ACT</rlm:phase>` + "`"
+
+const actPhaseGuidance = `## Phase: ACT
+
+**Objective:** Implement the planned changes.
+
+**Actions:**
+1. Review focus set from narrow phase
+2. Implement changes in identified files
+3. Follow existing code patterns and conventions
+4. Write minimal, focused changes
+
+**State updates:**
+- Record changes made in history
+- Update any affected discoveries
+
+**Exit criteria:**
+- Changes implemented
+- Code follows existing patterns
+- Ready for verification
+
+**Output:** Signal phase completion with:
+` + "`" + `<rlm:phase>VERIFY</rlm:phase>` + "`"
+
+const verifyPhaseGuidance = `## Phase: VERIFY
+
+**Objective:** Validate changes work correctly.
+
+**Actions:**
+1. Run relevant build commands
+2. Run relevant test commands
+3. Check for any regressions
+4. Fix issues if found
+
+**State updates:**
+- Store verification results in .ralph/state/verification/
+- Update history with verification outcome
+
+**If verification passes:**
+1. Signal verification success with: ` + "`" + `<rlm:verified>true</rlm:verified>` + "`" + `
+2. Commit your changes
+3. If all tasks complete: ` + "`" + `<promise>COMPLETE</promise>` + "`" + `
+4. Otherwise signal next search: ` + "`" + `<rlm:phase>SEARCH</rlm:phase>` + "`" + `
+
+**If verification fails:**
+1. Analyze failure
+2. Return to ACT phase to fix: ` + "`" + `<rlm:phase>ACT</rlm:phase>` + "`" + `
+`
+
+// PhaseDisplayName returns a human-readable name for the phase
+func PhaseDisplayName(phase Phase) string {
+	switch phase {
+	case PhasePlan:
+		return "Planning"
+	case PhaseSearch:
+		return "Searching"
+	case PhaseNarrow:
+		return "Narrowing"
+	case PhaseAct:
+		return "Implementing"
+	case PhaseVerify:
+		return "Verifying"
+	default:
+		return string(phase)
+	}
+}

--- a/internal/loop/rlm_types.go
+++ b/internal/loop/rlm_types.go
@@ -1,0 +1,153 @@
+package loop
+
+import "time"
+
+// Phase represents the current phase in the RLM cycle
+type Phase string
+
+const (
+	// PhasePlan is the planning phase - analyze task and create approach
+	PhasePlan Phase = "PLAN"
+	// PhaseSearch is the search phase - explore codebase to find relevant code
+	PhaseSearch Phase = "SEARCH"
+	// PhaseNarrow is the narrow phase - focus on specific files/functions
+	PhaseNarrow Phase = "NARROW"
+	// PhaseAct is the action phase - make changes to code
+	PhaseAct Phase = "ACT"
+	// PhaseVerify is the verify phase - run tests and validate changes
+	PhaseVerify Phase = "VERIFY"
+)
+
+// RLMConfig holds RLM-specific configuration
+type RLMConfig struct {
+	Enabled      bool
+	MaxDepth     int
+	CurrentDepth int
+	Verify       bool
+}
+
+// SessionState represents the current RLM session state
+type SessionState struct {
+	SessionID   string    `json:"session_id"`
+	Iteration   int       `json:"iteration"`
+	Depth       int       `json:"depth"`
+	Phase       Phase     `json:"phase"`
+	StartedAt   time.Time `json:"started_at"`
+	LastUpdated time.Time `json:"last_updated"`
+}
+
+// ContextManifest tracks discovered context across iterations
+type ContextManifest struct {
+	// Task information from PROMPT.md
+	Task TaskInfo `json:"task"`
+
+	// Codebase information
+	Codebase CodebaseInfo `json:"codebase"`
+
+	// Discoveries made during exploration
+	Discoveries []Discovery `json:"discoveries"`
+
+	// Current focus - files/functions being worked on
+	Focus FocusSet `json:"focus"`
+
+	// Last updated timestamp
+	LastUpdated time.Time `json:"last_updated"`
+}
+
+// TaskInfo contains parsed task information
+type TaskInfo struct {
+	Summary     string   `json:"summary"`
+	Objectives  []string `json:"objectives"`
+	Constraints []string `json:"constraints"`
+}
+
+// CodebaseInfo contains discovered codebase structure
+type CodebaseInfo struct {
+	RootDir     string   `json:"root_dir"`
+	Language    string   `json:"language"`
+	BuildSystem string   `json:"build_system"`
+	KeyFiles    []string `json:"key_files"`
+	Patterns    []string `json:"patterns"`
+}
+
+// Discovery represents a finding during exploration
+type Discovery struct {
+	Iteration   int       `json:"iteration"`
+	Phase       Phase     `json:"phase"`
+	Type        string    `json:"type"` // file, function, pattern, dependency
+	Path        string    `json:"path"`
+	Description string    `json:"description"`
+	Relevance   string    `json:"relevance"` // high, medium, low
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+// FocusSet represents the current working context
+type FocusSet struct {
+	Files     []string `json:"files"`
+	Functions []string `json:"functions"`
+	Tests     []string `json:"tests"`
+}
+
+// HistoryEntry represents a single conversation entry in history
+type HistoryEntry struct {
+	Iteration int       `json:"iteration"`
+	Role      string    `json:"role"` // system, assistant, user
+	Content   string    `json:"content"`
+	Phase     Phase     `json:"phase"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// SearchQuery represents a recorded search operation
+type SearchQuery struct {
+	Iteration int       `json:"iteration"`
+	Query     string    `json:"query"`
+	Type      string    `json:"type"` // grep, glob, semantic
+	Results   []string  `json:"results"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// SearchResults aggregates search results for the session
+type SearchResults struct {
+	Queries []SearchQuery `json:"queries"`
+}
+
+// NarrowedSet represents a subset of context for focused work
+type NarrowedSet struct {
+	Iteration   int       `json:"iteration"`
+	Description string    `json:"description"`
+	Files       []string  `json:"files"`
+	Functions   []string  `json:"functions"`
+	Rationale   string    `json:"rationale"`
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+// VerificationReport contains the results of verification checks
+type VerificationReport struct {
+	Iteration int                 `json:"iteration"`
+	Passed    bool                `json:"passed"`
+	Checks    []VerificationCheck `json:"checks"`
+	Timestamp time.Time           `json:"timestamp"`
+}
+
+// VerificationCheck represents a single verification check
+type VerificationCheck struct {
+	Name    string `json:"name"`
+	Command string `json:"command"`
+	Passed  bool   `json:"passed"`
+	Output  string `json:"output"`
+	Error   string `json:"error,omitempty"`
+}
+
+// RLM marker patterns for output detection
+const (
+	// RLMPhaseMarkerStart is the start of a phase marker
+	RLMPhaseMarkerStart = "<rlm:phase>"
+	// RLMPhaseMarkerEnd is the end of a phase marker
+	RLMPhaseMarkerEnd = "</rlm:phase>"
+	// RLMVerifiedMarkerStart is the start of a verified marker
+	RLMVerifiedMarkerStart = "<rlm:verified>"
+	// RLMVerifiedMarkerEnd is the end of a verified marker
+	RLMVerifiedMarkerEnd = "</rlm:verified>"
+	// StateDir is the directory for RLM state files
+	StateDir = ".ralph/state"
+)

--- a/internal/loop/state.go
+++ b/internal/loop/state.go
@@ -1,0 +1,357 @@
+package loop
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// StateManager handles RLM state persistence
+type StateManager struct {
+	baseDir string
+}
+
+// NewStateManager creates a new StateManager
+func NewStateManager(baseDir string) *StateManager {
+	return &StateManager{baseDir: baseDir}
+}
+
+// InitSession initializes a new RLM session, cleaning up any previous state
+func (sm *StateManager) InitSession() (*SessionState, error) {
+	// Clean up previous state
+	if err := os.RemoveAll(sm.baseDir); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to clean previous state: %w", err)
+	}
+
+	// Create state directories
+	dirs := []string{
+		sm.baseDir,
+		filepath.Join(sm.baseDir, "search"),
+		filepath.Join(sm.baseDir, "narrow"),
+		filepath.Join(sm.baseDir, "results"),
+		filepath.Join(sm.baseDir, "verification"),
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create state directory %s: %w", dir, err)
+		}
+	}
+
+	// Create initial session state
+	now := time.Now()
+	state := &SessionState{
+		SessionID:   uuid.New().String(),
+		Iteration:   0,
+		Depth:       0,
+		Phase:       PhasePlan,
+		StartedAt:   now,
+		LastUpdated: now,
+	}
+
+	if err := sm.SaveSession(state); err != nil {
+		return nil, err
+	}
+
+	// Create initial context manifest
+	context := &ContextManifest{
+		Task:        TaskInfo{},
+		Codebase:    CodebaseInfo{},
+		Discoveries: []Discovery{},
+		Focus:       FocusSet{},
+		LastUpdated: now,
+	}
+	if err := sm.saveContext(context); err != nil {
+		return nil, err
+	}
+
+	return state, nil
+}
+
+// LoadSession loads the current session state
+func (sm *StateManager) LoadSession() (*SessionState, error) {
+	path := filepath.Join(sm.baseDir, "session.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session state: %w", err)
+	}
+
+	var state SessionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to parse session state: %w", err)
+	}
+
+	return &state, nil
+}
+
+// SaveSession saves the session state
+func (sm *StateManager) SaveSession(state *SessionState) error {
+	state.LastUpdated = time.Now()
+	path := filepath.Join(sm.baseDir, "session.json")
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal session state: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write session state: %w", err)
+	}
+
+	return nil
+}
+
+// GetContext loads the context manifest
+func (sm *StateManager) GetContext() (*ContextManifest, error) {
+	path := filepath.Join(sm.baseDir, "context.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read context manifest: %w", err)
+	}
+
+	var context ContextManifest
+	if err := json.Unmarshal(data, &context); err != nil {
+		return nil, fmt.Errorf("failed to parse context manifest: %w", err)
+	}
+
+	return &context, nil
+}
+
+// UpdateContext updates the context manifest
+func (sm *StateManager) UpdateContext(context *ContextManifest) error {
+	return sm.saveContext(context)
+}
+
+func (sm *StateManager) saveContext(context *ContextManifest) error {
+	context.LastUpdated = time.Now()
+	path := filepath.Join(sm.baseDir, "context.json")
+
+	data, err := json.MarshalIndent(context, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal context manifest: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write context manifest: %w", err)
+	}
+
+	return nil
+}
+
+// AppendHistory appends a history entry to the history file
+func (sm *StateManager) AppendHistory(entry HistoryEntry) error {
+	entry.Timestamp = time.Now()
+	path := filepath.Join(sm.baseDir, "history.jsonl")
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open history file: %w", err)
+	}
+	defer f.Close()
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal history entry: %w", err)
+	}
+
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("failed to write history entry: %w", err)
+	}
+
+	return nil
+}
+
+// GetHistory reads all history entries
+func (sm *StateManager) GetHistory() ([]HistoryEntry, error) {
+	path := filepath.Join(sm.baseDir, "history.jsonl")
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []HistoryEntry{}, nil
+		}
+		return nil, fmt.Errorf("failed to open history file: %w", err)
+	}
+	defer f.Close()
+
+	var entries []HistoryEntry
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var entry HistoryEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue // Skip malformed entries
+		}
+		entries = append(entries, entry)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read history file: %w", err)
+	}
+
+	return entries, nil
+}
+
+// GetRecentHistory returns the last n history entries
+func (sm *StateManager) GetRecentHistory(n int) ([]HistoryEntry, error) {
+	entries, err := sm.GetHistory()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(entries) <= n {
+		return entries, nil
+	}
+	return entries[len(entries)-n:], nil
+}
+
+// StoreSearchResult stores a search query and its results
+func (sm *StateManager) StoreSearchResult(query SearchQuery) error {
+	query.Timestamp = time.Now()
+	filename := fmt.Sprintf("search_%d_%d.json", query.Iteration, time.Now().UnixMilli())
+	path := filepath.Join(sm.baseDir, "search", filename)
+
+	data, err := json.MarshalIndent(query, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal search result: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write search result: %w", err)
+	}
+
+	return nil
+}
+
+// StoreNarrowedSet stores a narrowed context set
+func (sm *StateManager) StoreNarrowedSet(set NarrowedSet) error {
+	set.Timestamp = time.Now()
+	filename := fmt.Sprintf("narrow_%d_%d.json", set.Iteration, time.Now().UnixMilli())
+	path := filepath.Join(sm.baseDir, "narrow", filename)
+
+	data, err := json.MarshalIndent(set, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal narrowed set: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write narrowed set: %w", err)
+	}
+
+	return nil
+}
+
+// StoreResult stores an intermediate computation result
+func (sm *StateManager) StoreResult(name string, data any) error {
+	filename := fmt.Sprintf("%s_%d.json", name, time.Now().UnixMilli())
+	path := filepath.Join(sm.baseDir, "results", filename)
+
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	if err := os.WriteFile(path, jsonData, 0644); err != nil {
+		return fmt.Errorf("failed to write result: %w", err)
+	}
+
+	return nil
+}
+
+// StoreVerification stores a verification report
+func (sm *StateManager) StoreVerification(report VerificationReport) error {
+	report.Timestamp = time.Now()
+	filename := fmt.Sprintf("verify_%d_%d.json", report.Iteration, time.Now().UnixMilli())
+	path := filepath.Join(sm.baseDir, "verification", filename)
+
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal verification report: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write verification report: %w", err)
+	}
+
+	return nil
+}
+
+// GetLatestVerification returns the most recent verification report
+func (sm *StateManager) GetLatestVerification() (*VerificationReport, error) {
+	dir := filepath.Join(sm.baseDir, "verification")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read verification directory: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	// Find most recent file (files are timestamped, so last alphabetically is most recent)
+	var latest string
+	for _, entry := range entries {
+		if !entry.IsDir() && entry.Name() > latest {
+			latest = entry.Name()
+		}
+	}
+
+	if latest == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, latest))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read verification report: %w", err)
+	}
+
+	var report VerificationReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("failed to parse verification report: %w", err)
+	}
+
+	return &report, nil
+}
+
+// AddDiscovery adds a discovery to the context manifest
+func (sm *StateManager) AddDiscovery(discovery Discovery) error {
+	context, err := sm.GetContext()
+	if err != nil {
+		return err
+	}
+
+	discovery.Timestamp = time.Now()
+	context.Discoveries = append(context.Discoveries, discovery)
+
+	return sm.UpdateContext(context)
+}
+
+// UpdateFocus updates the focus set in the context manifest
+func (sm *StateManager) UpdateFocus(focus FocusSet) error {
+	context, err := sm.GetContext()
+	if err != nil {
+		return err
+	}
+
+	context.Focus = focus
+	return sm.UpdateContext(context)
+}
+
+// UpdateIteration increments the iteration counter and optionally changes phase
+func (sm *StateManager) UpdateIteration(phase Phase) error {
+	state, err := sm.LoadSession()
+	if err != nil {
+		return err
+	}
+
+	state.Iteration++
+	state.Phase = phase
+
+	return sm.SaveSession(state)
+}

--- a/internal/loop/types.go
+++ b/internal/loop/types.go
@@ -19,12 +19,15 @@ const (
 
 // Config holds the loop configuration
 type Config struct {
-	PromptFile    string
-	PlanFile      string // Session-scoped plan file path
-	MaxIterations int
-	NoPush        bool
-	Agent         AgentProvider
-	Output        io.Writer
+	PromptFile     string
+	PlanFile       string // Session-scoped plan file path
+	MaxIterations  int
+	NoPush         bool
+	Agent          AgentProvider
+	Output         io.Writer
+	RLM            RLMConfig // RLM mode configuration
+	VerifyEnabled  bool      // Run verification before commit
+	VerifyCommands []string  // Custom verification commands (auto-detected if empty)
 }
 
 // GeneratePlanPath returns a timestamped path for a new session-scoped plan file.
@@ -80,6 +83,8 @@ type ResultMessage struct {
 	Usage           Usage   `json:"usage"`
 	HasCost         bool    `json:"-"` // Internal field: true if provider supplies cost data
 	SessionComplete bool    `json:"-"` // Internal: true if agent emitted completion promise
+	RLMPhase        Phase   `json:"-"` // Internal: detected phase from RLM markers
+	RLMVerified     bool    `json:"-"` // Internal: true if agent emitted verified marker
 }
 
 // Usage represents token usage statistics

--- a/internal/loop/verify.go
+++ b/internal/loop/verify.go
@@ -1,0 +1,173 @@
+package loop
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Verifier runs verification commands before commit
+type Verifier struct {
+	commands []string
+}
+
+// NewVerifier creates a new Verifier with the specified commands
+// If commands is empty, it will auto-detect project type
+func NewVerifier(commands []string) *Verifier {
+	if len(commands) == 0 {
+		commands = DetectProjectType()
+	}
+	return &Verifier{commands: commands}
+}
+
+// Run executes all verification commands and returns a report
+func (v *Verifier) Run(iteration int) VerificationReport {
+	report := VerificationReport{
+		Iteration: iteration,
+		Passed:    true,
+		Checks:    make([]VerificationCheck, 0, len(v.commands)),
+		Timestamp: time.Now(),
+	}
+
+	for _, cmd := range v.commands {
+		check := v.runCheck(cmd)
+		report.Checks = append(report.Checks, check)
+		if !check.Passed {
+			report.Passed = false
+		}
+	}
+
+	return report
+}
+
+// runCheck executes a single verification command
+func (v *Verifier) runCheck(cmdStr string) VerificationCheck {
+	check := VerificationCheck{
+		Name:    cmdStr,
+		Command: cmdStr,
+	}
+
+	// Parse command - simple split on spaces
+	parts := strings.Fields(cmdStr)
+	if len(parts) == 0 {
+		check.Error = "empty command"
+		return check
+	}
+
+	cmd := exec.Command(parts[0], parts[1:]...)
+
+	// Capture output
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	check.Output = stdout.String()
+	if stderr.Len() > 0 {
+		if check.Output != "" {
+			check.Output += "\n"
+		}
+		check.Output += stderr.String()
+	}
+
+	if err != nil {
+		check.Passed = false
+		check.Error = err.Error()
+	} else {
+		check.Passed = true
+	}
+
+	return check
+}
+
+// HasCommands returns true if the verifier has commands to run
+func (v *Verifier) HasCommands() bool {
+	return len(v.commands) > 0
+}
+
+// DetectProjectType analyzes the current directory and returns appropriate verification commands
+func DetectProjectType() []string {
+	// Check for Go project
+	if _, err := os.Stat("go.mod"); err == nil {
+		return []string{
+			"go build ./...",
+			"go test ./...",
+		}
+	}
+
+	// Check for Node.js project
+	if _, err := os.Stat("package.json"); err == nil {
+		commands := []string{}
+		// Check if build script exists
+		if hasPkgScript("build") {
+			commands = append(commands, "npm run build")
+		}
+		// Check if test script exists
+		if hasPkgScript("test") {
+			commands = append(commands, "npm test")
+		}
+		if len(commands) > 0 {
+			return commands
+		}
+	}
+
+	// Check for Rust project
+	if _, err := os.Stat("Cargo.toml"); err == nil {
+		return []string{
+			"cargo build",
+			"cargo test",
+		}
+	}
+
+	// Check for Python project
+	if _, err := os.Stat("pyproject.toml"); err == nil {
+		return []string{"pytest"}
+	}
+	if _, err := os.Stat("setup.py"); err == nil {
+		return []string{"pytest"}
+	}
+
+	// Check for Makefile
+	if _, err := os.Stat("Makefile"); err == nil {
+		// Check for common targets
+		if hasMakeTarget("test") {
+			return []string{"make test"}
+		}
+		if hasMakeTarget("check") {
+			return []string{"make check"}
+		}
+	}
+
+	// No recognized project type
+	return nil
+}
+
+// hasPkgScript checks if package.json contains a specific script
+func hasPkgScript(script string) bool {
+	data, err := os.ReadFile("package.json")
+	if err != nil {
+		return false
+	}
+	// Simple check - look for "script": in the JSON
+	searchStr := fmt.Sprintf(`"%s":`, script)
+	return bytes.Contains(data, []byte(searchStr))
+}
+
+// hasMakeTarget checks if Makefile contains a specific target
+func hasMakeTarget(target string) bool {
+	data, err := os.ReadFile("Makefile")
+	if err != nil {
+		return false
+	}
+	// Look for target: at the start of a line
+	searchStr := target + ":"
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if bytes.HasPrefix(bytes.TrimSpace(line), []byte(searchStr)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pageindex/doc.go
+++ b/internal/pageindex/doc.go
@@ -1,0 +1,58 @@
+// Package pageindex implements a vectorless, reasoning-based RAG (Retrieval
+// Augmented Generation) framework for building tree-structured indexes from
+// documents.
+//
+// This is a Go port of the PageIndex Python framework:
+// https://github.com/VectifyAI/PageIndex
+//
+// # Overview
+//
+// PageIndex uses LLM reasoning to traverse document structures instead of
+// vector similarity search. It builds hierarchical tree indexes from PDFs
+// and Markdown files, enabling efficient document navigation and retrieval.
+//
+// # Key Concepts
+//
+//   - Tree-structured indexes: Documents are parsed into hierarchical trees
+//     where each node represents a section with title, content, and children.
+//
+//   - TOC detection: For PDFs, the system detects table of contents pages and
+//     uses them to build the document structure.
+//
+//   - Structure indices: Nodes are assigned hierarchical structure codes like
+//     "1.2.3" that define parent-child relationships.
+//
+//   - LLM verification: Section boundaries are verified using LLM calls to
+//     check if titles appear on specified pages.
+//
+// # Usage
+//
+// For Markdown files:
+//
+//	cfg := pageindex.DefaultConfig()
+//	doc, err := pageindex.MDToTree(ctx, "document.md", cfg, llmProvider)
+//
+// For PDFs (to be implemented):
+//
+//	doc, err := pageindex.PDFToTree(ctx, "document.pdf", cfg, llmProvider)
+//
+// # Architecture
+//
+// The package is organized into several components:
+//
+//   - types.go: Core data types (TreeNode, TOCItem, Config)
+//   - llm.go: LLM provider interface and OpenAI implementation
+//   - tree.go: Tree building from flat TOC lists
+//   - markdown.go: Markdown file processing
+//   - tokens.go: Token counting utilities
+//
+// # Python Reference
+//
+// This implementation is based on the PageIndex Python framework. Key mappings:
+//
+//   - page_index.py:tree_parser → tree.PostProcessTOC
+//   - page_index.py:meta_processor → (planned for PDF support)
+//   - page_index_md.py:md_to_tree → markdown.MDToTree
+//   - utils.py:list_to_tree → tree.ListToTree
+//   - utils.py:build_tree_from_nodes → tree.BuildTreeFromNodes
+package pageindex

--- a/internal/pageindex/llm.go
+++ b/internal/pageindex/llm.go
@@ -1,0 +1,304 @@
+package pageindex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// LLMProvider defines the interface for LLM interactions.
+type LLMProvider interface {
+	// Complete sends a prompt and returns the response text.
+	Complete(ctx context.Context, prompt string) (string, error)
+
+	// CompleteWithHistory sends a prompt with conversation history.
+	CompleteWithHistory(ctx context.Context, messages []Message) (string, error)
+
+	// Model returns the model identifier being used.
+	Model() string
+}
+
+// Message represents a chat message for conversation history.
+type Message struct {
+	Role    string `json:"role"`    // "user", "assistant", or "system"
+	Content string `json:"content"` // Message content
+}
+
+// OpenAIProvider implements LLMProvider using OpenAI's API.
+type OpenAIProvider struct {
+	apiKey     string
+	model      string
+	httpClient *http.Client
+	maxRetries int
+}
+
+// OpenAIRequest represents the request body for OpenAI's chat completions API.
+type OpenAIRequest struct {
+	Model       string          `json:"model"`
+	Messages    []OpenAIMessage `json:"messages"`
+	Temperature float64         `json:"temperature"`
+}
+
+// OpenAIMessage represents a message in the OpenAI format.
+type OpenAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// OpenAIResponse represents the response from OpenAI's chat completions API.
+type OpenAIResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index        int           `json:"index"`
+		Message      OpenAIMessage `json:"message"`
+		FinishReason string        `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+	Error *OpenAIError `json:"error,omitempty"`
+}
+
+// OpenAIError represents an error response from OpenAI.
+type OpenAIError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code"`
+}
+
+// NewOpenAIProvider creates a new OpenAI provider.
+func NewOpenAIProvider(model string) (*OpenAIProvider, error) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		apiKey = os.Getenv("CHATGPT_API_KEY")
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("OPENAI_API_KEY or CHATGPT_API_KEY environment variable not set")
+	}
+	return &OpenAIProvider{
+		apiKey:     apiKey,
+		model:      model,
+		httpClient: &http.Client{Timeout: 120 * time.Second},
+		maxRetries: 10,
+	}, nil
+}
+
+// Model returns the model identifier.
+func (p *OpenAIProvider) Model() string {
+	return p.model
+}
+
+// Complete sends a prompt and returns the response.
+func (p *OpenAIProvider) Complete(ctx context.Context, prompt string) (string, error) {
+	return p.CompleteWithHistory(ctx, []Message{{Role: "user", Content: prompt}})
+}
+
+// CompleteWithHistory sends a prompt with conversation history.
+func (p *OpenAIProvider) CompleteWithHistory(ctx context.Context, messages []Message) (string, error) {
+	// Convert to OpenAI format
+	oaiMessages := make([]OpenAIMessage, len(messages))
+	for i, m := range messages {
+		oaiMessages[i] = OpenAIMessage{Role: m.Role, Content: m.Content}
+	}
+
+	req := OpenAIRequest{
+		Model:       p.model,
+		Messages:    oaiMessages,
+		Temperature: 0,
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < p.maxRetries; attempt++ {
+		body, err := json.Marshal(req)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal request: %w", err)
+		}
+
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return "", fmt.Errorf("failed to create request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+		resp, err := p.httpClient.Do(httpReq)
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Second)
+			continue
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Second)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+			time.Sleep(time.Second)
+			continue
+		}
+
+		var oaiResp OpenAIResponse
+		if err := json.Unmarshal(respBody, &oaiResp); err != nil {
+			lastErr = fmt.Errorf("failed to parse response: %w", err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		if oaiResp.Error != nil {
+			lastErr = fmt.Errorf("API error: %s", oaiResp.Error.Message)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		if len(oaiResp.Choices) == 0 {
+			lastErr = fmt.Errorf("no choices in response")
+			time.Sleep(time.Second)
+			continue
+		}
+
+		return oaiResp.Choices[0].Message.Content, nil
+	}
+
+	return "", fmt.Errorf("max retries exceeded: %w", lastErr)
+}
+
+// CompleteWithFinishReason sends a prompt and returns both response and finish reason.
+func (p *OpenAIProvider) CompleteWithFinishReason(ctx context.Context, prompt string, history []Message) (string, string, error) {
+	messages := append(history, Message{Role: "user", Content: prompt})
+	oaiMessages := make([]OpenAIMessage, len(messages))
+	for i, m := range messages {
+		oaiMessages[i] = OpenAIMessage{Role: m.Role, Content: m.Content}
+	}
+
+	req := OpenAIRequest{
+		Model:       p.model,
+		Messages:    oaiMessages,
+		Temperature: 0,
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < p.maxRetries; attempt++ {
+		body, err := json.Marshal(req)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to marshal request: %w", err)
+		}
+
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return "", "", fmt.Errorf("failed to create request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+		resp, err := p.httpClient.Do(httpReq)
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Second)
+			continue
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Second)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+			time.Sleep(time.Second)
+			continue
+		}
+
+		var oaiResp OpenAIResponse
+		if err := json.Unmarshal(respBody, &oaiResp); err != nil {
+			lastErr = fmt.Errorf("failed to parse response: %w", err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		if oaiResp.Error != nil {
+			lastErr = fmt.Errorf("API error: %s", oaiResp.Error.Message)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		if len(oaiResp.Choices) == 0 {
+			lastErr = fmt.Errorf("no choices in response")
+			time.Sleep(time.Second)
+			continue
+		}
+
+		finishReason := oaiResp.Choices[0].FinishReason
+		if finishReason == "length" {
+			finishReason = "max_output_reached"
+		} else {
+			finishReason = "finished"
+		}
+
+		return oaiResp.Choices[0].Message.Content, finishReason, nil
+	}
+
+	return "", "", fmt.Errorf("max retries exceeded: %w", lastErr)
+}
+
+// ExtractJSON extracts and parses JSON from an LLM response.
+// It handles responses wrapped in ```json ... ``` blocks.
+func ExtractJSON[T any](content string) (T, error) {
+	var result T
+
+	// Try to extract from code block
+	content = strings.TrimSpace(content)
+	if startIdx := strings.Index(content, "```json"); startIdx != -1 {
+		startIdx += 7
+		if endIdx := strings.LastIndex(content, "```"); endIdx > startIdx {
+			content = content[startIdx:endIdx]
+		}
+	} else if startIdx := strings.Index(content, "```"); startIdx != -1 {
+		startIdx += 3
+		if endIdx := strings.LastIndex(content[startIdx:], "```"); endIdx != -1 {
+			content = content[startIdx : startIdx+endIdx]
+		}
+	}
+
+	// Clean up common issues
+	content = strings.TrimSpace(content)
+	content = strings.ReplaceAll(content, "None", "null")
+
+	// First attempt
+	if err := json.Unmarshal([]byte(content), &result); err != nil {
+		// Try fixing trailing commas
+		content = strings.ReplaceAll(content, ",]", "]")
+		content = strings.ReplaceAll(content, ",}", "}")
+		if err := json.Unmarshal([]byte(content), &result); err != nil {
+			return result, fmt.Errorf("failed to parse JSON: %w (content: %s)", err, truncate(content, 200))
+		}
+	}
+
+	return result, nil
+}
+
+// truncate shortens a string to maxLen, adding "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/pageindex/markdown.go
+++ b/internal/pageindex/markdown.go
@@ -1,0 +1,428 @@
+package pageindex
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// MarkdownNode represents a node extracted from markdown headers.
+type MarkdownNode struct {
+	Title    string
+	Level    int
+	LineNum  int
+	Text     string
+	TokenCnt int
+}
+
+var (
+	headerPattern    = regexp.MustCompile(`^(#{1,6})\s+(.+)$`)
+	codeBlockPattern = regexp.MustCompile(`^\x60\x60\x60`)
+)
+
+// ExtractNodesFromMarkdown parses a markdown file and extracts header nodes.
+func ExtractNodesFromMarkdown(content string) ([]MarkdownNode, []string) {
+	lines := strings.Split(content, "\n")
+	var nodes []MarkdownNode
+	inCodeBlock := false
+
+	for lineNum, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Check for code block delimiters
+		if codeBlockPattern.MatchString(trimmed) {
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+
+		// Skip if in code block or empty
+		if inCodeBlock || trimmed == "" {
+			continue
+		}
+
+		// Check for header
+		if matches := headerPattern.FindStringSubmatch(trimmed); matches != nil {
+			nodes = append(nodes, MarkdownNode{
+				Title:   strings.TrimSpace(matches[2]),
+				Level:   len(matches[1]), // Number of # characters
+				LineNum: lineNum + 1,     // 1-indexed
+			})
+		}
+	}
+
+	return nodes, lines
+}
+
+// ExtractNodeTextContent populates the Text field for each node.
+// Text includes everything from the header line until the next header.
+func ExtractNodeTextContent(nodes []MarkdownNode, lines []string) []MarkdownNode {
+	result := make([]MarkdownNode, len(nodes))
+	copy(result, nodes)
+
+	for i := range result {
+		startLine := result[i].LineNum - 1 // 0-indexed
+
+		var endLine int
+		if i+1 < len(result) {
+			endLine = result[i+1].LineNum - 1
+		} else {
+			endLine = len(lines)
+		}
+
+		// Join lines for this section
+		result[i].Text = strings.TrimSpace(strings.Join(lines[startLine:endLine], "\n"))
+	}
+
+	return result
+}
+
+// TreeThinning merges nodes that are below the minimum token threshold.
+// Small children are absorbed into their parent.
+func TreeThinning(nodes []MarkdownNode, minTokenThreshold int, tokenCounter func(string) int) []MarkdownNode {
+	// First, calculate cumulative token counts (including children)
+	nodes = updateNodeTokenCounts(nodes, tokenCounter)
+
+	// Set of indices to remove (absorbed into parent)
+	toRemove := make(map[int]bool)
+
+	// Process from end to start so children are processed before parents
+	for i := len(nodes) - 1; i >= 0; i-- {
+		if toRemove[i] {
+			continue
+		}
+
+		node := nodes[i]
+		if node.TokenCnt < minTokenThreshold {
+			// Find all children of this node
+			childIndices := findAllChildren(nodes, i)
+
+			// Collect and merge children text
+			var childTexts []string
+			for _, idx := range childIndices {
+				if !toRemove[idx] && strings.TrimSpace(nodes[idx].Text) != "" {
+					childTexts = append(childTexts, nodes[idx].Text)
+					toRemove[idx] = true
+				}
+			}
+
+			// Merge into parent
+			if len(childTexts) > 0 {
+				merged := nodes[i].Text
+				for _, ct := range childTexts {
+					if merged != "" && !strings.HasSuffix(merged, "\n") {
+						merged += "\n\n"
+					}
+					merged += ct
+				}
+				nodes[i].Text = merged
+				nodes[i].TokenCnt = tokenCounter(merged)
+			}
+		}
+	}
+
+	// Build result excluding removed nodes
+	var result []MarkdownNode
+	for i, node := range nodes {
+		if !toRemove[i] {
+			result = append(result, node)
+		}
+	}
+
+	return result
+}
+
+// updateNodeTokenCounts calculates token counts including children.
+func updateNodeTokenCounts(nodes []MarkdownNode, tokenCounter func(string) int) []MarkdownNode {
+	result := make([]MarkdownNode, len(nodes))
+	copy(result, nodes)
+
+	// Process from end to start
+	for i := len(result) - 1; i >= 0; i-- {
+		childIndices := findAllChildren(nodes, i)
+
+		// Combine own text with children
+		totalText := result[i].Text
+		for _, idx := range childIndices {
+			if result[idx].Text != "" {
+				totalText += "\n" + result[idx].Text
+			}
+		}
+
+		result[i].TokenCnt = tokenCounter(totalText)
+	}
+
+	return result
+}
+
+// findAllChildren finds all descendant nodes of the given parent index.
+func findAllChildren(nodes []MarkdownNode, parentIdx int) []int {
+	if parentIdx >= len(nodes) {
+		return nil
+	}
+
+	parentLevel := nodes[parentIdx].Level
+	var children []int
+
+	for i := parentIdx + 1; i < len(nodes); i++ {
+		if nodes[i].Level <= parentLevel {
+			break // Hit a node at same or higher level
+		}
+		children = append(children, i)
+	}
+
+	return children
+}
+
+// BuildMarkdownTree builds a tree from markdown nodes.
+func BuildMarkdownTree(nodes []MarkdownNode) []*TreeNode {
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	type stackEntry struct {
+		node  *TreeNode
+		level int
+	}
+
+	var stack []stackEntry
+	var rootNodes []*TreeNode
+	nodeCounter := 1
+
+	for _, n := range nodes {
+		treeNode := &TreeNode{
+			Title:   n.Title,
+			NodeID:  padNodeID(nodeCounter),
+			Text:    n.Text,
+			LineNum: n.LineNum,
+		}
+		nodeCounter++
+
+		// Pop stack until we find parent
+		for len(stack) > 0 && stack[len(stack)-1].level >= n.Level {
+			stack = stack[:len(stack)-1]
+		}
+
+		if len(stack) == 0 {
+			rootNodes = append(rootNodes, treeNode)
+		} else {
+			parent := stack[len(stack)-1].node
+			parent.Children = append(parent.Children, treeNode)
+		}
+
+		stack = append(stack, stackEntry{node: treeNode, level: n.Level})
+	}
+
+	return rootNodes
+}
+
+// MDToTree processes a markdown file and returns a tree structure.
+func MDToTree(ctx context.Context, mdPath string, cfg *Config, llm LLMProvider) (*Document, error) {
+	// Read file
+	content, err := os.ReadFile(mdPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract nodes
+	nodes, lines := ExtractNodesFromMarkdown(string(content))
+	nodes = ExtractNodeTextContent(nodes, lines)
+
+	// Optional tree thinning
+	if cfg.MinNodeToken > 0 {
+		tokenCounter := func(s string) int {
+			// Simple word-based approximation
+			return len(strings.Fields(s)) * 4 / 3 // ~1.33 tokens per word average
+		}
+		nodes = TreeThinning(nodes, cfg.MinNodeToken, tokenCounter)
+	}
+
+	// Build tree
+	tree := BuildMarkdownTree(nodes)
+
+	// Assign node IDs
+	if cfg.IfAddNodeID {
+		WriteNodeIDs(tree)
+	}
+
+	// Generate summaries if requested
+	if cfg.IfAddNodeSummary && llm != nil {
+		if err := generateSummariesForTree(ctx, tree, cfg, llm); err != nil {
+			return nil, err
+		}
+	}
+
+	// Generate document description if requested
+	var description string
+	if cfg.IfAddDocDescription && llm != nil {
+		var err error
+		description, err = generateDocDescription(ctx, tree, llm)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Remove text if not requested
+	if !cfg.IfAddNodeText {
+		removeTextFromTree(tree)
+	}
+
+	// Build document
+	docName := strings.TrimSuffix(filepath.Base(mdPath), filepath.Ext(mdPath))
+
+	return &Document{
+		Name:        docName,
+		Description: description,
+		Structure:   tree,
+	}, nil
+}
+
+// generateSummariesForTree generates summaries for all nodes in the tree.
+func generateSummariesForTree(ctx context.Context, nodes []*TreeNode, cfg *Config, llm LLMProvider) error {
+	allNodes := FlattenTree(nodes)
+
+	for _, node := range allNodes {
+		if node.Text == "" {
+			continue
+		}
+
+		// Simple token approximation
+		tokenCount := len(strings.Fields(node.Text)) * 4 / 3
+
+		if tokenCount < cfg.SummaryTokenThreshold {
+			// Use text as-is for small sections
+			if len(node.Children) == 0 {
+				node.Summary = node.Text
+			} else {
+				node.PrefixSum = node.Text
+			}
+		} else {
+			// Generate summary via LLM
+			summary, err := generateNodeSummary(ctx, node, llm)
+			if err != nil {
+				return err
+			}
+			if len(node.Children) == 0 {
+				node.Summary = summary
+			} else {
+				node.PrefixSum = summary
+			}
+		}
+	}
+
+	return nil
+}
+
+// generateNodeSummary generates a summary for a single node.
+func generateNodeSummary(ctx context.Context, node *TreeNode, llm LLMProvider) (string, error) {
+	prompt := `You are given a part of a document, your task is to generate a description of the partial document about what are main points covered in the partial document.
+
+Partial Document Text: ` + node.Text + `
+
+Directly return the description, do not include any other text.`
+
+	return llm.Complete(ctx, prompt)
+}
+
+// generateDocDescription generates a description for the entire document.
+func generateDocDescription(ctx context.Context, tree []*TreeNode, llm LLMProvider) (string, error) {
+	// Create clean structure for description (without text)
+	cleanTree := createCleanStructureForDescription(tree)
+
+	prompt := `Your are an expert in generating descriptions for a document.
+You are given a structure of a document. Your task is to generate a one-sentence description for the document, which makes it easy to distinguish the document from other documents.
+
+Document Structure: ` + structureToString(cleanTree) + `
+
+Directly return the description, do not include any other text.`
+
+	return llm.Complete(ctx, prompt)
+}
+
+// createCleanStructureForDescription creates a minimal structure for doc description.
+func createCleanStructureForDescription(nodes []*TreeNode) []*TreeNode {
+	var clean []*TreeNode
+	for _, node := range nodes {
+		cleanNode := &TreeNode{
+			Title:     node.Title,
+			NodeID:    node.NodeID,
+			Summary:   node.Summary,
+			PrefixSum: node.PrefixSum,
+		}
+		if len(node.Children) > 0 {
+			cleanNode.Children = createCleanStructureForDescription(node.Children)
+		}
+		clean = append(clean, cleanNode)
+	}
+	return clean
+}
+
+// structureToString converts a tree to a string representation.
+func structureToString(nodes []*TreeNode) string {
+	var sb strings.Builder
+	var write func([]*TreeNode, int)
+	write = func(children []*TreeNode, indent int) {
+		for _, node := range children {
+			sb.WriteString(strings.Repeat("  ", indent))
+			sb.WriteString("- ")
+			sb.WriteString(node.Title)
+			if node.Summary != "" {
+				sb.WriteString(": ")
+				sb.WriteString(truncate(node.Summary, 100))
+			}
+			sb.WriteString("\n")
+			if len(node.Children) > 0 {
+				write(node.Children, indent+1)
+			}
+		}
+	}
+	write(nodes, 0)
+	return sb.String()
+}
+
+// removeTextFromTree removes Text field from all nodes.
+func removeTextFromTree(nodes []*TreeNode) {
+	for _, node := range nodes {
+		node.Text = ""
+		if len(node.Children) > 0 {
+			removeTextFromTree(node.Children)
+		}
+	}
+}
+
+// ReadMarkdownFile reads a markdown file and returns its content.
+func ReadMarkdownFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	var sb strings.Builder
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		sb.WriteString(scanner.Text())
+		sb.WriteString("\n")
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
+}
+
+// PrintTOC prints a tree structure as an indented table of contents.
+func PrintTOC(nodes []*TreeNode, indent int) string {
+	var sb strings.Builder
+	for _, node := range nodes {
+		sb.WriteString(strings.Repeat("  ", indent))
+		sb.WriteString(node.Title)
+		sb.WriteString("\n")
+		if len(node.Children) > 0 {
+			sb.WriteString(PrintTOC(node.Children, indent+1))
+		}
+	}
+	return sb.String()
+}

--- a/internal/pageindex/pdf.go
+++ b/internal/pageindex/pdf.go
@@ -1,0 +1,542 @@
+package pageindex
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// PDFProcessor handles PDF document processing using PageIndex algorithms.
+type PDFProcessor struct {
+	llm      LLMProvider
+	config   *Config
+	detector *TOCDetector
+	verifier *Verifier
+}
+
+// NewPDFProcessor creates a new PDF processor with the given LLM provider.
+func NewPDFProcessor(llm LLMProvider, config *Config) *PDFProcessor {
+	if config == nil {
+		config = DefaultConfig()
+	}
+	return &PDFProcessor{
+		llm:      llm,
+		config:   config,
+		detector: NewTOCDetector(llm, config),
+		verifier: NewVerifier(llm, config),
+	}
+}
+
+// ProcessPDF processes a PDF file and returns a structured Document.
+// This is the main entry point for PDF processing.
+func (p *PDFProcessor) ProcessPDF(ctx context.Context, pdfPath string) (*Document, error) {
+	// Extract pages from PDF
+	pages, err := p.extractPages(pdfPath)
+	if err != nil {
+		return nil, fmt.Errorf("extracting pages: %w", err)
+	}
+
+	if len(pages) == 0 {
+		return nil, fmt.Errorf("no pages extracted from PDF")
+	}
+
+	// Detect TOC
+	tocResult, err := p.detector.DetectTOC(ctx, pages)
+	if err != nil {
+		return nil, fmt.Errorf("detecting TOC: %w", err)
+	}
+
+	// Determine processing mode
+	mode := DetermineProcessingMode(tocResult)
+
+	var tree []*TreeNode
+	switch mode {
+	case "toc_with_pages":
+		tree, err = p.processTOCWithPages(ctx, tocResult, pages)
+	case "toc_without_pages":
+		tree, err = p.processTOCWithoutPages(ctx, tocResult, pages)
+	case "no_toc":
+		tree, err = p.processNoTOC(ctx, pages)
+	default:
+		return nil, fmt.Errorf("unknown processing mode: %s", mode)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("processing with mode %s: %w", mode, err)
+	}
+
+	// Post-process tree
+	if p.config.IfAddNodeID {
+		WriteNodeIDs(tree)
+	}
+
+	// Add text to nodes if requested
+	if p.config.IfAddNodeText {
+		p.addNodeTexts(tree, pages)
+	}
+
+	// Generate summaries if requested
+	if p.config.IfAddNodeSummary {
+		if err := p.generateSummaries(ctx, tree); err != nil {
+			return nil, fmt.Errorf("generating summaries: %w", err)
+		}
+	}
+
+	// Generate document description if requested
+	var description string
+	if p.config.IfAddDocDescription {
+		description, err = generateDocDescription(ctx, tree, p.llm)
+		if err != nil {
+			return nil, fmt.Errorf("generating description: %w", err)
+		}
+	}
+
+	// Build document
+	docName := strings.TrimSuffix(filepath.Base(pdfPath), filepath.Ext(pdfPath))
+
+	return &Document{
+		Name:        docName,
+		Description: description,
+		Structure:   tree,
+	}, nil
+}
+
+// processTOCWithPages processes PDFs that have a TOC with page numbers.
+func (p *PDFProcessor) processTOCWithPages(ctx context.Context, tocResult *TOCCheckResult, pages []PageContent) ([]*TreeNode, error) {
+	// Transform TOC to structured format
+	items, err := p.detector.TransformTOC(ctx, tocResult.TOCContent)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map logical page numbers to physical indices
+	items = MapPageNumbersToPhysical(items, tocResult.TOCPageList, len(pages))
+
+	// Validate and truncate physical indices
+	items = ValidateAndTruncatePhysicalIndices(items, len(pages), 1)
+
+	// Add preface if document content starts before first TOC entry
+	items = AddPrefaceIfNeeded(items)
+
+	// Verify TOC entries against actual pages
+	report, err := p.verifier.VerifyTOCEntries(ctx, items, pages, 10)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine action based on verification
+	action := EvaluateVerification(report, nil)
+
+	switch action {
+	case "fix":
+		// Attempt to fix incorrect entries
+		items, _, err = p.verifier.FixIncorrectTOCWithRetries(ctx, items, pages, 3)
+		if err != nil {
+			return nil, err
+		}
+	case "fallback":
+		// TOC is too inaccurate, generate from scratch
+		return p.processNoTOC(ctx, pages)
+	}
+
+	// Check section starts
+	items, err = p.detector.CheckSectionStartsConcurrently(ctx, items, pages, 5)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to tree
+	return PostProcessTOC(items, len(pages)-1), nil
+}
+
+// processTOCWithoutPages processes PDFs that have a TOC but no page numbers.
+func (p *PDFProcessor) processTOCWithoutPages(ctx context.Context, tocResult *TOCCheckResult, pages []PageContent) ([]*TreeNode, error) {
+	// Transform TOC to structured format
+	items, err := p.detector.TransformTOC(ctx, tocResult.TOCContent)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find each section in the document
+	items, err = p.findSectionPages(ctx, items, pages)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check section starts
+	items, err = p.detector.CheckSectionStartsConcurrently(ctx, items, pages, 5)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to tree
+	return PostProcessTOC(items, len(pages)-1), nil
+}
+
+// processNoTOC processes PDFs that don't have an explicit TOC.
+func (p *PDFProcessor) processNoTOC(ctx context.Context, pages []PageContent) ([]*TreeNode, error) {
+	// Generate TOC from document structure
+	items, err := p.detector.GenerateTOC(ctx, pages)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(items) == 0 {
+		// Fallback: create single node for entire document
+		return []*TreeNode{{
+			Title:    "Document",
+			StartIdx: 0,
+			EndIdx:   len(pages) - 1,
+		}}, nil
+	}
+
+	// Check section starts
+	items, err = p.detector.CheckSectionStartsConcurrently(ctx, items, pages, 5)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to tree
+	return PostProcessTOC(items, len(pages)-1), nil
+}
+
+// findSectionPages searches for each section title in the document pages.
+func (p *PDFProcessor) findSectionPages(ctx context.Context, items []TOCItem, pages []PageContent) ([]TOCItem, error) {
+	result := make([]TOCItem, len(items))
+	copy(result, items)
+
+	// Search sequentially to maintain order
+	currentPage := 0
+	for i := range result {
+		title := result[i].Title
+
+		// Search from current position forward
+		found := false
+		for j := currentPage; j < len(pages) && !found; j++ {
+			if containsFuzzy(pages[j].Text, title) {
+				result[i].PhysicalIndex = &j
+				currentPage = j
+				found = true
+			}
+		}
+
+		if !found {
+			// Use LLM to find the section
+			pageNum, err := p.verifier.searchForEntry(ctx, title, pages, currentPage, 10)
+			if err == nil && pageNum >= 0 {
+				result[i].PhysicalIndex = &pageNum
+				if pageNum > currentPage {
+					currentPage = pageNum
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// addNodeTexts populates the Text field for all nodes based on page ranges.
+func (p *PDFProcessor) addNodeTexts(nodes []*TreeNode, pages []PageContent) {
+	for _, node := range FlattenTree(nodes) {
+		if node.StartIdx < 0 || node.EndIdx < node.StartIdx {
+			continue
+		}
+
+		start := node.StartIdx
+		end := node.EndIdx
+		if start >= len(pages) {
+			continue
+		}
+		if end >= len(pages) {
+			end = len(pages) - 1
+		}
+
+		var text strings.Builder
+		for i := start; i <= end; i++ {
+			if text.Len() > 0 {
+				text.WriteString("\n\n")
+			}
+			text.WriteString(pages[i].Text)
+		}
+
+		node.Text = text.String()
+	}
+}
+
+// generateSummaries generates summaries for all nodes using the LLM.
+func (p *PDFProcessor) generateSummaries(ctx context.Context, nodes []*TreeNode) error {
+	allNodes := FlattenTree(nodes)
+
+	for _, node := range allNodes {
+		if node.Text == "" {
+			continue
+		}
+
+		tokenCount := CountTokens(node.Text)
+
+		if tokenCount < p.config.SummaryTokenThreshold {
+			// Use text as-is for small sections
+			if len(node.Children) == 0 {
+				node.Summary = node.Text
+			} else {
+				node.PrefixSum = node.Text
+			}
+		} else {
+			// Generate summary via LLM
+			prompt := fmt.Sprintf(SummaryPrompt, node.Title, truncateForPrompt(node.Text, 4000))
+			summary, err := p.llm.Complete(ctx, prompt)
+			if err != nil {
+				return err
+			}
+			if len(node.Children) == 0 {
+				node.Summary = summary
+			} else {
+				node.PrefixSum = summary
+			}
+		}
+	}
+
+	return nil
+}
+
+// extractPages extracts text content from each page of a PDF.
+// Uses pdftotext (from poppler-utils) for extraction.
+func (p *PDFProcessor) extractPages(pdfPath string) ([]PageContent, error) {
+	// Check if pdftotext is available
+	if _, err := exec.LookPath("pdftotext"); err != nil {
+		return nil, fmt.Errorf("pdftotext not found: install poppler-utils (brew install poppler on macOS)")
+	}
+
+	// Get page count
+	pageCount, err := p.getPageCount(pdfPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract each page
+	pages := make([]PageContent, pageCount)
+	for i := 0; i < pageCount; i++ {
+		text, err := p.extractPage(pdfPath, i+1)
+		if err != nil {
+			return nil, fmt.Errorf("extracting page %d: %w", i+1, err)
+		}
+
+		pages[i] = PageContent{
+			Text:       text,
+			TokenCount: CountTokens(text),
+		}
+	}
+
+	return pages, nil
+}
+
+// getPageCount returns the number of pages in a PDF.
+func (p *PDFProcessor) getPageCount(pdfPath string) (int, error) {
+	// Use pdfinfo to get page count
+	cmd := exec.Command("pdfinfo", pdfPath)
+	output, err := cmd.Output()
+	if err != nil {
+		// Fallback: try pdftotext with a high page number
+		// This is less efficient but works if pdfinfo isn't available
+		return p.getPageCountFallback(pdfPath)
+	}
+
+	// Parse "Pages: N" from output
+	for _, line := range strings.Split(string(output), "\n") {
+		if strings.HasPrefix(line, "Pages:") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				count, err := strconv.Atoi(parts[1])
+				if err != nil {
+					continue
+				}
+				return count, nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("could not determine page count from pdfinfo")
+}
+
+// getPageCountFallback counts pages by extracting until failure.
+func (p *PDFProcessor) getPageCountFallback(pdfPath string) (int, error) {
+	// Binary search for page count
+	low, high := 1, 10000
+
+	for low < high {
+		mid := (low + high + 1) / 2
+
+		cmd := exec.Command("pdftotext", "-f", strconv.Itoa(mid), "-l", strconv.Itoa(mid), pdfPath, "-")
+		if err := cmd.Run(); err != nil {
+			high = mid - 1
+		} else {
+			low = mid
+		}
+	}
+
+	if low == 0 {
+		return 0, fmt.Errorf("could not determine page count")
+	}
+
+	return low, nil
+}
+
+// extractPage extracts text from a single page of a PDF.
+func (p *PDFProcessor) extractPage(pdfPath string, pageNum int) (string, error) {
+	cmd := exec.Command("pdftotext", "-f", strconv.Itoa(pageNum), "-l", strconv.Itoa(pageNum), "-layout", pdfPath, "-")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
+
+// SplitLargeNodes recursively splits nodes that exceed size thresholds.
+func (p *PDFProcessor) SplitLargeNodes(ctx context.Context, nodes []*TreeNode, pages []PageContent) ([]*TreeNode, error) {
+	var result []*TreeNode
+
+	for _, node := range nodes {
+		// First process children
+		if len(node.Children) > 0 {
+			children, err := p.SplitLargeNodes(ctx, node.Children, pages)
+			if err != nil {
+				return nil, err
+			}
+			node.Children = children
+		}
+
+		// Check if node needs splitting
+		pageSpan := node.EndIdx - node.StartIdx + 1
+		tokenCount := 0
+		if node.Text != "" {
+			tokenCount = CountTokens(node.Text)
+		} else if node.StartIdx >= 0 && node.EndIdx >= node.StartIdx {
+			for i := node.StartIdx; i <= node.EndIdx && i < len(pages); i++ {
+				tokenCount += pages[i].TokenCount
+			}
+		}
+
+		needsSplit := pageSpan > p.config.MaxPageNumEachNode || tokenCount > p.config.MaxTokenNumEachNode
+
+		if needsSplit && len(node.Children) == 0 {
+			// Split this leaf node
+			children, err := p.splitNode(ctx, node, pages)
+			if err != nil {
+				// On error, keep the node as-is
+				result = append(result, node)
+			} else if len(children) > 0 {
+				node.Children = children
+				result = append(result, node)
+			} else {
+				result = append(result, node)
+			}
+		} else {
+			result = append(result, node)
+		}
+	}
+
+	return result, nil
+}
+
+// splitNode splits a large node into smaller child nodes.
+func (p *PDFProcessor) splitNode(ctx context.Context, node *TreeNode, pages []PageContent) ([]*TreeNode, error) {
+	// Gather text for this node
+	var text strings.Builder
+	for i := node.StartIdx; i <= node.EndIdx && i < len(pages); i++ {
+		text.WriteString(pages[i].Text)
+	}
+
+	if text.Len() == 0 {
+		return nil, nil
+	}
+
+	// Use LLM to suggest subsections
+	prompt := fmt.Sprintf(SplitNodePrompt, node.Title, truncateForPrompt(text.String(), 4000))
+
+	response, err := p.llm.Complete(ctx, prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	type splitResult struct {
+		Subsections []struct {
+			Title         string `json:"title"`
+			StartPosition int    `json:"start_position"`
+			EndPosition   int    `json:"end_position"`
+		} `json:"subsections"`
+	}
+
+	result, err := ExtractJSON[splitResult](response)
+	if err != nil {
+		// Fallback: split evenly by pages
+		return p.splitNodeByPages(node, pages), nil
+	}
+
+	if len(result.Subsections) == 0 {
+		return nil, nil
+	}
+
+	// Create child nodes
+	var children []*TreeNode
+	totalPages := node.EndIdx - node.StartIdx + 1
+
+	for i, sub := range result.Subsections {
+		// Map character positions to page numbers (approximate)
+		startRatio := float64(sub.StartPosition) / float64(text.Len())
+		endRatio := float64(sub.EndPosition) / float64(text.Len())
+
+		startPage := node.StartIdx + int(startRatio*float64(totalPages))
+		endPage := node.StartIdx + int(endRatio*float64(totalPages))
+
+		if startPage < node.StartIdx {
+			startPage = node.StartIdx
+		}
+		if endPage > node.EndIdx {
+			endPage = node.EndIdx
+		}
+		if i < len(result.Subsections)-1 && endPage >= result.Subsections[i+1].StartPosition {
+			// Avoid overlap
+			endPage = node.StartIdx + int(float64(result.Subsections[i+1].StartPosition)/float64(text.Len())*float64(totalPages)) - 1
+		}
+
+		children = append(children, &TreeNode{
+			Title:    sub.Title,
+			StartIdx: startPage,
+			EndIdx:   endPage,
+		})
+	}
+
+	return children, nil
+}
+
+// splitNodeByPages splits a node evenly by page count.
+func (p *PDFProcessor) splitNodeByPages(node *TreeNode, pages []PageContent) []*TreeNode {
+	totalPages := node.EndIdx - node.StartIdx + 1
+	if totalPages <= p.config.MaxPageNumEachNode {
+		return nil
+	}
+
+	numParts := (totalPages + p.config.MaxPageNumEachNode - 1) / p.config.MaxPageNumEachNode
+	pagesPerPart := totalPages / numParts
+
+	var children []*TreeNode
+	for i := 0; i < numParts; i++ {
+		startPage := node.StartIdx + i*pagesPerPart
+		endPage := startPage + pagesPerPart - 1
+		if i == numParts-1 {
+			endPage = node.EndIdx
+		}
+
+		children = append(children, &TreeNode{
+			Title:    fmt.Sprintf("%s (Part %d)", node.Title, i+1),
+			StartIdx: startPage,
+			EndIdx:   endPage,
+		})
+	}
+
+	return children
+}

--- a/internal/pageindex/pdf.go
+++ b/internal/pageindex/pdf.go
@@ -514,7 +514,7 @@ func (p *PDFProcessor) splitNode(ctx context.Context, node *TreeNode, pages []Pa
 }
 
 // splitNodeByPages splits a node evenly by page count.
-func (p *PDFProcessor) splitNodeByPages(node *TreeNode, pages []PageContent) []*TreeNode {
+func (p *PDFProcessor) splitNodeByPages(node *TreeNode, _ []PageContent) []*TreeNode {
 	totalPages := node.EndIdx - node.StartIdx + 1
 	if totalPages <= p.config.MaxPageNumEachNode {
 		return nil

--- a/internal/pageindex/prompts.go
+++ b/internal/pageindex/prompts.go
@@ -1,0 +1,219 @@
+package pageindex
+
+// LLM prompt templates for PageIndex operations.
+// These prompts are based on the Python PageIndex implementation.
+
+// TOCDetectorPrompt asks the LLM to determine if a page contains TOC content.
+const TOCDetectorPrompt = `You are an expert in analyzing document pages. You are given the text of a page in a PDF document. Your task is to determine whether this page contains a Table of Contents (TOC).
+
+A Table of Contents typically:
+- Contains a list of section/chapter titles
+- May include page numbers
+- Has a hierarchical structure (chapters, sections, subsections)
+- Appears near the beginning of a document
+
+Page Text:
+%s
+
+Respond in JSON format:
+{
+  "thinking": "<your reasoning>",
+  "toc_detected": "<yes or no>"
+}`
+
+// PageIndexGivenPrompt asks whether page numbers are included in the TOC.
+const PageIndexGivenPrompt = `You are an expert in analyzing document structure. You are given a Table of Contents from a PDF document. Your task is to determine whether page numbers are explicitly given in the Table of Contents.
+
+Table of Contents:
+%s
+
+Respond in JSON format:
+{
+  "thinking": "<your reasoning>",
+  "page_index_given_in_toc": "<yes or no>"
+}`
+
+// TOCTransformPrompt converts raw TOC text into structured JSON format.
+const TOCTransformPrompt = `You are an expert in parsing document structures. You are given a Table of Contents from a PDF document. Your task is to parse it into a structured JSON format.
+
+For each entry, extract:
+- structure: The hierarchical index (e.g., "1", "1.1", "1.2.3"). Use "0" for unnumbered items like "Preface"
+- title: The section title
+- page: The page number if given (as integer), or null if not present
+
+Table of Contents:
+%s
+
+Respond in JSON format:
+{
+  "table_of_contents": [
+    {"structure": "1", "title": "Introduction", "page": 5},
+    {"structure": "1.1", "title": "Background", "page": 7},
+    ...
+  ]
+}`
+
+// TOCTransformContinuePrompt asks the LLM to continue an incomplete TOC transformation.
+const TOCTransformContinuePrompt = `Continue parsing the Table of Contents from where you left off. Keep the same JSON format.`
+
+// VerifyTOCEntryPrompt asks the LLM to verify if a TOC entry appears on a page.
+const VerifyTOCEntryPrompt = `You are an expert in verifying document structure. You are given:
+1. A section title from a Table of Contents
+2. The text of a page where the section should appear
+
+Your task is to determine whether the section title appears on this page. The title may have slight variations in spacing or formatting.
+
+Section Title: %s
+Expected Page Number: %d
+
+Page Text:
+%s
+
+Respond in JSON format:
+{
+  "thinking": "<your reasoning>",
+  "answer": "<yes or no>"
+}`
+
+// VerifyBatchPrompt verifies multiple TOC entries at once.
+const VerifyBatchPrompt = `You are an expert in verifying document structure. You are given:
+1. A list of section titles from a Table of Contents
+2. A list of page texts
+
+Your task is to verify which sections appear on their expected pages. For each entry, check if the title (or a close variation) appears on the corresponding page.
+
+Entries to verify:
+%s
+
+Page Texts:
+%s
+
+Respond in JSON format:
+{
+  "results": [
+    {"list_index": 0, "answer": "yes", "title": "...", "page_number": 5},
+    {"list_index": 1, "answer": "no", "title": "...", "page_number": 10},
+    ...
+  ]
+}`
+
+// StartCheckPrompt determines if a section starts at the beginning of a page.
+const StartCheckPrompt = `You are an expert in analyzing document layout. You are given:
+1. A section title
+2. The text of a page
+
+Your task is to determine whether the section title appears at or near the BEGINNING of the page (first ~200 characters), indicating the section starts on this page.
+
+Section Title: %s
+
+Page Text (first 500 characters):
+%s
+
+Respond in JSON format:
+{
+  "thinking": "<your reasoning>",
+  "start_begin": "<yes or no>"
+}`
+
+// CompletionCheckPrompt determines if a TOC transformation is complete.
+const CompletionCheckPrompt = `You are given a partial JSON response that was parsing a Table of Contents. Determine if the parsing appears to be complete or if there are likely more entries to parse.
+
+Partial Response:
+%s
+
+Original TOC Content:
+%s
+
+Respond in JSON format:
+{
+  "thinking": "<your reasoning>",
+  "completed": "<yes or no>"
+}`
+
+// GenerateTOCPrompt generates a TOC when none exists in the document.
+const GenerateTOCPrompt = `You are an expert in analyzing document structure. You are given pages from a PDF document that does not have an explicit Table of Contents. Your task is to generate a Table of Contents based on the document's structure.
+
+Look for:
+- Chapter/section headers
+- Clear topic changes
+- Numbered sections
+- Bold or emphasized titles
+
+Document Pages:
+%s
+
+Generate a Table of Contents in JSON format:
+{
+  "table_of_contents": [
+    {"structure": "1", "title": "Introduction", "physical_index": 1},
+    {"structure": "1.1", "title": "Background", "physical_index": 3},
+    ...
+  ]
+}
+
+Use physical_index for the actual page number where each section begins.`
+
+// FixTOCPrompt asks the LLM to fix incorrect page numbers in a TOC.
+const FixTOCPrompt = `You are an expert in correcting document structure. You are given:
+1. A Table of Contents with some incorrect page numbers
+2. Verification results showing which entries are incorrect
+3. Page texts around the incorrect entries
+
+Your task is to fix the incorrect page numbers by searching for the correct pages where the sections actually appear.
+
+Current TOC:
+%s
+
+Incorrect Entries (list_index, expected_page):
+%s
+
+Page Texts (page_number: text):
+%s
+
+Respond with the corrected entries in JSON format:
+{
+  "corrections": [
+    {"list_index": 0, "corrected_page": 8, "thinking": "..."},
+    ...
+  ]
+}`
+
+// SplitNodePrompt generates child entries when splitting a large node.
+const SplitNodePrompt = `You are an expert in analyzing document structure. A section of a document is too large and needs to be split into smaller subsections. You are given the text of the section.
+
+Generate a list of subsections based on the content structure. Look for:
+- Topic changes
+- Natural paragraph groupings
+- Subheadings within the text
+- Logical content divisions
+
+Section Title: %s
+Section Text:
+%s
+
+Generate subsections in JSON format:
+{
+  "subsections": [
+    {"title": "Subsection Title", "start_position": 0, "end_position": 500},
+    ...
+  ]
+}
+
+Positions are character offsets within the section text.`
+
+// SummaryPrompt generates a summary for a document section.
+const SummaryPrompt = `You are an expert in summarizing documents. You are given a part of a document. Generate a concise summary that captures the main points.
+
+Section Title: %s
+Section Text:
+%s
+
+Generate a summary in 2-3 sentences that captures the key information. Respond with just the summary text, no JSON formatting.`
+
+// DocumentDescriptionPrompt generates a one-sentence description for the entire document.
+const DocumentDescriptionPrompt = `You are an expert in generating document descriptions. You are given the structure of a document. Generate a one-sentence description that distinguishes this document from others.
+
+Document Structure:
+%s
+
+Respond with just the description, no other text.`

--- a/internal/pageindex/toc.go
+++ b/internal/pageindex/toc.go
@@ -1,0 +1,354 @@
+package pageindex
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// TOCDetector handles detection and extraction of table of contents from documents.
+type TOCDetector struct {
+	llm    LLMProvider
+	config *Config
+}
+
+// NewTOCDetector creates a new TOC detector with the given LLM provider.
+func NewTOCDetector(llm LLMProvider, config *Config) *TOCDetector {
+	if config == nil {
+		config = DefaultConfig()
+	}
+	return &TOCDetector{llm: llm, config: config}
+}
+
+// DetectTOC scans the first N pages of a document to find the table of contents.
+// Returns the TOC content, list of page indices containing TOC, and whether page numbers are given.
+func (d *TOCDetector) DetectTOC(ctx context.Context, pages []PageContent) (*TOCCheckResult, error) {
+	checkLimit := d.config.TOCCheckPageNum
+	if checkLimit > len(pages) {
+		checkLimit = len(pages)
+	}
+
+	var tocPages []int
+	var tocContent strings.Builder
+
+	// Scan pages for TOC content
+	for i := 0; i < checkLimit; i++ {
+		isTOC, err := d.isPageTOC(ctx, pages[i].Text)
+		if err != nil {
+			return nil, fmt.Errorf("checking page %d for TOC: %w", i, err)
+		}
+
+		if isTOC {
+			tocPages = append(tocPages, i)
+			if tocContent.Len() > 0 {
+				tocContent.WriteString("\n")
+			}
+			tocContent.WriteString(pages[i].Text)
+		} else if len(tocPages) > 0 {
+			// Stop when we hit a non-TOC page after finding TOC
+			break
+		}
+	}
+
+	if len(tocPages) == 0 {
+		return &TOCCheckResult{
+			TOCContent:        "",
+			TOCPageList:       nil,
+			PageIndexGivenTOC: false,
+		}, nil
+	}
+
+	// Check if page numbers are given in TOC
+	pageIndexGiven, err := d.hasPageNumbers(ctx, tocContent.String())
+	if err != nil {
+		return nil, fmt.Errorf("checking for page numbers: %w", err)
+	}
+
+	return &TOCCheckResult{
+		TOCContent:        tocContent.String(),
+		TOCPageList:       tocPages,
+		PageIndexGivenTOC: pageIndexGiven,
+	}, nil
+}
+
+// isPageTOC uses the LLM to determine if a page contains TOC content.
+func (d *TOCDetector) isPageTOC(ctx context.Context, pageText string) (bool, error) {
+	prompt := fmt.Sprintf(TOCDetectorPrompt, truncateForPrompt(pageText, 3000))
+
+	response, err := d.llm.Complete(ctx, prompt)
+	if err != nil {
+		return false, err
+	}
+
+	result, err := ExtractJSON[TOCDetectorResponse](response)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.ToLower(result.TOCDetected) == "yes", nil
+}
+
+// hasPageNumbers uses the LLM to determine if the TOC includes page numbers.
+func (d *TOCDetector) hasPageNumbers(ctx context.Context, tocContent string) (bool, error) {
+	prompt := fmt.Sprintf(PageIndexGivenPrompt, truncateForPrompt(tocContent, 4000))
+
+	response, err := d.llm.Complete(ctx, prompt)
+	if err != nil {
+		return false, err
+	}
+
+	result, err := ExtractJSON[PageIndexResponse](response)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.ToLower(result.PageIndexGivenTOC) == "yes", nil
+}
+
+// TransformTOC converts raw TOC text into structured TOC items.
+func (d *TOCDetector) TransformTOC(ctx context.Context, tocContent string) ([]TOCItem, error) {
+	prompt := fmt.Sprintf(TOCTransformPrompt, tocContent)
+
+	// Use continuation for potentially long responses
+	fullResponse, err := d.completeWithContinuation(ctx, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("transforming TOC: %w", err)
+	}
+
+	result, err := ExtractJSON[TOCTransformResponse](fullResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.TableOfContents, nil
+}
+
+// completeWithContinuation handles long responses that may be truncated.
+func (d *TOCDetector) completeWithContinuation(ctx context.Context, prompt string) (string, error) {
+	provider, ok := d.llm.(*OpenAIProvider)
+	if !ok {
+		// Fallback to simple completion for other providers
+		return d.llm.Complete(ctx, prompt)
+	}
+
+	var fullResponse strings.Builder
+	history := []Message{{Role: "user", Content: prompt}}
+
+	for i := 0; i < 10; i++ { // Max 10 continuations
+		var response, finishReason string
+		var err error
+
+		if i == 0 {
+			response, finishReason, err = provider.CompleteWithFinishReason(ctx, prompt, nil)
+		} else {
+			response, finishReason, err = provider.CompleteWithFinishReason(ctx, TOCTransformContinuePrompt, history)
+		}
+
+		if err != nil {
+			return "", err
+		}
+
+		fullResponse.WriteString(response)
+		history = append(history, Message{Role: "assistant", Content: response})
+
+		if finishReason == "finished" {
+			break
+		}
+
+		// Check if response looks complete
+		isComplete, err := d.isResponseComplete(ctx, fullResponse.String(), prompt)
+		if err != nil {
+			// Continue anyway on error
+			continue
+		}
+		if isComplete {
+			break
+		}
+
+		history = append(history, Message{Role: "user", Content: TOCTransformContinuePrompt})
+	}
+
+	return fullResponse.String(), nil
+}
+
+// isResponseComplete checks if a partial response appears complete.
+func (d *TOCDetector) isResponseComplete(ctx context.Context, response, original string) (bool, error) {
+	prompt := fmt.Sprintf(CompletionCheckPrompt, truncateForPrompt(response, 2000), truncateForPrompt(original, 2000))
+
+	resp, err := d.llm.Complete(ctx, prompt)
+	if err != nil {
+		return false, err
+	}
+
+	result, err := ExtractJSON[CompletionCheckResponse](resp)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.ToLower(result.Completed) == "yes", nil
+}
+
+// GenerateTOC creates a TOC when the document doesn't have one.
+func (d *TOCDetector) GenerateTOC(ctx context.Context, pages []PageContent) ([]TOCItem, error) {
+	// Combine page texts for analysis
+	var combined strings.Builder
+	for i, page := range pages {
+		combined.WriteString(fmt.Sprintf("\n=== Page %d ===\n", i+1))
+		combined.WriteString(truncateForPrompt(page.Text, 1000))
+	}
+
+	prompt := fmt.Sprintf(GenerateTOCPrompt, truncateForPrompt(combined.String(), 8000))
+
+	response, err := d.llm.Complete(ctx, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("generating TOC: %w", err)
+	}
+
+	result, err := ExtractJSON[TOCTransformResponse](response)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.TableOfContents, nil
+}
+
+// MapPageNumbersToPhysical converts logical page numbers to physical page indices.
+// This handles documents where logical page 1 may not be physical page 1.
+func MapPageNumbersToPhysical(items []TOCItem, tocPageIndices []int, totalPages int) []TOCItem {
+	if len(items) == 0 {
+		return items
+	}
+
+	// Find the offset between logical and physical pages
+	// Assume first content page after TOC is where numbering starts
+	firstContentPage := 0
+	if len(tocPageIndices) > 0 {
+		firstContentPage = tocPageIndices[len(tocPageIndices)-1] + 1
+	}
+
+	// Find the smallest page number in TOC to determine offset
+	minPage := -1
+	for _, item := range items {
+		if item.Page != nil {
+			if minPage == -1 || *item.Page < minPage {
+				minPage = *item.Page
+			}
+		}
+	}
+
+	if minPage == -1 {
+		// No page numbers in TOC
+		return items
+	}
+
+	// Calculate offset: physical_index = page_number + offset
+	offset := firstContentPage - minPage
+
+	result := make([]TOCItem, len(items))
+	for i, item := range items {
+		result[i] = item
+		if item.Page != nil {
+			physIdx := *item.Page + offset
+			if physIdx >= 0 && physIdx < totalPages {
+				result[i].PhysicalIndex = &physIdx
+			}
+		}
+	}
+
+	return result
+}
+
+// CheckSectionStart determines if a section starts at the beginning of its page.
+func (d *TOCDetector) CheckSectionStart(ctx context.Context, title string, pageText string) (bool, error) {
+	// Get first 500 characters of page
+	pageStart := truncateForPrompt(pageText, 500)
+
+	prompt := fmt.Sprintf(StartCheckPrompt, title, pageStart)
+
+	response, err := d.llm.Complete(ctx, prompt)
+	if err != nil {
+		return false, err
+	}
+
+	result, err := ExtractJSON[StartCheckResponse](response)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.ToLower(result.StartBegin) == "yes", nil
+}
+
+// CheckSectionStartsConcurrently checks multiple sections in parallel.
+func (d *TOCDetector) CheckSectionStartsConcurrently(ctx context.Context, items []TOCItem, pages []PageContent, maxWorkers int) ([]TOCItem, error) {
+	if maxWorkers <= 0 {
+		maxWorkers = 5
+	}
+
+	result := make([]TOCItem, len(items))
+	copy(result, items)
+
+	type job struct {
+		index int
+		item  TOCItem
+		page  PageContent
+	}
+
+	type jobResult struct {
+		index      int
+		startsHere bool
+		err        error
+	}
+
+	jobs := make(chan job, len(items))
+	results := make(chan jobResult, len(items))
+
+	// Start workers
+	var wg sync.WaitGroup
+	for w := 0; w < maxWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobs {
+				startsHere, err := d.CheckSectionStart(ctx, j.item.Title, j.page.Text)
+				results <- jobResult{index: j.index, startsHere: startsHere, err: err}
+			}
+		}()
+	}
+
+	// Queue jobs
+	for i, item := range items {
+		if item.PhysicalIndex != nil && *item.PhysicalIndex < len(pages) {
+			jobs <- job{index: i, item: item, page: pages[*item.PhysicalIndex]}
+		}
+	}
+	close(jobs)
+
+	// Wait for completion
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// Collect results
+	for r := range results {
+		if r.err != nil {
+			continue // Skip errors, leave as default
+		}
+		if r.startsHere {
+			result[r.index].AppearStart = "yes"
+		} else {
+			result[r.index].AppearStart = "no"
+		}
+	}
+
+	return result, nil
+}
+
+// truncateForPrompt shortens text to fit in prompts.
+func truncateForPrompt(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "\n...[truncated]"
+}

--- a/internal/pageindex/tokens.go
+++ b/internal/pageindex/tokens.go
@@ -1,0 +1,192 @@
+package pageindex
+
+import (
+	"strings"
+	"unicode"
+)
+
+// CountTokens provides a simple token count approximation.
+// For accurate counting, use a proper tokenizer like tiktoken.
+// This approximation uses ~4 characters per token on average.
+func CountTokens(text string) int {
+	if text == "" {
+		return 0
+	}
+
+	// Count words and punctuation as rough token estimate
+	// Most tokenizers produce ~1.3 tokens per word on average
+	words := strings.Fields(text)
+	wordCount := len(words)
+
+	// Add extra for punctuation (typically separate tokens)
+	punctCount := 0
+	for _, r := range text {
+		if unicode.IsPunct(r) {
+			punctCount++
+		}
+	}
+
+	// Approximate: words * 1.3 + punctuation
+	return int(float64(wordCount)*1.3) + punctCount/2
+}
+
+// CountTokensForModel returns a token counter function for a specific model.
+// Currently returns the simple approximation; can be extended with tiktoken.
+func CountTokensForModel(model string) func(string) int {
+	// TODO: Integrate with tiktoken for accurate counting
+	// For now, use approximation
+	return CountTokens
+}
+
+// EstimateTokensPerPage estimates tokens for a page of PDF text.
+// Average is about 500-800 tokens per page depending on content.
+func EstimateTokensPerPage(pageText string) int {
+	return CountTokens(pageText)
+}
+
+// SplitByTokens splits text into chunks of approximately maxTokens each.
+func SplitByTokens(text string, maxTokens int) []string {
+	if maxTokens <= 0 {
+		return []string{text}
+	}
+
+	tokens := CountTokens(text)
+	if tokens <= maxTokens {
+		return []string{text}
+	}
+
+	// Split by paragraphs first, then by sentences if needed
+	paragraphs := strings.Split(text, "\n\n")
+
+	var chunks []string
+	var currentChunk strings.Builder
+	currentTokens := 0
+
+	for _, para := range paragraphs {
+		paraTokens := CountTokens(para)
+
+		if currentTokens+paraTokens > maxTokens && currentChunk.Len() > 0 {
+			// Save current chunk and start new one
+			chunks = append(chunks, strings.TrimSpace(currentChunk.String()))
+			currentChunk.Reset()
+			currentTokens = 0
+		}
+
+		if paraTokens > maxTokens {
+			// Paragraph too large, split by sentences
+			sentences := splitIntoSentences(para)
+			for _, sent := range sentences {
+				sentTokens := CountTokens(sent)
+				if currentTokens+sentTokens > maxTokens && currentChunk.Len() > 0 {
+					chunks = append(chunks, strings.TrimSpace(currentChunk.String()))
+					currentChunk.Reset()
+					currentTokens = 0
+				}
+				if currentChunk.Len() > 0 {
+					currentChunk.WriteString(" ")
+				}
+				currentChunk.WriteString(sent)
+				currentTokens += sentTokens
+			}
+		} else {
+			if currentChunk.Len() > 0 {
+				currentChunk.WriteString("\n\n")
+			}
+			currentChunk.WriteString(para)
+			currentTokens += paraTokens
+		}
+	}
+
+	if currentChunk.Len() > 0 {
+		chunks = append(chunks, strings.TrimSpace(currentChunk.String()))
+	}
+
+	return chunks
+}
+
+// splitIntoSentences splits text into sentences.
+func splitIntoSentences(text string) []string {
+	var sentences []string
+	var current strings.Builder
+
+	for _, r := range text {
+		current.WriteRune(r)
+		if r == '.' || r == '!' || r == '?' {
+			s := strings.TrimSpace(current.String())
+			if s != "" {
+				sentences = append(sentences, s)
+			}
+			current.Reset()
+		}
+	}
+
+	// Handle remaining text
+	if current.Len() > 0 {
+		s := strings.TrimSpace(current.String())
+		if s != "" {
+			sentences = append(sentences, s)
+		}
+	}
+
+	return sentences
+}
+
+// GroupPagesByTokens groups pages into chunks that fit within maxTokens.
+// Returns slices of page content with overlap for context continuity.
+func GroupPagesByTokens(pages []PageContent, maxTokens, overlapPages int) []string {
+	if len(pages) == 0 {
+		return nil
+	}
+
+	totalTokens := 0
+	for _, p := range pages {
+		totalTokens += p.TokenCount
+	}
+
+	if totalTokens <= maxTokens {
+		// All fits in one group
+		var sb strings.Builder
+		for _, p := range pages {
+			sb.WriteString(p.Text)
+		}
+		return []string{sb.String()}
+	}
+
+	// Calculate expected parts for even distribution
+	expectedParts := (totalTokens + maxTokens - 1) / maxTokens
+	avgTokensPerPart := (totalTokens/expectedParts + maxTokens) / 2
+
+	var groups []string
+	var current strings.Builder
+	currentTokens := 0
+	startIdx := 0
+
+	for i, page := range pages {
+		if currentTokens+page.TokenCount > avgTokensPerPart && current.Len() > 0 {
+			// Save current group
+			groups = append(groups, current.String())
+
+			// Start new group with overlap
+			current.Reset()
+			currentTokens = 0
+			overlapStart := i - overlapPages
+			if overlapStart < startIdx {
+				overlapStart = startIdx
+			}
+			for j := overlapStart; j < i; j++ {
+				current.WriteString(pages[j].Text)
+				currentTokens += pages[j].TokenCount
+			}
+			startIdx = i
+		}
+
+		current.WriteString(page.Text)
+		currentTokens += page.TokenCount
+	}
+
+	if current.Len() > 0 {
+		groups = append(groups, current.String())
+	}
+
+	return groups
+}

--- a/internal/pageindex/tokens_test.go
+++ b/internal/pageindex/tokens_test.go
@@ -1,0 +1,169 @@
+package pageindex
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCountTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		minExpected int
+		maxExpected int
+	}{
+		{"empty string", "", 0, 0},
+		{"single word", "hello", 1, 3},
+		{"simple sentence", "Hello world!", 2, 5},
+		{"longer text", "The quick brown fox jumps over the lazy dog.", 10, 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CountTokens(tt.input)
+			if result < tt.minExpected || result > tt.maxExpected {
+				t.Errorf("CountTokens(%q) = %d, want between %d and %d",
+					tt.input, result, tt.minExpected, tt.maxExpected)
+			}
+		})
+	}
+}
+
+func TestCountTokensForModel(t *testing.T) {
+	// Should return a function
+	counter := CountTokensForModel("gpt-4")
+	if counter == nil {
+		t.Fatal("expected non-nil counter function")
+	}
+
+	// Should work like CountTokens
+	result := counter("hello world")
+	if result <= 0 {
+		t.Error("expected positive token count")
+	}
+}
+
+func TestEstimateTokensPerPage(t *testing.T) {
+	text := "This is a sample page with some text content."
+	result := EstimateTokensPerPage(text)
+	if result <= 0 {
+		t.Error("expected positive token count")
+	}
+}
+
+func TestSplitByTokens(t *testing.T) {
+	t.Run("empty text", func(t *testing.T) {
+		result := SplitByTokens("", 100)
+		if len(result) != 1 {
+			t.Errorf("expected 1 chunk, got %d", len(result))
+		}
+	})
+
+	t.Run("text within limit", func(t *testing.T) {
+		text := "Short text."
+		result := SplitByTokens(text, 1000)
+		if len(result) != 1 {
+			t.Errorf("expected 1 chunk, got %d", len(result))
+		}
+		if result[0] != text {
+			t.Errorf("expected unchanged text, got %q", result[0])
+		}
+	})
+
+	t.Run("text exceeds limit", func(t *testing.T) {
+		// Create text that will need splitting
+		para1 := "First paragraph with some content."
+		para2 := "Second paragraph with more content."
+		para3 := "Third paragraph with even more content."
+		text := para1 + "\n\n" + para2 + "\n\n" + para3
+
+		// Use a very small limit to force splitting
+		result := SplitByTokens(text, 10)
+		if len(result) < 2 {
+			t.Errorf("expected text to be split into multiple chunks, got %d", len(result))
+		}
+	})
+
+	t.Run("zero limit returns original", func(t *testing.T) {
+		text := "Some text."
+		result := SplitByTokens(text, 0)
+		if len(result) != 1 || result[0] != text {
+			t.Error("expected original text returned for zero limit")
+		}
+	})
+}
+
+func TestSplitIntoSentences(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{"single sentence", "Hello world.", 1},
+		{"two sentences", "Hello world. How are you?", 2},
+		{"with exclamation", "Hello! World.", 2},
+		{"no punctuation", "Hello world", 1},
+		{"empty string", "", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitIntoSentences(tt.input)
+			if len(result) != tt.expected {
+				t.Errorf("splitIntoSentences(%q) returned %d sentences, want %d",
+					tt.input, len(result), tt.expected)
+			}
+		})
+	}
+}
+
+func TestGroupPagesByTokens(t *testing.T) {
+	t.Run("empty pages", func(t *testing.T) {
+		result := GroupPagesByTokens(nil, 100, 1)
+		if result != nil {
+			t.Error("expected nil for empty pages")
+		}
+	})
+
+	t.Run("all pages fit", func(t *testing.T) {
+		pages := []PageContent{
+			{Text: "Page 1 content.", TokenCount: 10},
+			{Text: "Page 2 content.", TokenCount: 10},
+		}
+		result := GroupPagesByTokens(pages, 100, 1)
+		if len(result) != 1 {
+			t.Errorf("expected 1 group, got %d", len(result))
+		}
+		if !strings.Contains(result[0], "Page 1") || !strings.Contains(result[0], "Page 2") {
+			t.Error("expected both pages in single group")
+		}
+	})
+
+	t.Run("pages need splitting", func(t *testing.T) {
+		pages := []PageContent{
+			{Text: "Page 1 content.", TokenCount: 50},
+			{Text: "Page 2 content.", TokenCount: 50},
+			{Text: "Page 3 content.", TokenCount: 50},
+			{Text: "Page 4 content.", TokenCount: 50},
+		}
+		result := GroupPagesByTokens(pages, 60, 0)
+		if len(result) < 2 {
+			t.Errorf("expected multiple groups, got %d", len(result))
+		}
+	})
+
+	t.Run("with overlap", func(t *testing.T) {
+		pages := []PageContent{
+			{Text: "Page 1. ", TokenCount: 30},
+			{Text: "Page 2. ", TokenCount: 30},
+			{Text: "Page 3. ", TokenCount: 30},
+			{Text: "Page 4. ", TokenCount: 30},
+		}
+		result := GroupPagesByTokens(pages, 50, 1)
+		if len(result) < 2 {
+			t.Errorf("expected multiple groups, got %d", len(result))
+		}
+		// Check that overlap is applied (page from previous group appears in next)
+		// This is a basic check; overlap implementation details may vary
+	})
+}

--- a/internal/pageindex/tree.go
+++ b/internal/pageindex/tree.go
@@ -1,0 +1,285 @@
+package pageindex
+
+import (
+	"strings"
+)
+
+// ListToTree converts a flat list of TOC items into a hierarchical tree structure.
+// It uses the structure field (e.g., "1.2.3") to determine parent-child relationships.
+func ListToTree(items []TOCItem) []*TreeNode {
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Map to track nodes by their structure code
+	nodeMap := make(map[string]*TreeNode)
+	var rootNodes []*TreeNode
+
+	for _, item := range items {
+		node := &TreeNode{
+			Title:    item.Title,
+			StartIdx: item.StartIndex,
+			EndIdx:   item.EndIndex,
+		}
+
+		if item.Structure == "" || item.Structure == "0" {
+			// Root node without structure
+			rootNodes = append(rootNodes, node)
+			continue
+		}
+
+		nodeMap[item.Structure] = node
+
+		// Find parent structure
+		parentStruct := getParentStructure(item.Structure)
+		if parentStruct == "" {
+			// Top-level node
+			rootNodes = append(rootNodes, node)
+		} else if parent, ok := nodeMap[parentStruct]; ok {
+			// Add as child to existing parent
+			parent.Children = append(parent.Children, node)
+		} else {
+			// Parent not found, treat as root
+			rootNodes = append(rootNodes, node)
+		}
+	}
+
+	return rootNodes
+}
+
+// getParentStructure returns the parent structure code.
+// For example, "1.2.3" returns "1.2", and "1" returns "".
+func getParentStructure(structure string) string {
+	parts := strings.Split(structure, ".")
+	if len(parts) <= 1 {
+		return ""
+	}
+	return strings.Join(parts[:len(parts)-1], ".")
+}
+
+// BuildTreeFromNodes builds a tree from a flat list of nodes with level information.
+// This is used for Markdown processing where nodes have explicit levels.
+func BuildTreeFromNodes(nodes []TOCItem) []*TreeNode {
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	type stackEntry struct {
+		node  *TreeNode
+		level int
+	}
+
+	var stack []stackEntry
+	var rootNodes []*TreeNode
+	nodeCounter := 1
+
+	for _, n := range nodes {
+		currentLevel := n.Level
+		if currentLevel == 0 {
+			currentLevel = 1 // Default to level 1 if not specified
+		}
+
+		treeNode := &TreeNode{
+			Title:    n.Title,
+			NodeID:   padNodeID(nodeCounter),
+			Text:     "", // Will be filled in later
+			LineNum:  n.Level, // Temporarily store level, will be updated
+			StartIdx: n.StartIndex,
+			EndIdx:   n.EndIndex,
+		}
+		nodeCounter++
+
+		// Pop nodes from stack until we find parent level
+		for len(stack) > 0 && stack[len(stack)-1].level >= currentLevel {
+			stack = stack[:len(stack)-1]
+		}
+
+		if len(stack) == 0 {
+			rootNodes = append(rootNodes, treeNode)
+		} else {
+			parent := stack[len(stack)-1].node
+			parent.Children = append(parent.Children, treeNode)
+		}
+
+		stack = append(stack, stackEntry{node: treeNode, level: currentLevel})
+	}
+
+	return rootNodes
+}
+
+// PostProcessTOC converts flat TOC items to tree structure with proper indices.
+// It calculates end indices based on the next item's start and handles "appear_start".
+func PostProcessTOC(items []TOCItem, endPhysicalIndex int) []*TreeNode {
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Calculate start and end indices
+	for i := range items {
+		if items[i].PhysicalIndex != nil {
+			items[i].StartIndex = *items[i].PhysicalIndex
+		}
+
+		if i < len(items)-1 {
+			if items[i+1].PhysicalIndex != nil {
+				nextIdx := *items[i+1].PhysicalIndex
+				// If next section starts at beginning of page, previous ends at page before
+				if items[i+1].AppearStart == "yes" {
+					items[i].EndIndex = nextIdx - 1
+				} else {
+					items[i].EndIndex = nextIdx
+				}
+			}
+		} else {
+			items[i].EndIndex = endPhysicalIndex
+		}
+	}
+
+	// Convert to tree
+	tree := ListToTree(items)
+	if len(tree) == 0 {
+		// If tree conversion failed, return flat structure
+		var nodes []*TreeNode
+		for _, item := range items {
+			nodes = append(nodes, &TreeNode{
+				Title:    item.Title,
+				StartIdx: item.StartIndex,
+				EndIdx:   item.EndIndex,
+			})
+		}
+		return nodes
+	}
+
+	return tree
+}
+
+// AddPrefaceIfNeeded adds a "Preface" node if the first item doesn't start at page 1.
+func AddPrefaceIfNeeded(items []TOCItem) []TOCItem {
+	if len(items) == 0 {
+		return items
+	}
+
+	firstIdx := items[0].PhysicalIndex
+	if firstIdx != nil && *firstIdx > 1 {
+		one := 1
+		preface := TOCItem{
+			Structure:     "0",
+			Title:         "Preface",
+			PhysicalIndex: &one,
+		}
+		return append([]TOCItem{preface}, items...)
+	}
+
+	return items
+}
+
+// ValidateAndTruncatePhysicalIndices removes items with invalid physical indices.
+func ValidateAndTruncatePhysicalIndices(items []TOCItem, pageCount, startIndex int) []TOCItem {
+	maxAllowedPage := pageCount + startIndex - 1
+
+	var valid []TOCItem
+	for _, item := range items {
+		if item.PhysicalIndex != nil {
+			if *item.PhysicalIndex <= maxAllowedPage {
+				valid = append(valid, item)
+			}
+			// Skip items with index beyond document length
+		} else {
+			valid = append(valid, item)
+		}
+	}
+
+	return valid
+}
+
+// padNodeID pads an integer ID to 4 digits.
+func padNodeID(id int) string {
+	return strings.Repeat("0", max(0, 4-len(itoa(id)))) + itoa(id)
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b strings.Builder
+	for i > 0 {
+		b.WriteByte(byte('0' + i%10))
+		i /= 10
+	}
+	s := b.String()
+	// Reverse
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// CleanTree removes empty Children slices and internal fields for output.
+func CleanTree(nodes []*TreeNode) []*TreeNode {
+	var cleaned []*TreeNode
+
+	for _, node := range nodes {
+		cleanNode := &TreeNode{
+			Title:    node.Title,
+			NodeID:   node.NodeID,
+			Text:     node.Text,
+			Summary:  node.Summary,
+			StartIdx: node.StartIdx,
+			EndIdx:   node.EndIdx,
+			LineNum:  node.LineNum,
+		}
+
+		if len(node.Children) > 0 {
+			cleanNode.Children = CleanTree(node.Children)
+		}
+
+		cleaned = append(cleaned, cleanNode)
+	}
+
+	return cleaned
+}
+
+// FlattenTree returns all nodes in the tree as a flat slice.
+func FlattenTree(nodes []*TreeNode) []*TreeNode {
+	var result []*TreeNode
+
+	var walk func([]*TreeNode)
+	walk = func(children []*TreeNode) {
+		for _, node := range children {
+			result = append(result, node)
+			if node.Children != nil {
+				walk(node.Children)
+			}
+		}
+	}
+
+	walk(nodes)
+	return result
+}
+
+// GetLeafNodes returns only leaf nodes (nodes without children).
+func GetLeafNodes(nodes []*TreeNode) []*TreeNode {
+	var leaves []*TreeNode
+
+	var walk func([]*TreeNode)
+	walk = func(children []*TreeNode) {
+		for _, node := range children {
+			if len(node.Children) == 0 {
+				leaves = append(leaves, node)
+			} else {
+				walk(node.Children)
+			}
+		}
+	}
+
+	walk(nodes)
+	return leaves
+}

--- a/internal/pageindex/tree_test.go
+++ b/internal/pageindex/tree_test.go
@@ -1,0 +1,302 @@
+package pageindex
+
+import (
+	"testing"
+)
+
+func TestGetParentStructure(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"single digit", "1", ""},
+		{"two levels", "1.2", "1"},
+		{"three levels", "1.2.3", "1.2"},
+		{"four levels", "1.2.3.4", "1.2.3"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getParentStructure(tt.input)
+			if result != tt.expected {
+				t.Errorf("getParentStructure(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestListToTree(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
+		result := ListToTree(nil)
+		if result != nil {
+			t.Error("expected nil for empty input")
+		}
+	})
+
+	t.Run("flat list", func(t *testing.T) {
+		items := []TOCItem{
+			{Structure: "1", Title: "Chapter 1", StartIndex: 1, EndIndex: 10},
+			{Structure: "2", Title: "Chapter 2", StartIndex: 11, EndIndex: 20},
+		}
+		result := ListToTree(items)
+		if len(result) != 2 {
+			t.Errorf("expected 2 root nodes, got %d", len(result))
+		}
+		if result[0].Title != "Chapter 1" {
+			t.Errorf("expected first node title 'Chapter 1', got %q", result[0].Title)
+		}
+	})
+
+	t.Run("nested structure", func(t *testing.T) {
+		items := []TOCItem{
+			{Structure: "1", Title: "Chapter 1", StartIndex: 1, EndIndex: 20},
+			{Structure: "1.1", Title: "Section 1.1", StartIndex: 1, EndIndex: 10},
+			{Structure: "1.2", Title: "Section 1.2", StartIndex: 11, EndIndex: 20},
+			{Structure: "2", Title: "Chapter 2", StartIndex: 21, EndIndex: 30},
+		}
+		result := ListToTree(items)
+		if len(result) != 2 {
+			t.Errorf("expected 2 root nodes, got %d", len(result))
+		}
+		if len(result[0].Children) != 2 {
+			t.Errorf("expected Chapter 1 to have 2 children, got %d", len(result[0].Children))
+		}
+		if result[0].Children[0].Title != "Section 1.1" {
+			t.Errorf("expected first child 'Section 1.1', got %q", result[0].Children[0].Title)
+		}
+	})
+
+	t.Run("deep nesting", func(t *testing.T) {
+		items := []TOCItem{
+			{Structure: "1", Title: "Chapter 1"},
+			{Structure: "1.1", Title: "Section 1.1"},
+			{Structure: "1.1.1", Title: "Subsection 1.1.1"},
+			{Structure: "1.1.1.1", Title: "Para 1.1.1.1"},
+		}
+		result := ListToTree(items)
+		if len(result) != 1 {
+			t.Fatalf("expected 1 root node, got %d", len(result))
+		}
+		// Navigate down the tree
+		node := result[0]
+		if len(node.Children) != 1 || node.Children[0].Title != "Section 1.1" {
+			t.Error("expected Section 1.1 as child")
+		}
+		node = node.Children[0]
+		if len(node.Children) != 1 || node.Children[0].Title != "Subsection 1.1.1" {
+			t.Error("expected Subsection 1.1.1 as child")
+		}
+		node = node.Children[0]
+		if len(node.Children) != 1 || node.Children[0].Title != "Para 1.1.1.1" {
+			t.Error("expected Para 1.1.1.1 as child")
+		}
+	})
+}
+
+func TestBuildTreeFromNodes(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		result := BuildTreeFromNodes(nil)
+		if result != nil {
+			t.Error("expected nil for empty input")
+		}
+	})
+
+	t.Run("flat nodes same level", func(t *testing.T) {
+		items := []TOCItem{
+			{Title: "Section A", Level: 1},
+			{Title: "Section B", Level: 1},
+		}
+		result := BuildTreeFromNodes(items)
+		if len(result) != 2 {
+			t.Errorf("expected 2 root nodes, got %d", len(result))
+		}
+	})
+
+	t.Run("nested by level", func(t *testing.T) {
+		items := []TOCItem{
+			{Title: "Chapter 1", Level: 1},
+			{Title: "Section 1.1", Level: 2},
+			{Title: "Section 1.2", Level: 2},
+			{Title: "Chapter 2", Level: 1},
+		}
+		result := BuildTreeFromNodes(items)
+		if len(result) != 2 {
+			t.Errorf("expected 2 root nodes, got %d", len(result))
+		}
+		if len(result[0].Children) != 2 {
+			t.Errorf("expected Chapter 1 to have 2 children, got %d", len(result[0].Children))
+		}
+	})
+}
+
+func TestPostProcessTOC(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		result := PostProcessTOC(nil, 100)
+		if result != nil {
+			t.Error("expected nil for empty input")
+		}
+	})
+
+	t.Run("calculates end indices", func(t *testing.T) {
+		idx1, idx2 := 1, 11
+		items := []TOCItem{
+			{Structure: "1", Title: "Chapter 1", PhysicalIndex: &idx1},
+			{Structure: "2", Title: "Chapter 2", PhysicalIndex: &idx2, AppearStart: "yes"},
+		}
+		result := PostProcessTOC(items, 20)
+		if len(result) != 2 {
+			t.Fatalf("expected 2 nodes, got %d", len(result))
+		}
+		// First item should end at 10 (11-1) because next starts at beginning
+		if result[0].EndIdx != 10 {
+			t.Errorf("expected first node EndIdx=10, got %d", result[0].EndIdx)
+		}
+		// Second item should end at document end
+		if result[1].EndIdx != 20 {
+			t.Errorf("expected second node EndIdx=20, got %d", result[1].EndIdx)
+		}
+	})
+}
+
+func TestAddPrefaceIfNeeded(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		result := AddPrefaceIfNeeded(nil)
+		if result != nil {
+			t.Error("expected nil for empty input")
+		}
+	})
+
+	t.Run("first item at page 1", func(t *testing.T) {
+		idx := 1
+		items := []TOCItem{{Title: "Chapter 1", PhysicalIndex: &idx}}
+		result := AddPrefaceIfNeeded(items)
+		if len(result) != 1 {
+			t.Error("expected no preface added when first page is 1")
+		}
+	})
+
+	t.Run("first item at page 5", func(t *testing.T) {
+		idx := 5
+		items := []TOCItem{{Title: "Chapter 1", PhysicalIndex: &idx}}
+		result := AddPrefaceIfNeeded(items)
+		if len(result) != 2 {
+			t.Fatalf("expected preface added, got %d items", len(result))
+		}
+		if result[0].Title != "Preface" {
+			t.Errorf("expected first item to be 'Preface', got %q", result[0].Title)
+		}
+	})
+}
+
+func TestValidateAndTruncatePhysicalIndices(t *testing.T) {
+	t.Run("all valid", func(t *testing.T) {
+		idx1, idx2 := 5, 10
+		items := []TOCItem{
+			{Title: "A", PhysicalIndex: &idx1},
+			{Title: "B", PhysicalIndex: &idx2},
+		}
+		result := ValidateAndTruncatePhysicalIndices(items, 20, 1)
+		if len(result) != 2 {
+			t.Error("expected all items to be valid")
+		}
+	})
+
+	t.Run("remove out of range", func(t *testing.T) {
+		idx1, idx2 := 5, 50
+		items := []TOCItem{
+			{Title: "A", PhysicalIndex: &idx1},
+			{Title: "B", PhysicalIndex: &idx2},
+		}
+		result := ValidateAndTruncatePhysicalIndices(items, 20, 1)
+		if len(result) != 1 {
+			t.Errorf("expected 1 valid item, got %d", len(result))
+		}
+		if result[0].Title != "A" {
+			t.Errorf("expected remaining item to be 'A', got %q", result[0].Title)
+		}
+	})
+}
+
+func TestPadNodeID(t *testing.T) {
+	tests := []struct {
+		input    int
+		expected string
+	}{
+		{0, "0000"},
+		{1, "0001"},
+		{12, "0012"},
+		{123, "0123"},
+		{1234, "1234"},
+		{12345, "12345"},
+	}
+
+	for _, tt := range tests {
+		result := padNodeID(tt.input)
+		if result != tt.expected {
+			t.Errorf("padNodeID(%d) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestFlattenTree(t *testing.T) {
+	root := &TreeNode{
+		Title: "Root",
+		Children: []*TreeNode{
+			{Title: "Child 1"},
+			{Title: "Child 2", Children: []*TreeNode{
+				{Title: "Grandchild"},
+			}},
+		},
+	}
+	result := FlattenTree([]*TreeNode{root})
+	if len(result) != 4 {
+		t.Errorf("expected 4 nodes, got %d", len(result))
+	}
+}
+
+func TestGetLeafNodes(t *testing.T) {
+	root := &TreeNode{
+		Title: "Root",
+		Children: []*TreeNode{
+			{Title: "Child 1"},
+			{Title: "Child 2", Children: []*TreeNode{
+				{Title: "Grandchild"},
+			}},
+		},
+	}
+	leaves := GetLeafNodes([]*TreeNode{root})
+	if len(leaves) != 2 {
+		t.Errorf("expected 2 leaf nodes, got %d", len(leaves))
+	}
+	titles := map[string]bool{}
+	for _, l := range leaves {
+		titles[l.Title] = true
+	}
+	if !titles["Child 1"] || !titles["Grandchild"] {
+		t.Error("expected leaf nodes to be 'Child 1' and 'Grandchild'")
+	}
+}
+
+func TestCleanTree(t *testing.T) {
+	nodes := []*TreeNode{
+		{
+			Title:  "Chapter 1",
+			NodeID: "0001",
+			Children: []*TreeNode{
+				{Title: "Section 1.1", NodeID: "0002"},
+			},
+		},
+	}
+	result := CleanTree(nodes)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(result))
+	}
+	if result[0].Title != "Chapter 1" {
+		t.Errorf("expected title 'Chapter 1', got %q", result[0].Title)
+	}
+	if len(result[0].Children) != 1 {
+		t.Error("expected children to be preserved")
+	}
+}

--- a/internal/pageindex/types.go
+++ b/internal/pageindex/types.go
@@ -1,0 +1,236 @@
+// Package pageindex implements a vectorless, reasoning-based RAG framework
+// for building tree-structured indexes from documents.
+//
+// This is a Go port of the PageIndex Python framework:
+// https://github.com/VectifyAI/PageIndex
+package pageindex
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TreeNode represents a node in the document structure tree.
+// Each node corresponds to a section in the document with its title,
+// position, and optional content.
+type TreeNode struct {
+	Title     string      `json:"title"`
+	NodeID    string      `json:"node_id,omitempty"`
+	StartIdx  int         `json:"start_index,omitempty"`
+	EndIdx    int         `json:"end_index,omitempty"`
+	LineNum   int         `json:"line_num,omitempty"`
+	Text      string      `json:"text,omitempty"`
+	Summary   string      `json:"summary,omitempty"`
+	PrefixSum string      `json:"prefix_summary,omitempty"`
+	Children  []*TreeNode `json:"nodes,omitempty"`
+}
+
+// TOCItem represents a flat table-of-contents entry before tree construction.
+// It contains the hierarchical structure index (e.g., "1.2.3") and page references.
+type TOCItem struct {
+	Structure     string `json:"structure,omitempty"`      // Hierarchical index like "1.2.3"
+	Title         string `json:"title"`                    // Section title
+	Page          *int   `json:"page,omitempty"`           // Logical page number from TOC
+	PhysicalIndex *int   `json:"physical_index,omitempty"` // Actual PDF page index
+	StartIndex    int    `json:"start_index,omitempty"`    // Start page after processing
+	EndIndex      int    `json:"end_index,omitempty"`      // End page after processing
+	AppearStart   string `json:"appear_start,omitempty"`   // "yes" if section starts at page beginning
+	Level         int    `json:"level,omitempty"`          // Header level for markdown
+}
+
+// Config holds configuration options for PageIndex operations.
+type Config struct {
+	// Model specifies the LLM model to use (e.g., "gpt-4o", "claude-sonnet-4-20250514")
+	Model string
+
+	// TOCCheckPageNum is the maximum number of pages to scan for TOC detection
+	TOCCheckPageNum int
+
+	// MaxPageNumEachNode is the threshold for splitting large nodes
+	MaxPageNumEachNode int
+
+	// MaxTokenNumEachNode is the token threshold for splitting large nodes
+	MaxTokenNumEachNode int
+
+	// IfAddNodeID controls whether to assign unique IDs to nodes
+	IfAddNodeID bool
+
+	// IfAddNodeText controls whether to include full text in nodes
+	IfAddNodeText bool
+
+	// IfAddNodeSummary controls whether to generate summaries for nodes
+	IfAddNodeSummary bool
+
+	// IfAddDocDescription controls whether to generate a document description
+	IfAddDocDescription bool
+
+	// SummaryTokenThreshold is the threshold below which text is used as-is for summary
+	SummaryTokenThreshold int
+
+	// MinNodeToken is the minimum token count for tree thinning
+	MinNodeToken int
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() *Config {
+	return &Config{
+		Model:                 "gpt-4o",
+		TOCCheckPageNum:       20,
+		MaxPageNumEachNode:    10,
+		MaxTokenNumEachNode:   5000,
+		IfAddNodeID:           true,
+		IfAddNodeText:         false,
+		IfAddNodeSummary:      false,
+		IfAddDocDescription:   false,
+		SummaryTokenThreshold: 200,
+		MinNodeToken:          500,
+	}
+}
+
+// PageContent represents extracted content from a single page.
+type PageContent struct {
+	Text       string // Extracted text content
+	TokenCount int    // Token count for the page
+}
+
+// Document represents a processed document with its metadata and structure.
+type Document struct {
+	Name        string      `json:"doc_name"`
+	Description string      `json:"doc_description,omitempty"`
+	Structure   []*TreeNode `json:"structure"`
+}
+
+// TOCCheckResult contains the result of checking for a table of contents.
+type TOCCheckResult struct {
+	TOCContent        string // Raw TOC content
+	TOCPageList       []int  // List of page indices containing TOC
+	PageIndexGivenTOC bool   // Whether page numbers are given in TOC
+}
+
+// VerifyResult contains the result of verifying a TOC entry.
+type VerifyResult struct {
+	ListIndex     int    `json:"list_index"`
+	Answer        string `json:"answer"` // "yes" or "no"
+	Title         string `json:"title"`
+	PageNumber    *int   `json:"page_number,omitempty"`
+	PhysicalIndex *int   `json:"physical_index,omitempty"`
+}
+
+// LLMResponse represents a generic JSON response from the LLM.
+type LLMResponse struct {
+	Thinking string `json:"thinking,omitempty"`
+	Answer   string `json:"answer,omitempty"`
+}
+
+// TOCDetectorResponse represents the response from TOC detection.
+type TOCDetectorResponse struct {
+	Thinking    string `json:"thinking,omitempty"`
+	TOCDetected string `json:"toc_detected"` // "yes" or "no"
+}
+
+// PageIndexResponse represents the response for page index detection.
+type PageIndexResponse struct {
+	Thinking          string `json:"thinking,omitempty"`
+	PageIndexGivenTOC string `json:"page_index_given_in_toc"` // "yes" or "no"
+}
+
+// CompletionCheckResponse represents the response for checking completeness.
+type CompletionCheckResponse struct {
+	Thinking  string `json:"thinking,omitempty"`
+	Completed string `json:"completed"` // "yes" or "no"
+}
+
+// StartCheckResponse represents the response for checking section start.
+type StartCheckResponse struct {
+	Thinking   string `json:"thinking,omitempty"`
+	StartBegin string `json:"start_begin"` // "yes" or "no"
+}
+
+// TOCTransformResponse represents the response from TOC transformation.
+type TOCTransformResponse struct {
+	TableOfContents []TOCItem `json:"table_of_contents"`
+}
+
+// String returns a JSON representation of the TreeNode for debugging.
+func (n *TreeNode) String() string {
+	b, _ := json.MarshalIndent(n, "", "  ")
+	return string(b)
+}
+
+// String returns a JSON representation of the Document.
+func (d *Document) String() string {
+	b, _ := json.MarshalIndent(d, "", "  ")
+	return string(b)
+}
+
+// Clone creates a deep copy of the TreeNode.
+func (n *TreeNode) Clone() *TreeNode {
+	if n == nil {
+		return nil
+	}
+	clone := &TreeNode{
+		Title:     n.Title,
+		NodeID:    n.NodeID,
+		StartIdx:  n.StartIdx,
+		EndIdx:    n.EndIdx,
+		LineNum:   n.LineNum,
+		Text:      n.Text,
+		Summary:   n.Summary,
+		PrefixSum: n.PrefixSum,
+	}
+	if n.Children != nil {
+		clone.Children = make([]*TreeNode, len(n.Children))
+		for i, child := range n.Children {
+			clone.Children[i] = child.Clone()
+		}
+	}
+	return clone
+}
+
+// Walk traverses the tree in depth-first order, calling fn for each node.
+func (n *TreeNode) Walk(fn func(*TreeNode)) {
+	if n == nil {
+		return
+	}
+	fn(n)
+	for _, child := range n.Children {
+		child.Walk(fn)
+	}
+}
+
+// LeafNodes returns all leaf nodes (nodes without children).
+func (n *TreeNode) LeafNodes() []*TreeNode {
+	var leaves []*TreeNode
+	n.Walk(func(node *TreeNode) {
+		if len(node.Children) == 0 {
+			leaves = append(leaves, node)
+		}
+	})
+	return leaves
+}
+
+// AllNodes returns all nodes in the tree as a flat slice.
+func (n *TreeNode) AllNodes() []*TreeNode {
+	var nodes []*TreeNode
+	n.Walk(func(node *TreeNode) {
+		nodes = append(nodes, node)
+	})
+	return nodes
+}
+
+// WriteNodeIDs assigns sequential zero-padded IDs to all nodes in the tree.
+func WriteNodeIDs(nodes []*TreeNode) int {
+	counter := 0
+	var assign func([]*TreeNode)
+	assign = func(children []*TreeNode) {
+		for _, node := range children {
+			node.NodeID = fmt.Sprintf("%04d", counter)
+			counter++
+			if node.Children != nil {
+				assign(node.Children)
+			}
+		}
+	}
+	assign(nodes)
+	return counter
+}

--- a/internal/pageindex/types_test.go
+++ b/internal/pageindex/types_test.go
@@ -1,0 +1,291 @@
+package pageindex
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg == nil {
+		t.Fatal("DefaultConfig returned nil")
+	}
+
+	if cfg.Model != "gpt-4o" {
+		t.Errorf("expected Model='gpt-4o', got %q", cfg.Model)
+	}
+
+	if cfg.TOCCheckPageNum != 20 {
+		t.Errorf("expected TOCCheckPageNum=20, got %d", cfg.TOCCheckPageNum)
+	}
+
+	if cfg.MaxPageNumEachNode != 10 {
+		t.Errorf("expected MaxPageNumEachNode=10, got %d", cfg.MaxPageNumEachNode)
+	}
+
+	if cfg.MaxTokenNumEachNode != 5000 {
+		t.Errorf("expected MaxTokenNumEachNode=5000, got %d", cfg.MaxTokenNumEachNode)
+	}
+
+	if !cfg.IfAddNodeID {
+		t.Error("expected IfAddNodeID=true")
+	}
+
+	if cfg.IfAddNodeText {
+		t.Error("expected IfAddNodeText=false")
+	}
+
+	if cfg.IfAddNodeSummary {
+		t.Error("expected IfAddNodeSummary=false")
+	}
+}
+
+func TestTreeNodeString(t *testing.T) {
+	node := &TreeNode{
+		Title:    "Test Node",
+		NodeID:   "0001",
+		StartIdx: 1,
+		EndIdx:   10,
+	}
+
+	result := node.String()
+	if result == "" {
+		t.Error("expected non-empty string representation")
+	}
+
+	// Should be valid JSON
+	var parsed TreeNode
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Errorf("String() should return valid JSON: %v", err)
+	}
+
+	if parsed.Title != "Test Node" {
+		t.Errorf("expected Title='Test Node', got %q", parsed.Title)
+	}
+}
+
+func TestDocumentString(t *testing.T) {
+	doc := &Document{
+		Name:        "Test Document",
+		Description: "A test document",
+		Structure: []*TreeNode{
+			{Title: "Chapter 1"},
+		},
+	}
+
+	result := doc.String()
+	if result == "" {
+		t.Error("expected non-empty string representation")
+	}
+
+	// Should be valid JSON
+	var parsed Document
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Errorf("String() should return valid JSON: %v", err)
+	}
+
+	if parsed.Name != "Test Document" {
+		t.Errorf("expected Name='Test Document', got %q", parsed.Name)
+	}
+}
+
+func TestTreeNodeClone(t *testing.T) {
+	t.Run("nil node", func(t *testing.T) {
+		var node *TreeNode
+		clone := node.Clone()
+		if clone != nil {
+			t.Error("expected nil clone for nil node")
+		}
+	})
+
+	t.Run("simple node", func(t *testing.T) {
+		node := &TreeNode{
+			Title:    "Original",
+			NodeID:   "0001",
+			StartIdx: 1,
+			EndIdx:   10,
+			Text:     "Some text",
+		}
+		clone := node.Clone()
+
+		if clone == node {
+			t.Error("clone should be a different object")
+		}
+		if clone.Title != node.Title {
+			t.Errorf("expected Title=%q, got %q", node.Title, clone.Title)
+		}
+
+		// Modify clone and ensure original is unchanged
+		clone.Title = "Modified"
+		if node.Title != "Original" {
+			t.Error("modifying clone should not affect original")
+		}
+	})
+
+	t.Run("node with children", func(t *testing.T) {
+		node := &TreeNode{
+			Title: "Parent",
+			Children: []*TreeNode{
+				{Title: "Child 1"},
+				{Title: "Child 2"},
+			},
+		}
+		clone := node.Clone()
+
+		if len(clone.Children) != 2 {
+			t.Errorf("expected 2 children, got %d", len(clone.Children))
+		}
+
+		// Modify clone's children
+		clone.Children[0].Title = "Modified Child"
+		if node.Children[0].Title != "Child 1" {
+			t.Error("modifying clone's children should not affect original")
+		}
+	})
+}
+
+func TestTreeNodeWalk(t *testing.T) {
+	t.Run("nil node", func(t *testing.T) {
+		var node *TreeNode
+		count := 0
+		node.Walk(func(n *TreeNode) { count++ })
+		if count != 0 {
+			t.Error("expected no walks for nil node")
+		}
+	})
+
+	t.Run("tree traversal", func(t *testing.T) {
+		node := &TreeNode{
+			Title: "Root",
+			Children: []*TreeNode{
+				{Title: "Child 1", Children: []*TreeNode{
+					{Title: "Grandchild"},
+				}},
+				{Title: "Child 2"},
+			},
+		}
+
+		var visited []string
+		node.Walk(func(n *TreeNode) {
+			visited = append(visited, n.Title)
+		})
+
+		if len(visited) != 4 {
+			t.Errorf("expected 4 nodes visited, got %d", len(visited))
+		}
+
+		// Depth-first order
+		expected := []string{"Root", "Child 1", "Grandchild", "Child 2"}
+		for i, title := range expected {
+			if visited[i] != title {
+				t.Errorf("expected visited[%d]=%q, got %q", i, title, visited[i])
+			}
+		}
+	})
+}
+
+func TestTreeNodeLeafNodes(t *testing.T) {
+	node := &TreeNode{
+		Title: "Root",
+		Children: []*TreeNode{
+			{Title: "Child 1"},
+			{Title: "Child 2", Children: []*TreeNode{
+				{Title: "Grandchild"},
+			}},
+		},
+	}
+
+	leaves := node.LeafNodes()
+	if len(leaves) != 2 {
+		t.Errorf("expected 2 leaf nodes, got %d", len(leaves))
+	}
+
+	titles := map[string]bool{}
+	for _, leaf := range leaves {
+		titles[leaf.Title] = true
+	}
+
+	if !titles["Child 1"] || !titles["Grandchild"] {
+		t.Error("expected leaves to be 'Child 1' and 'Grandchild'")
+	}
+}
+
+func TestTreeNodeAllNodes(t *testing.T) {
+	node := &TreeNode{
+		Title: "Root",
+		Children: []*TreeNode{
+			{Title: "Child 1"},
+			{Title: "Child 2"},
+		},
+	}
+
+	all := node.AllNodes()
+	if len(all) != 3 {
+		t.Errorf("expected 3 nodes, got %d", len(all))
+	}
+}
+
+func TestWriteNodeIDs(t *testing.T) {
+	nodes := []*TreeNode{
+		{
+			Title: "Chapter 1",
+			Children: []*TreeNode{
+				{Title: "Section 1.1"},
+				{Title: "Section 1.2"},
+			},
+		},
+		{
+			Title: "Chapter 2",
+		},
+	}
+
+	count := WriteNodeIDs(nodes)
+	if count != 4 {
+		t.Errorf("expected 4 nodes assigned IDs, got %d", count)
+	}
+
+	// Check IDs are sequential
+	if nodes[0].NodeID != "0000" {
+		t.Errorf("expected first node ID='0000', got %q", nodes[0].NodeID)
+	}
+	if nodes[0].Children[0].NodeID != "0001" {
+		t.Errorf("expected second node ID='0001', got %q", nodes[0].Children[0].NodeID)
+	}
+	if nodes[0].Children[1].NodeID != "0002" {
+		t.Errorf("expected third node ID='0002', got %q", nodes[0].Children[1].NodeID)
+	}
+	if nodes[1].NodeID != "0003" {
+		t.Errorf("expected fourth node ID='0003', got %q", nodes[1].NodeID)
+	}
+}
+
+func TestTOCItemJSON(t *testing.T) {
+	page := 5
+	item := TOCItem{
+		Structure: "1.2.3",
+		Title:     "Test Section",
+		Page:      &page,
+		Level:     3,
+	}
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("failed to marshal TOCItem: %v", err)
+	}
+
+	var parsed TOCItem
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal TOCItem: %v", err)
+	}
+
+	if parsed.Structure != "1.2.3" {
+		t.Errorf("expected Structure='1.2.3', got %q", parsed.Structure)
+	}
+	if parsed.Title != "Test Section" {
+		t.Errorf("expected Title='Test Section', got %q", parsed.Title)
+	}
+	if parsed.Page == nil || *parsed.Page != 5 {
+		t.Error("expected Page=5")
+	}
+}

--- a/internal/pageindex/verify.go
+++ b/internal/pageindex/verify.go
@@ -1,0 +1,345 @@
+package pageindex
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// Verifier handles verification and correction of TOC entries.
+type Verifier struct {
+	llm    LLMProvider
+	config *Config
+}
+
+// NewVerifier creates a new Verifier with the given LLM provider.
+func NewVerifier(llm LLMProvider, config *Config) *Verifier {
+	if config == nil {
+		config = DefaultConfig()
+	}
+	return &Verifier{llm: llm, config: config}
+}
+
+// VerificationReport contains the results of verifying a TOC.
+type VerificationReport struct {
+	TotalEntries     int
+	CorrectEntries   int
+	IncorrectEntries []int // Indices of incorrect entries
+	Accuracy         float64
+}
+
+// VerifyTOCEntries verifies that TOC entries appear on their expected pages.
+// Returns a report with accuracy and list of incorrect entries.
+func (v *Verifier) VerifyTOCEntries(ctx context.Context, items []TOCItem, pages []PageContent, maxWorkers int) (*VerificationReport, error) {
+	if maxWorkers <= 0 {
+		maxWorkers = 10
+	}
+
+	// Filter items with physical indices
+	var toVerify []int
+	for i, item := range items {
+		if item.PhysicalIndex != nil && *item.PhysicalIndex >= 0 && *item.PhysicalIndex < len(pages) {
+			toVerify = append(toVerify, i)
+		}
+	}
+
+	if len(toVerify) == 0 {
+		return &VerificationReport{
+			TotalEntries:   len(items),
+			CorrectEntries: 0,
+			Accuracy:       0,
+		}, nil
+	}
+
+	type result struct {
+		index   int
+		correct bool
+		err     error
+	}
+
+	results := make(chan result, len(toVerify))
+
+	// Create worker pool
+	jobs := make(chan int, len(toVerify))
+
+	var wg sync.WaitGroup
+	for w := 0; w < maxWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range jobs {
+				item := items[idx]
+				pageIdx := *item.PhysicalIndex
+				correct, err := v.verifyEntry(ctx, item.Title, pageIdx, pages[pageIdx].Text)
+				results <- result{index: idx, correct: correct, err: err}
+			}
+		}()
+	}
+
+	// Queue jobs
+	for _, idx := range toVerify {
+		jobs <- idx
+	}
+	close(jobs)
+
+	// Wait for completion
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// Collect results
+	correctCount := 0
+	var incorrect []int
+
+	for r := range results {
+		if r.err != nil {
+			// Treat errors as unverified (not incorrect)
+			continue
+		}
+		if r.correct {
+			correctCount++
+		} else {
+			incorrect = append(incorrect, r.index)
+		}
+	}
+
+	accuracy := float64(correctCount) / float64(len(toVerify))
+
+	return &VerificationReport{
+		TotalEntries:     len(items),
+		CorrectEntries:   correctCount,
+		IncorrectEntries: incorrect,
+		Accuracy:         accuracy,
+	}, nil
+}
+
+// verifyEntry checks if a title appears on the expected page.
+func (v *Verifier) verifyEntry(ctx context.Context, title string, pageNum int, pageText string) (bool, error) {
+	// First, try simple string matching with fuzzy comparison
+	if containsFuzzy(pageText, title) {
+		return true, nil
+	}
+
+	// Fall back to LLM verification
+	prompt := fmt.Sprintf(VerifyTOCEntryPrompt, title, pageNum, truncateForPrompt(pageText, 3000))
+
+	response, err := v.llm.Complete(ctx, prompt)
+	if err != nil {
+		return false, err
+	}
+
+	result, err := ExtractJSON[LLMResponse](response)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.ToLower(result.Answer) == "yes", nil
+}
+
+// containsFuzzy checks if the page contains the title with fuzzy matching.
+// Handles common OCR and formatting issues like extra spaces.
+func containsFuzzy(pageText, title string) bool {
+	// Normalize both strings
+	normalizeStr := func(s string) string {
+		// Collapse multiple spaces
+		s = strings.Join(strings.Fields(s), " ")
+		// Lowercase
+		s = strings.ToLower(s)
+		return s
+	}
+
+	pageNorm := normalizeStr(pageText)
+	titleNorm := normalizeStr(title)
+
+	return strings.Contains(pageNorm, titleNorm)
+}
+
+// FixIncorrectEntries attempts to fix incorrect TOC entries by searching nearby pages.
+func (v *Verifier) FixIncorrectEntries(ctx context.Context, items []TOCItem, pages []PageContent, incorrectIndices []int, searchRadius int) ([]TOCItem, error) {
+	if searchRadius <= 0 {
+		searchRadius = 5
+	}
+
+	result := make([]TOCItem, len(items))
+	copy(result, items)
+
+	for _, idx := range incorrectIndices {
+		item := items[idx]
+		if item.PhysicalIndex == nil {
+			continue
+		}
+
+		originalPage := *item.PhysicalIndex
+
+		// Search nearby pages
+		found := false
+		for offset := -searchRadius; offset <= searchRadius && !found; offset++ {
+			if offset == 0 {
+				continue // Already checked this page
+			}
+
+			searchPage := originalPage + offset
+			if searchPage < 0 || searchPage >= len(pages) {
+				continue
+			}
+
+			if containsFuzzy(pages[searchPage].Text, item.Title) {
+				result[idx].PhysicalIndex = &searchPage
+				found = true
+			}
+		}
+
+		if !found {
+			// Use LLM to search if simple matching fails
+			correctedPage, err := v.searchForEntry(ctx, item.Title, pages, originalPage, searchRadius)
+			if err == nil && correctedPage >= 0 {
+				result[idx].PhysicalIndex = &correctedPage
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// searchForEntry uses LLM to find where a title actually appears.
+func (v *Verifier) searchForEntry(ctx context.Context, title string, pages []PageContent, centerPage, radius int) (int, error) {
+	// Build context of pages around the expected location
+	var pagesContext strings.Builder
+	startPage := centerPage - radius
+	if startPage < 0 {
+		startPage = 0
+	}
+	endPage := centerPage + radius
+	if endPage >= len(pages) {
+		endPage = len(pages) - 1
+	}
+
+	for i := startPage; i <= endPage; i++ {
+		pagesContext.WriteString(fmt.Sprintf("\n=== Page %d ===\n%s\n", i, truncateForPrompt(pages[i].Text, 500)))
+	}
+
+	prompt := fmt.Sprintf(`You are an expert in analyzing documents. You are looking for where a section title appears in a document.
+
+Section Title: %s
+
+Pages to search:
+%s
+
+Which page number does this section title appear on? If not found, respond with -1.
+
+Respond in JSON format:
+{
+  "thinking": "<your reasoning>",
+  "page_number": <page number or -1>
+}`, title, pagesContext.String())
+
+	response, err := v.llm.Complete(ctx, prompt)
+	if err != nil {
+		return -1, err
+	}
+
+	type pageResult struct {
+		PageNumber int `json:"page_number"`
+	}
+
+	result, err := ExtractJSON[pageResult](response)
+	if err != nil {
+		return -1, err
+	}
+
+	return result.PageNumber, nil
+}
+
+// FixIncorrectTOCWithRetries iteratively fixes incorrect entries with multiple attempts.
+func (v *Verifier) FixIncorrectTOCWithRetries(ctx context.Context, items []TOCItem, pages []PageContent, maxRetries int) ([]TOCItem, *VerificationReport, error) {
+	if maxRetries <= 0 {
+		maxRetries = 3
+	}
+
+	current := make([]TOCItem, len(items))
+	copy(current, items)
+
+	var lastReport *VerificationReport
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		// Verify current state
+		report, err := v.VerifyTOCEntries(ctx, current, pages, 10)
+		if err != nil {
+			return current, report, err
+		}
+
+		lastReport = report
+
+		// Check if we've reached acceptable accuracy
+		if report.Accuracy >= 1.0 {
+			return current, report, nil
+		}
+
+		if len(report.IncorrectEntries) == 0 {
+			return current, report, nil
+		}
+
+		// Attempt to fix incorrect entries
+		// Increase search radius with each attempt
+		searchRadius := 5 + attempt*3
+
+		fixed, err := v.FixIncorrectEntries(ctx, current, pages, report.IncorrectEntries, searchRadius)
+		if err != nil {
+			return current, report, err
+		}
+
+		current = fixed
+	}
+
+	return current, lastReport, nil
+}
+
+// DetermineProcessingMode decides which TOC processing mode to use.
+// Returns: "toc_with_pages", "toc_without_pages", or "no_toc"
+func DetermineProcessingMode(tocResult *TOCCheckResult) string {
+	if tocResult == nil || len(tocResult.TOCPageList) == 0 {
+		return "no_toc"
+	}
+
+	if tocResult.PageIndexGivenTOC {
+		return "toc_with_pages"
+	}
+
+	return "toc_without_pages"
+}
+
+// VerificationThreshold defines the accuracy thresholds for TOC verification.
+type VerificationThreshold struct {
+	Complete    float64 // Accuracy for considering complete (default 1.0)
+	Fixable     float64 // Minimum accuracy to attempt fixing (default 0.6)
+	FallbackMin float64 // Below this, fallback to generation (default 0.6)
+}
+
+// DefaultVerificationThreshold returns the default threshold values.
+func DefaultVerificationThreshold() *VerificationThreshold {
+	return &VerificationThreshold{
+		Complete:    1.0,
+		Fixable:     0.6,
+		FallbackMin: 0.6,
+	}
+}
+
+// EvaluateVerification determines the next action based on verification results.
+// Returns: "complete", "fix", or "fallback"
+func EvaluateVerification(report *VerificationReport, threshold *VerificationThreshold) string {
+	if threshold == nil {
+		threshold = DefaultVerificationThreshold()
+	}
+
+	if report.Accuracy >= threshold.Complete {
+		return "complete"
+	}
+
+	if report.Accuracy >= threshold.Fixable {
+		return "fix"
+	}
+
+	return "fallback"
+}


### PR DESCRIPTION
## Summary
Adds two major features: RLM (Recursive Language Model) mode for structured agentic execution with file-based state persistence, and PageIndex - a PDF processing system ported from Python for TOC detection and verification.

## Changes

### RLM Mode
- Add RLM type definitions and constants (`rlm_types.go`)
- Add StateManager for persisting state to `.ralph/state/` across iterations (`state.go`)
- Add PhaseRouter for RLM phase inference and guidance (`phases.go`)
- Add Verifier for build/test validation before commits (`verify.go`)
- Add RLM prompt builder with context injection (`prompt.go`)
- Detect RLM markers in agent output for phase transitions
- Add RLM-specific output formatting with lipgloss styling
- Integrate RLM mode and verification into main loop
- Add CLI flags: `--rlm`, `--verify`, `--max-depth`

### PageIndex (PDF Processing)
- Port PageIndex system from Python to Go
- Add PDF processing with TOC detection and extraction
- Add Claude LLM provider for intelligent content analysis
- Add markdown generation from PDF structure
- Add tree data structure for representing document hierarchy
- Add token estimation for LLM context management
- Add verification system for TOC quality

### Other
- Add `github.com/google/uuid` dependency for RLM session IDs
- Update CLAUDE.md with RLM mode documentation

## Commits
- `21804f4` feat(loop): add RLM type definitions and constants
- `5ee4a5f` chore(deps): add github.com/google/uuid for RLM session IDs
- `24ce92e` feat(loop): add StateManager for RLM state persistence
- `53f922e` feat(loop): add PhaseRouter for RLM phase inference and guidance
- `33196b7` feat(loop): add Verifier for build/test validation
- `149564c` feat(loop): extend Config with RLM and verification options
- `ef97dcf` feat(loop): add RLM prompt builder with context injection
- `975a755` feat(loop): detect RLM markers in agent output
- `9b07d25` feat(loop): add RLM output formatting
- `1a33b1e` feat(loop): integrate RLM mode and verification into main loop
- `4f5ecf2` feat(cmd): add CLI flags for RLM mode and verification
- `c9411f1` docs: update CLAUDE.md with RLM mode documentation
- `b4dbe69` feat(pageindex): add initial PageIndex port from Python
- `fa898d2` feat(pageindex): add PDF processing with TOC detection and verification
- `94b88f2` feat(pageindex): add Claude LLM provider
- `942ea5c` test(pageindex): add unit tests for core types, tree, and tokens modules

## Breaking Changes
None

## Test Plan
- [ ] Run `task build` to verify the project compiles
- [ ] Run `task test` to verify all tests pass
- [ ] Test RLM mode:
  ```bash
  goralph run --rlm --verify
  ```
- [ ] Test verification standalone:
  ```bash
  goralph run --verify
  ```
- [ ] Verify state files are created in `.ralph/state/` when using RLM mode

## Release Notes
### RLM Mode
Users can now run goralph in RLM (Recursive Language Model) mode with `--rlm` flag. RLM mode persists state to files between iterations, enabling:
- Phase-based execution: PLAN → SEARCH → NARROW → ACT → VERIFY
- Context preservation across iterations via `.ralph/state/` directory
- Optional build/test verification with `--verify` flag before commits
- Configurable recursion depth with `--max-depth` flag

### PageIndex
New internal PageIndex package provides PDF processing capabilities including table of contents extraction, document hierarchy analysis, and LLM-powered content understanding.

## Checklist
- [ ] Tests pass locally (`task test`)
- [ ] Build succeeds (`task build`)
- [ ] Documentation updated (CLAUDE.md)
- [ ] Conventional commit format followed