### PR TITLE
docs(config): add LM Studio provider recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
   <img src="assets/img/qi-logo.png" alt="qi logo" width="200" />
 </p>
 
-A local-first knowledge search CLI for macOS and Linux. Index your documents and search them using BM25 full-text search, vector embeddings, and LLM-powered Q&A.
-Choose your own models via Ollama, LM Studio, llama.cpp, MLX or using OpenAI's cloud models.
+A local-first knowledge search CLI for macOS and Linux. Index and search anything — codebases, documentation, research papers, notes, wikis, datasets, logs, contracts, books — using BM25 full-text search, vector embeddings, and LLM-powered Q&A. Choose your own models via Ollama, LM Studio, llama.cpp, MLX or using OpenAI's cloud models.
 
 ## Features
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,17 @@ embedding:
   dimension: 768            # match the model you loaded
 ```
 
+_LM Studio_ (local, free):
+```yaml
+embedding:
+  name: lmstudio
+  base_url: http://localhost:1234
+  model: nomic-ai/nomic-embed-text-v1.5-GGUF   # must match model loaded in LM Studio
+  dimension: 768                                 # match the model you loaded
+```
+
+Load an embedding model in LM Studio (Models → Search → load), then start the local server (Local Server tab). The model field must match the identifier shown in LM Studio exactly.
+
 _OpenAI_ (cloud, requires API key):
 ```yaml
 embedding:
@@ -181,6 +192,16 @@ generation:
   base_url: http://localhost:8080
   model: llama3.2   # informational only
 ```
+
+_LM Studio_ (local, free):
+```yaml
+generation:
+  name: lmstudio
+  base_url: http://localhost:1234
+  model: google/gemma-4-26b-a4b   # must match model loaded in LM Studio
+```
+
+Load a chat model in LM Studio and start the local server (Local Server tab). The model field must match the identifier shown in LM Studio exactly.
 
 _OpenAI_ (cloud, requires API key):
 ```yaml


### PR DESCRIPTION
## Summary
Documents LM Studio as a supported local provider for both embedding and generation, and expands the README description with concrete indexable content examples.

## Changes
- Added LM Studio embedding recipe (`http://localhost:1234`, OpenAI-compatible, no API key required)
- Added LM Studio generation recipe with the same server setup
- Each recipe includes a note on loading the correct model in LM Studio and starting the local server
- Condensed README description into one line with a broader list of indexable content types

## Breaking Changes
None

## Test Plan
- [ ] Verify docs render correctly on GitHub
- [ ] Confirm example YAML snippets are syntactically valid

## Release Notes
LM Studio is now documented as a first-class local provider option for both embedding and generation. Users can configure it at `http://localhost:1234` with any model loaded in the LM Studio local server, no API key required.

## Checklist
- [x] Documentation updated
- [x] Conventional commit format followed
- [x] No code changes — docs only