### PR TITLE
fix(indexer): skip common VCS/tool/build dirs by default

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -19,6 +19,20 @@ import (
 	"github.com/itsmostafa/qi/internal/parser"
 )
 
+// defaultIgnoreDirs are skipped unconditionally (common VCS/tool/build directories).
+var defaultIgnoreDirs = map[string]bool{
+	".git": true, ".hg": true, ".svn": true,
+	".venv": true, "venv": true, ".env": true,
+	"node_modules": true,
+	"vendor": true,
+	".tox": true, ".mypy_cache": true, ".pytest_cache": true, "__pycache__": true,
+	".ruff_cache": true, ".hypothesis": true,
+	"target": true,        // Rust/Java/Maven
+	"dist": true, "build": true, "out": true,
+	".gradle": true, ".idea": true, ".vscode": true,
+	".DS_Store": true,
+}
+
 // defaultExtensions are indexed when a collection doesn't specify extensions.
 var defaultExtensions = map[string]bool{
 	".md": true, ".markdown": true,
@@ -81,7 +95,7 @@ func (idx *Indexer) Index(ctx context.Context, col config.Collection) (Stats, er
 			return err
 		}
 		if d.IsDir() {
-			if ignoreSet[d.Name()] {
+			if defaultIgnoreDirs[d.Name()] || ignoreSet[d.Name()] {
 				return filepath.SkipDir
 			}
 			return nil


### PR DESCRIPTION
## Summary
Adds a built-in `defaultIgnoreDirs` set to the indexer so common noise directories are skipped unconditionally, without requiring users to configure them in every collection.

## Changes
- Add `defaultIgnoreDirs` map covering common VCS, Python, Node, Rust/Java, IDE, and build directories
- Apply `defaultIgnoreDirs` check alongside the user-defined `ignoreSet` during directory traversal

## Breaking Changes
None — user-defined ignore lists continue to work on top of the new defaults.

## Test Plan
- [ ] Run `task check` to verify build, tests, and vet pass
- [ ] Index a project that contains `node_modules`, `.git`, or `vendor` and confirm they are not indexed
- [ ] Confirm user-configured `ignore` entries in a collection still take effect

## Related Issues
None

## Release Notes
The indexer now automatically skips common directories (`.git`, `node_modules`, `vendor`, `dist`, `build`, `.venv`, etc.) without any configuration. This prevents accidental indexing of dependencies, build artifacts, and VCS metadata.

## Checklist
- [x] Conventional commit format followed
- [x] No breaking changes
- [ ] Tests pass locally (`task check`)