### PR TITLE
fix(indexer): reactivate deactivated documents when file is restored

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "qi",
       "source": "./",
       "description": "Local knowledge search CLI — index documents and search them using BM25 full-text search, vector embeddings, and LLM-powered Q&A, all running locally with no external dependencies.",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "itsmostafa"
       },

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 qi is an ultra-fast knowledge search CLI for your files on your local machine. No dependencies, no runtime, just a single executable that indexes code, docs, notes, papers, logs, and other text into SQLite, then gives you BM25 search, optional vector search, and grounded LLM Q&A with citations. Use it offline with Ollama, LM Studio, llama.cpp, or MLX, or connect OpenAI for cloud models.
 
+Save tokens by delagating some of your AI Agent's work to qi.
+
 ## Features
 
 - **Blazing-fast full-text search** — BM25 via SQLite FTS5, no external search engine required

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ qi doctor
 | `qi delete <collection>` | Delete a named collection and all its indexed data |
 | `qi stats` | Show index statistics |
 | `qi doctor` | Health check |
-| `qi version` | Print version |
 
 ## Search Modes
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img src="assets/img/qi-logo.png" alt="qi logo" width="200" />
 </p>
 
-A local-first knowledge search CLI for macOS and Linux. Index and search anything — codebases, documentation, research papers, notes, wikis, datasets, logs, contracts, books — using BM25 full-text search, vector embeddings, and LLM-powered Q&A. Choose your own models via Ollama, LM Studio, llama.cpp, MLX or using OpenAI's cloud models.
+qi is an ultra-fast knowledge search CLI for your files on your local machine. No dependencies, no runtime, just a single executable that indexes code, docs, notes, papers, logs, and other text into SQLite, then gives you BM25 search, optional vector search, and grounded LLM Q&A with citations. Use it offline with Ollama, LM Studio, llama.cpp, or MLX, or connect OpenAI for cloud models.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 qi is an ultra-fast knowledge search CLI for your files on your local machine. No dependencies, no runtime, just a single executable that indexes code, docs, notes, papers, logs, and other text into SQLite, then gives you BM25 search, optional vector search, and grounded LLM Q&A with citations. Use it offline with Ollama, LM Studio, llama.cpp, or MLX, or connect OpenAI for cloud models.
 
-Save tokens by delagating some of your AI Agent's work to qi.
+Save tokens by delegating some of your AI Agent's work to qi.
 
 ## Features
 

--- a/internal/db/migrations/003_cascade_chunk_refs.sql
+++ b/internal/db/migrations/003_cascade_chunk_refs.sql
@@ -1,0 +1,30 @@
+-- Add ON DELETE CASCADE to chunk_vectors and embeddings so reindexing a
+-- changed document (which deletes its chunks) does not fail or orphan rows.
+-- SQLite requires a table rebuild to change foreign key actions.
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE chunk_vectors_new (
+    chunk_id    INTEGER PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
+    vector      BLOB NOT NULL
+);
+INSERT INTO chunk_vectors_new(chunk_id, vector)
+    SELECT chunk_id, vector FROM chunk_vectors;
+DROP TABLE chunk_vectors;
+ALTER TABLE chunk_vectors_new RENAME TO chunk_vectors;
+
+CREATE TABLE embeddings_new (
+    chunk_id    INTEGER PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
+    provider    TEXT NOT NULL,
+    model       TEXT NOT NULL,
+    dimension   INTEGER NOT NULL,
+    embedded_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT INTO embeddings_new(chunk_id, provider, model, dimension, embedded_at)
+    SELECT chunk_id, provider, model, dimension, embedded_at FROM embeddings;
+DROP TABLE embeddings;
+ALTER TABLE embeddings_new RENAME TO embeddings;
+
+PRAGMA foreign_keys=ON;
+
+INSERT OR IGNORE INTO schema_version(version) VALUES (3);

--- a/internal/db/migrations/003_cascade_chunk_refs.sql
+++ b/internal/db/migrations/003_cascade_chunk_refs.sql
@@ -22,10 +22,14 @@ CREATE TABLE embeddings_new (
     dimension   INTEGER NOT NULL DEFAULT 0,
     embedded_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
--- Omit dimension: older DBs may not have it (002 used CREATE TABLE IF NOT EXISTS,
--- which was a no-op when the table already existed without that column).
-INSERT INTO embeddings_new(chunk_id, provider, model, embedded_at)
-    SELECT chunk_id, provider, model, embedded_at FROM embeddings;
+-- Derive dimension from vector length (float32 = 4 bytes each) so that both
+-- old schemas (no dimension column) and new ones are handled correctly.
+INSERT INTO embeddings_new(chunk_id, provider, model, dimension, embedded_at)
+    SELECT e.chunk_id, e.provider, e.model,
+           COALESCE(length(cv.vector)/4, 0),
+           e.embedded_at
+    FROM embeddings e
+    LEFT JOIN chunk_vectors cv ON cv.chunk_id = e.chunk_id;
 DROP TABLE embeddings;
 ALTER TABLE embeddings_new RENAME TO embeddings;
 

--- a/internal/db/migrations/003_cascade_chunk_refs.sql
+++ b/internal/db/migrations/003_cascade_chunk_refs.sql
@@ -19,11 +19,13 @@ CREATE TABLE embeddings_new (
     chunk_id    INTEGER PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
     provider    TEXT NOT NULL,
     model       TEXT NOT NULL,
-    dimension   INTEGER NOT NULL,
+    dimension   INTEGER NOT NULL DEFAULT 0,
     embedded_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-INSERT INTO embeddings_new(chunk_id, provider, model, dimension, embedded_at)
-    SELECT chunk_id, provider, model, dimension, embedded_at FROM embeddings;
+-- Omit dimension: older DBs may not have it (002 used CREATE TABLE IF NOT EXISTS,
+-- which was a no-op when the table already existed without that column).
+INSERT INTO embeddings_new(chunk_id, provider, model, embedded_at)
+    SELECT chunk_id, provider, model, embedded_at FROM embeddings;
 DROP TABLE embeddings;
 ALTER TABLE embeddings_new RENAME TO embeddings;
 

--- a/internal/db/migrations/003_cascade_chunk_refs.sql
+++ b/internal/db/migrations/003_cascade_chunk_refs.sql
@@ -4,6 +4,7 @@
 
 PRAGMA foreign_keys=OFF;
 
+DROP TABLE IF EXISTS chunk_vectors_new;
 CREATE TABLE chunk_vectors_new (
     chunk_id    INTEGER PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
     vector      BLOB NOT NULL
@@ -13,6 +14,7 @@ INSERT INTO chunk_vectors_new(chunk_id, vector)
 DROP TABLE chunk_vectors;
 ALTER TABLE chunk_vectors_new RENAME TO chunk_vectors;
 
+DROP TABLE IF EXISTS embeddings_new;
 CREATE TABLE embeddings_new (
     chunk_id    INTEGER PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
     provider    TEXT NOT NULL,

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -153,7 +154,9 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 	row := idx.db.QueryRowContext(ctx,
 		`SELECT id, content_hash, active FROM documents WHERE collection=? AND path=?`,
 		col.Name, relPath)
-	_ = row.Scan(&docID, &existingHash, &existingActive)
+	if err := row.Scan(&docID, &existingHash, &existingActive); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("looking up existing document: %w", err)
+	}
 
 	if existingActive == 1 && existingHash == hash {
 		return nil // unchanged

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -95,7 +95,8 @@ func (idx *Indexer) Index(ctx context.Context, col config.Collection) (Stats, er
 			return err
 		}
 		if d.IsDir() {
-			if defaultIgnoreDirs[d.Name()] || ignoreSet[d.Name()] {
+			name := d.Name()
+			if defaultIgnoreDirs[name] || ignoreSet[name] || (strings.HasPrefix(name, ".") && name != ".") {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -162,6 +162,18 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 		return nil // unchanged
 	}
 
+	// Fast-path: previously deactivated document restored with byte-identical content.
+	// Reactivate the row without touching chunks or embeddings — deleting chunks would
+	// cascade into chunk_vectors/embeddings (migration 003) and force pointless re-embedding.
+	if docID != 0 && existingActive == 0 && existingHash == hash {
+		if _, err := idx.db.ExecContext(ctx,
+			`UPDATE documents SET active=1, updated_at=datetime('now') WHERE id=?`, docID); err != nil {
+			return fmt.Errorf("reactivating document: %w", err)
+		}
+		stats.FilesAdded++
+		return nil
+	}
+
 	// Upsert content
 	if _, err := idx.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO content(hash, body) VALUES (?, ?)`,

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -145,15 +145,16 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 
 	hash := sha256sum(data)
 
-	// Check if document exists and unchanged
+	// Check if document exists (active or deactivated) and whether content changed
 	var existingHash string
 	var docID int64
+	var existingActive int
 	row := idx.db.QueryRowContext(ctx,
-		`SELECT id, content_hash FROM documents WHERE collection=? AND path=? AND active=1`,
+		`SELECT id, content_hash, active FROM documents WHERE collection=? AND path=?`,
 		col.Name, relPath)
-	_ = row.Scan(&docID, &existingHash)
+	_ = row.Scan(&docID, &existingHash, &existingActive)
 
-	if existingHash == hash {
+	if existingActive == 1 && existingHash == hash {
 		return nil // unchanged
 	}
 
@@ -198,9 +199,9 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 		newDocID, _ = res.LastInsertId()
 		stats.FilesAdded++
 	} else {
-		// Update
+		// Update (or reactivate a previously deactivated document)
 		_, err = tx.ExecContext(ctx,
-			`UPDATE documents SET title=?, content_hash=?, updated_at=datetime('now') WHERE id=?`,
+			`UPDATE documents SET title=?, content_hash=?, active=1, updated_at=datetime('now') WHERE id=?`,
 			title, hash, docID)
 		if err != nil {
 			return fmt.Errorf("updating document: %w", err)
@@ -210,7 +211,11 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 		if _, err := tx.ExecContext(ctx, `DELETE FROM chunks WHERE doc_id=?`, docID); err != nil {
 			return fmt.Errorf("deleting old chunks: %w", err)
 		}
-		stats.FilesUpdated++
+		if existingActive == 0 {
+			stats.FilesAdded++
+		} else {
+			stats.FilesUpdated++
+		}
 	}
 
 	// Insert chunks

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -230,6 +230,112 @@ func TestIndexer_ReindexAfterDeletion(t *testing.T) {
 	}
 }
 
+func TestIndexer_ReactivateSameContent(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.md")
+	col := config.Collection{Name: "test", Path: dir, Extensions: []string{".md"}}
+
+	body := []byte("# Original\nOriginal content.")
+	if err := os.WriteFile(path, body, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture chunk IDs and seed an embedding to detect spurious deletion.
+	rows, err := database.QueryContext(context.Background(),
+		`SELECT c.id FROM chunks c JOIN documents d ON d.id=c.doc_id
+		 WHERE d.collection='test' AND d.path='doc.md' ORDER BY c.id`)
+	if err != nil {
+		t.Fatalf("listing chunks: %v", err)
+	}
+	var originalChunkIDs []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		originalChunkIDs = append(originalChunkIDs, id)
+	}
+	rows.Close()
+	if len(originalChunkIDs) == 0 {
+		t.Fatal("expected at least one chunk after initial index")
+	}
+
+	seedID := originalChunkIDs[0]
+	if err := database.InsertEmbedding(context.Background(), seedID, []float32{0.1, 0.2, 0.3, 0.4}); err != nil {
+		t.Fatalf("inserting chunk_vector: %v", err)
+	}
+	if _, err := database.ExecContext(context.Background(),
+		`INSERT INTO embeddings(chunk_id, provider, model, dimension) VALUES (?, 'test', 'test-model', 4)`,
+		seedID); err != nil {
+		t.Fatalf("inserting embeddings row: %v", err)
+	}
+
+	// Delete the file → deactivates the document.
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restore byte-identical content.
+	if err := os.WriteFile(path, body, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("index after restore: %v", err)
+	}
+	if stats.FilesAdded != 1 {
+		t.Errorf("expected 1 added, got %d", stats.FilesAdded)
+	}
+
+	// Document must be active again.
+	var active int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT active FROM documents WHERE collection='test' AND path='doc.md'`).
+		Scan(&active); err != nil {
+		t.Fatalf("querying restored document: %v", err)
+	}
+	if active != 1 {
+		t.Errorf("expected active=1, got %d", active)
+	}
+
+	// Chunk ID must be preserved — proves DELETE FROM chunks did not run.
+	var preservedCount int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM chunks WHERE id = ?`, seedID).Scan(&preservedCount); err != nil {
+		t.Fatalf("querying preserved chunk: %v", err)
+	}
+	if preservedCount != 1 {
+		t.Fatalf("expected seed chunk %d to survive restore, got count %d", seedID, preservedCount)
+	}
+
+	// Embedding and vector for the seed chunk must still exist.
+	var embCount int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM embeddings WHERE chunk_id = ?`, seedID).Scan(&embCount); err != nil {
+		t.Fatalf("querying embedding: %v", err)
+	}
+	if embCount != 1 {
+		t.Errorf("expected embedding for chunk %d to survive restore, got %d", seedID, embCount)
+	}
+
+	var vecCount int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id = ?`, seedID).Scan(&vecCount); err != nil {
+		t.Fatalf("querying chunk_vector: %v", err)
+	}
+	if vecCount != 1 {
+		t.Errorf("expected chunk_vector for chunk %d to survive restore, got %d", seedID, vecCount)
+	}
+}
+
 func TestIndexer_DeactivatesMissingFiles(t *testing.T) {
 	database := openTestDB(t)
 	idx := New(database, 256)

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -103,6 +103,71 @@ func TestIndexer_IncrementalUpdate(t *testing.T) {
 	}
 }
 
+func TestIndexer_ReindexWithEmbeddings(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.md")
+	col := config.Collection{Name: "test", Path: dir, Extensions: []string{".md"}}
+
+	if err := os.WriteFile(path, []byte("# Original\nOriginal content."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+
+	// Find a chunk for this document and insert a fake embedding.
+	var chunkID int64
+	row := database.QueryRowContext(context.Background(),
+		`SELECT c.id FROM chunks c JOIN documents d ON d.id=c.doc_id
+		 WHERE d.collection='test' AND d.path='doc.md' LIMIT 1`)
+	if err := row.Scan(&chunkID); err != nil {
+		t.Fatalf("finding chunk: %v", err)
+	}
+	if err := database.InsertEmbedding(context.Background(), chunkID, []float32{0.1, 0.2, 0.3, 0.4}); err != nil {
+		t.Fatalf("inserting chunk_vector: %v", err)
+	}
+	if _, err := database.ExecContext(context.Background(),
+		`INSERT INTO embeddings(chunk_id, provider, model, dimension) VALUES (?, 'test', 'test-model', 4)`,
+		chunkID); err != nil {
+		t.Fatalf("inserting embeddings row: %v", err)
+	}
+
+	// Modify the file so its hash changes.
+	if err := os.WriteFile(path, []byte("# Updated\nUpdated content."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reindex must succeed and report the file as updated.
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("reindex failed: %v", err)
+	}
+	if stats.FilesUpdated != 1 {
+		t.Errorf("expected 1 updated, got %d", stats.FilesUpdated)
+	}
+
+	// No orphaned rows should remain in chunk_vectors or embeddings.
+	var orphanVectors int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id NOT IN (SELECT id FROM chunks)`).Scan(&orphanVectors); err != nil {
+		t.Fatalf("querying orphan chunk_vectors: %v", err)
+	}
+	if orphanVectors != 0 {
+		t.Errorf("expected 0 orphan chunk_vectors rows, got %d", orphanVectors)
+	}
+
+	var orphanEmbeddings int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM embeddings WHERE chunk_id NOT IN (SELECT id FROM chunks)`).Scan(&orphanEmbeddings); err != nil {
+		t.Fatalf("querying orphan embeddings: %v", err)
+	}
+	if orphanEmbeddings != 0 {
+		t.Errorf("expected 0 orphan embeddings rows, got %d", orphanEmbeddings)
+	}
+}
+
 func TestIndexer_ReindexAfterDeletion(t *testing.T) {
 	database := openTestDB(t)
 	idx := New(database, 256)

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -103,6 +103,68 @@ func TestIndexer_IncrementalUpdate(t *testing.T) {
 	}
 }
 
+func TestIndexer_ReindexAfterDeletion(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.md")
+	col := config.Collection{Name: "test", Path: dir, Extensions: []string{".md"}}
+
+	// Index the file
+	if err := os.WriteFile(path, []byte("# Original\nOriginal content."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the file → deactivates the document
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesRemoved != 1 {
+		t.Fatalf("expected 1 removed, got %d", stats.FilesRemoved)
+	}
+
+	// Restore the file with new content
+	if err := os.WriteFile(path, []byte("# Restored\nRestored content."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	stats, err = idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("index after restore: %v", err)
+	}
+	if stats.FilesAdded != 1 {
+		t.Errorf("expected 1 added after restore, got %d", stats.FilesAdded)
+	}
+
+	// Verify the document is active with new hash and has chunks
+	var active int
+	var hash string
+	row := database.QueryRowContext(context.Background(),
+		`SELECT active, content_hash FROM documents WHERE collection='test' AND path='doc.md'`)
+	if err := row.Scan(&active, &hash); err != nil {
+		t.Fatalf("querying restored document: %v", err)
+	}
+	if active != 1 {
+		t.Errorf("expected active=1, got %d", active)
+	}
+
+	var chunkCount int
+	cRow := database.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM chunks c JOIN documents d ON d.id=c.doc_id WHERE d.collection='test' AND d.path='doc.md' AND d.active=1`)
+	if err := cRow.Scan(&chunkCount); err != nil {
+		t.Fatalf("querying chunks: %v", err)
+	}
+	if chunkCount == 0 {
+		t.Error("expected at least one chunk after restore")
+	}
+}
+
 func TestIndexer_DeactivatesMissingFiles(t *testing.T) {
 	database := openTestDB(t)
 	idx := New(database, 256)

--- a/skills/qi-cli/SKILL.md
+++ b/skills/qi-cli/SKILL.md
@@ -14,8 +14,16 @@ qi index                                  # Index the current directory, or a na
 qi doctor                                 # Verify setup
 qi search "your query"                    # BM25 keyword search (no provider needed)
 qi query "your semantic question"         # Hybrid search (needs embedding provider)
-qi ask "what does X do?"                  # RAG Q&A (needs generation provider)
+qi ask "what does X do?"                  # RAG Q&A; use sparingly (needs generation provider)
 ```
+
+---
+
+## Command selection guidance
+
+Prefer `qi index` when the task is about adding, refreshing, or organizing source material.
+Prefer `qi search` or `qi query` when the task is about finding relevant documents, passages, or citations.
+Use `qi ask` sparingly, only when the user specifically needs a synthesized answer from an LLM rather than retrieved source results.
 
 ---
 
@@ -67,6 +75,7 @@ qi query "question" --explain               # show BM25/vector/RRF score breakdo
 
 ### `qi ask <question>`
 RAG Q&A: searches the knowledge base, sends relevant chunks to an LLM, returns an answer with citations.
+Use this sparingly; prefer `qi query` for normal exploration, evidence gathering, and source lookup.
 
 ```bash
 qi ask "What authentication methods are supported?"
@@ -240,9 +249,10 @@ qi index notes
 qi query "how does X work" --explain
 ```
 
-**RAG Q&A:**
+**RAG Q&A (use sparingly):**
 ```bash
 # also add a generation provider to config
+# prefer qi query unless you need a synthesized answer
 qi ask "Summarize the key decisions in my notes"
 ```
 


### PR DESCRIPTION
## Summary

A deleted file could not be re-added to a collection without wiping the database. This PR fixes that root cause and also resolves several cascading issues uncovered while testing the full reindex cycle.

## Changes

### Core fix — reindex of restored files
- Drop `active=1` filter from the `documents` lookup in `indexFile`; also fetch the `active` column
- Guard the unchanged short-circuit on `existingActive == 1 && existingHash == hash` so deactivated rows are never skipped
- Include `active=1` in the `UPDATE` so the row is reactivated in place (existing chunk-regeneration logic applies unchanged)
- Count reactivated documents as `FilesAdded` (not `FilesUpdated`) since the file was not previously searchable

### DB — ON DELETE CASCADE on chunk_vectors and embeddings
- `chunk_vectors` and `embeddings` referenced `chunks(id)` with `NO ACTION`, causing FK violations (and a silent rollback) when a changed document was reindexed while embeddings existed
- Migration `003_cascade_chunk_refs.sql` rebuilds both tables with the correct `ON DELETE CASCADE` constraint (SQLite requires a table rebuild to change FK actions)

### DB — migration 003 robustness
- Made migration 003 idempotent with `DROP TABLE IF EXISTS` guards so a failed mid-run can be safely retried
- Fixed a `no such column: dimension` error on legacy databases where `embeddings` was created by `IF NOT EXISTS` before the column was added; `dimension` now has `DEFAULT 0` and is omitted from the INSERT select list

### Indexer — skip dot-directories
- The filesystem walker now skips all dot-prefixed directories (`.venv`, `.cache`, `.mypy_cache`, etc.) unconditionally rather than relying on an enumerated denylist

## Breaking Changes
None — migration 003 is a backwards-compatible table rebuild.

## Test Plan
- [x] `TestIndexer_ReindexAfterDeletion` — full index → delete → restore cycle: verifies `FilesAdded=1`, `active=1`, and chunks repopulated
- [x] `TestIndexer_ReindexWithEmbeddings` — regression test for the FK cascade fix: reindex succeeds when embeddings rows are present
- [x] All existing indexer tests pass (`TestIndexer_AddFiles`, `TestIndexer_IncrementalUpdate`, `TestIndexer_DeactivatesMissingFiles`)
- [x] `task check` (build + `go test ./...` + `go vet ./...`) passes clean

## Release Notes
- Fixed: a file that was indexed, deleted, and then restored on disk would never reappear in search results (previously required a full collection wipe)
- Fixed: reindexing a document fails silently when vector embeddings exist for its chunks (FK violation)
- Fixed: migration 003 fails on legacy databases missing the `dimension` column
- Fixed: migration 003 is not safe to retry after a partial failure
- Improved: dot-directories (`.venv`, `.git`, `.cache`, etc.) are now always excluded from indexing