### PR TITLE
docs(readme): add explicit URL to brew tap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Save tokens by delegating some of your AI Agent's work to qi.
 ## Install
 
 ```sh
-brew tap itsmostafa/qi
+brew tap itsmostafa/qi https://github.com/itsmostafa/qi
 brew install qi
 ```
 


### PR DESCRIPTION
## Summary
Updates the `brew tap` install command in the README to include the full GitHub URL, ensuring the tap source is explicit and unambiguous for users in fresh shell environments.

## Changes
- Added full GitHub URL to `brew tap itsmostafa/qi` → `brew tap itsmostafa/qi https://github.com/itsmostafa/qi`

## Breaking Changes
None

## Test Plan
- [ ] Verify `brew tap itsmostafa/qi https://github.com/itsmostafa/qi` works in a fresh shell
- [ ] Verify README renders correctly on GitHub

## Related Issues
None

## Release Notes
The Homebrew install instructions now include an explicit tap URL for improved clarity and reliability.

## Checklist
- [x] Documentation updated
- [x] Conventional commit format followed