### PR TITLE
fix(config): restrict config file permissions to owner-only

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -327,7 +327,7 @@ func writeConfigNode(configPath string, doc *yaml.Node) error {
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	return os.WriteFile(configPath, out, 0644)
+	return os.WriteFile(configPath, out, 0o600)
 }
 
 func (c *Config) validate() error {


### PR DESCRIPTION
## Summary
Config files written by qi could contain plaintext API keys (for embedding or generation providers) but were created world-readable (`0644`), allowing any local user on a shared system to read them.

## Changes
- `internal/config/config.go`: change `writeConfigNode` to use `0o600` instead of `0644`

## Breaking Changes
None. Users with existing config files should manually tighten permissions on their current file:
```sh
chmod 600 ~/.config/qi/config.yaml
```

## Test Plan
- [x] `task check` passes (build, vet, tests)
- [ ] Verify new config writes are `0600`: run `qi index` after the fix and confirm `ls -l ~/.config/qi/config.yaml` shows `-rw-------`

## Related Issues
None

## Release Notes
Fixed a security issue where the qi config file (which may contain API keys) was written with world-readable permissions (`0644`). The file is now written with `0600` (owner read/write only). Users should also manually update permissions on any existing config file: `chmod 600 ~/.config/qi/config.yaml`.

## Checklist
- [x] Tests pass locally (`task check`)
- [x] Linting passes
- [x] Conventional commit format followed
- [x] Breaking changes documented