### PR TITLE
feat(output): add ask result formatter with JSON support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,20 +23,23 @@ Always run `task check` before finishing any code change to ensure all checks pa
 - **Content-addressable storage**: `content` table keyed by SHA-256 hash; `documents` references by hash. Enables deduplication and O(1) change detection.
 - **Break-point chunker**: Scores chunk boundaries by type (heading=100, code fence=80, blank line=20) with distance decay from target size.
 - **Graceful degradation**: Vector search and generation are optional — BM25 always works.
+- **Auto-generated collection names**: Collection names are derived from full path segments (e.g. `~/Projects/tools/qi` → `tools-qi`). The `--name` flag was removed from `index`; use the derived slug or configure an alias. Legacy names are normalized on startup.
+- **Query relaxation**: BM25 search automatically falls back from conjunctive to disjunctive matching for natural-language queries that return zero results.
+- **Auto-embed on index**: When an embedder is configured, chunks are embedded immediately after indexing without a separate step.
 - **Config**: Raw `gopkg.in/yaml.v3`, no viper. `~` expansion + relative path resolution.
 
 ## Package Structure
 
 ```
-cmd/                  Cobra commands (root, init, index, search, query, ask, get, doctor, stats)
+cmd/                  Cobra commands (root, init, index, search, query, ask, get, doctor, stats, list, update)
 internal/
   app/                Wires config + db + services
   config/             Config loading, defaults, path expansion
   db/                 SQLite open/migrate/WAL, embedding blob storage
-    migrations/       Embedded SQL migrations (001_init.sql)
+    migrations/       Embedded SQL migrations (001_init.sql, 002_add_chunk_vectors.sql, 003_cascade_chunk_refs.sql)
   chunker/            Break-point chunker (chunker.Chunker interface)
   indexer/            Filesystem walker, SHA-256 change detection, embedder
-  output/             Text/JSON/Markdown formatters
+  output/             Text/JSON formatters (ask results, generic formatter)
   parser/             Document parsers (Markdown via goldmark, plaintext, source)
   providers/          HTTP adapters for embedding, rerank, generation APIs
   search/             BM25, vector KNN, RRF fusion, hybrid, ask, cache, prompt
@@ -55,7 +58,7 @@ Tests use real in-memory SQLite (no mocking). Provider tests use `httptest.NewSe
 
 ## Adding a New Migration
 
-Add `internal/db/migrations/00N_description.sql` — the runner applies them in alphabetical order.
+Add `internal/db/migrations/00N_description.sql` — the runner applies them in alphabetical order. Current migrations: `001_init.sql`, `002_add_chunk_vectors.sql`, `003_cascade_chunk_refs.sql`.
 
 ## sqlite-vec Note
 

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -37,15 +37,7 @@ var askCmd = &cobra.Command{
 			return fmt.Errorf("ask failed: %w", err)
 		}
 
-		fmt.Fprintln(os.Stdout, result.Answer)
-
-		if len(result.Sources) > 0 {
-			fmt.Fprintln(os.Stdout)
-			fmt.Fprintln(os.Stdout, "Sources:")
-			formatter := output.New(format)
-			return formatter.WriteResults(os.Stdout, result.Sources)
-		}
-		return nil
+		return output.WriteAskResult(os.Stdout, result.Answer, result.Sources, a.Config.Collections, format)
 	},
 }
 

--- a/internal/output/ask.go
+++ b/internal/output/ask.go
@@ -15,6 +15,7 @@ import (
 // AskSource is a compact source reference for generated answers.
 type AskSource struct {
 	Index        int    `json:"index"`
+	Indices      []int  `json:"indices"`
 	Title        string `json:"title"`
 	Path         string `json:"path"`
 	Collection   string `json:"collection"`
@@ -35,6 +36,14 @@ func WriteAskResult(w io.Writer, answer string, results []search.Result, collect
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		return enc.Encode(AskOutput{Answer: answer, Sources: sources})
+	case "markdown", "md":
+		fmt.Fprintln(w, answer)
+		if len(sources) == 0 {
+			return nil
+		}
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "## Sources")
+		return WriteAskSourcesMarkdown(w, sources)
 	default:
 		fmt.Fprintln(w, answer)
 		if len(sources) == 0 {
@@ -49,15 +58,17 @@ func WriteAskResult(w io.Writer, answer string, results []search.Result, collect
 // CompactAskSources converts chunk-level search hits into document-level source rows.
 func CompactAskSources(results []search.Result, collections []config.Collection) []AskSource {
 	bases := collectionPathBases(collections)
-	seen := map[string]bool{}
+	sourceByKey := map[string]int{}
 	sources := make([]AskSource, 0, len(results))
 
-	for _, r := range results {
+	for i, r := range results {
+		promptIndex := i + 1
 		key := r.Collection + "\x00" + r.Path
-		if seen[key] {
+		if sourceIndex, ok := sourceByKey[key]; ok {
+			sources[sourceIndex].Indices = append(sources[sourceIndex].Indices, promptIndex)
 			continue
 		}
-		seen[key] = true
+		sourceByKey[key] = len(sources)
 
 		title := strings.TrimSpace(r.Title)
 		if title == "" {
@@ -65,7 +76,8 @@ func CompactAskSources(results []search.Result, collections []config.Collection)
 		}
 
 		source := AskSource{
-			Index:        len(sources) + 1,
+			Index:        promptIndex,
+			Indices:      []int{promptIndex},
 			Title:        title,
 			Path:         displaySourcePath(r, bases),
 			Collection:   r.Collection,
@@ -80,10 +92,32 @@ func CompactAskSources(results []search.Result, collections []config.Collection)
 // WriteAskSources writes compact source rows.
 func WriteAskSources(w io.Writer, sources []AskSource) error {
 	for _, source := range sources {
-		fmt.Fprintf(w, "[%d] %s\n", source.Index, source.Title)
+		fmt.Fprintf(w, "%s %s\n", formatSourceIndices(source), source.Title)
 		fmt.Fprintf(w, "    %s\n", source.Path)
 	}
 	return nil
+}
+
+// WriteAskSourcesMarkdown writes compact source rows as Markdown.
+func WriteAskSourcesMarkdown(w io.Writer, sources []AskSource) error {
+	for _, source := range sources {
+		fmt.Fprintf(w, "- %s **%s**\n", formatSourceIndices(source), source.Title)
+		fmt.Fprintf(w, "  `%s`\n", source.Path)
+	}
+	return nil
+}
+
+func formatSourceIndices(source AskSource) string {
+	indices := source.Indices
+	if len(indices) == 0 {
+		indices = []int{source.Index}
+	}
+
+	parts := make([]string, 0, len(indices))
+	for _, index := range indices {
+		parts = append(parts, fmt.Sprintf("%d", index))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
 }
 
 func collectionPathBases(collections []config.Collection) map[string]string {

--- a/internal/output/ask.go
+++ b/internal/output/ask.go
@@ -1,0 +1,123 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/itsmostafa/qi/internal/config"
+	"github.com/itsmostafa/qi/internal/search"
+)
+
+// AskSource is a compact source reference for generated answers.
+type AskSource struct {
+	Index        int    `json:"index"`
+	Title        string `json:"title"`
+	Path         string `json:"path"`
+	Collection   string `json:"collection"`
+	RelativePath string `json:"relative_path"`
+}
+
+// AskOutput is the structured JSON shape for qi ask.
+type AskOutput struct {
+	Answer  string      `json:"answer"`
+	Sources []AskSource `json:"sources"`
+}
+
+// WriteAskResult writes a generated answer and compact, deduplicated sources.
+func WriteAskResult(w io.Writer, answer string, results []search.Result, collections []config.Collection, format string) error {
+	sources := CompactAskSources(results, collections)
+	switch strings.ToLower(format) {
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(AskOutput{Answer: answer, Sources: sources})
+	default:
+		fmt.Fprintln(w, answer)
+		if len(sources) == 0 {
+			return nil
+		}
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Sources:")
+		return WriteAskSources(w, sources)
+	}
+}
+
+// CompactAskSources converts chunk-level search hits into document-level source rows.
+func CompactAskSources(results []search.Result, collections []config.Collection) []AskSource {
+	bases := collectionPathBases(collections)
+	seen := map[string]bool{}
+	sources := make([]AskSource, 0, len(results))
+
+	for _, r := range results {
+		key := r.Collection + "\x00" + r.Path
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		title := strings.TrimSpace(r.Title)
+		if title == "" {
+			title = r.Path
+		}
+
+		source := AskSource{
+			Index:        len(sources) + 1,
+			Title:        title,
+			Path:         displaySourcePath(r, bases),
+			Collection:   r.Collection,
+			RelativePath: filepath.ToSlash(r.Path),
+		}
+		sources = append(sources, source)
+	}
+
+	return sources
+}
+
+// WriteAskSources writes compact source rows.
+func WriteAskSources(w io.Writer, sources []AskSource) error {
+	for _, source := range sources {
+		fmt.Fprintf(w, "[%d] %s\n", source.Index, source.Title)
+		fmt.Fprintf(w, "    %s\n", source.Path)
+	}
+	return nil
+}
+
+func collectionPathBases(collections []config.Collection) map[string]string {
+	bases := make(map[string]string, len(collections))
+	for _, col := range collections {
+		base := collectionPathBase(col)
+		bases[col.Name] = base
+		if col.OriginalName != "" {
+			bases[col.OriginalName] = base
+		}
+	}
+	return bases
+}
+
+func collectionPathBase(col config.Collection) string {
+	if col.Path == "" {
+		return col.Name
+	}
+	base := filepath.Base(filepath.Clean(col.Path))
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		return col.Name
+	}
+	return base
+}
+
+func displaySourcePath(r search.Result, bases map[string]string) string {
+	base := bases[r.Collection]
+	if base == "" {
+		base = r.Collection
+	}
+	relPath := filepath.ToSlash(r.Path)
+	base = filepath.ToSlash(base)
+	if relPath == "" {
+		return base
+	}
+	return path.Join(base, relPath)
+}

--- a/internal/output/ask_test.go
+++ b/internal/output/ask_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -50,11 +51,17 @@ func TestCompactAskSourcesDeduplicatesAndUsesTreeRelativePaths(t *testing.T) {
 	if got, want := sources[0].Index, 1; got != want {
 		t.Fatalf("first index = %d, want %d", got, want)
 	}
+	if got, want := sources[0].Indices, []int{1, 2}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("first indices = %v, want %v", got, want)
+	}
 	if got, want := sources[0].Path, "qi/README.md"; got != want {
 		t.Fatalf("first path = %q, want %q", got, want)
 	}
-	if got, want := sources[1].Index, 2; got != want {
+	if got, want := sources[1].Index, 3; got != want {
 		t.Fatalf("second index = %d, want %d", got, want)
+	}
+	if got, want := sources[1].Indices, []int{3}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("second indices = %v, want %v", got, want)
 	}
 	if got, want := sources[1].Path, "qi/skills/qi-cli/SKILL.md"; got != want {
 		t.Fatalf("second path = %q, want %q", got, want)
@@ -76,6 +83,14 @@ func TestWriteAskResultTextOmitsSearchDetails(t *testing.T) {
 			Score:       0.0328,
 		},
 		{
+			Collection:  "Projects-tools-qi",
+			Path:        "README.md",
+			Title:       "qi - query engine cli for ai agents and humans",
+			HeadingPath: "Install",
+			Snippet:     "Install <b>qi</b> locally.",
+			Score:       0.0310,
+		},
+		{
 			Collection: "Projects-tools-qi",
 			Path:       "skills/qi-cli/SKILL.md",
 			Title:      "qi-cli",
@@ -85,26 +100,82 @@ func TestWriteAskResultTextOmitsSearchDetails(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := WriteAskResult(&buf, "Using qi saves tokens [1].", results, collections, "text"); err != nil {
+	if err := WriteAskResult(&buf, "Using qi saves tokens [2].", results, collections, "text"); err != nil {
 		t.Fatalf("writing ask result: %v", err)
 	}
 
-	want := `Using qi saves tokens [1].
+	want := `Using qi saves tokens [2].
 
 Sources:
-[1] qi - query engine cli for ai agents and humans
+[1, 2] qi - query engine cli for ai agents and humans
     qi/README.md
-[2] qi-cli
+[3] qi-cli
     qi/skills/qi-cli/SKILL.md
 `
 	if got := buf.String(); got != want {
 		t.Fatalf("unexpected text output:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 
-	for _, forbidden := range []string{"score:", "0.0328", "<b>", "</b>", "qi://", "Search Modes", "Use qi"} {
+	for _, forbidden := range []string{"score:", "0.0328", "<b>", "</b>", "qi://", "Search Modes", "Use qi", "Install qi"} {
 		if strings.Contains(buf.String(), forbidden) {
 			t.Fatalf("output contains search detail %q:\n%s", forbidden, buf.String())
 		}
+	}
+}
+
+func TestWriteAskResultMarkdownFormatsSources(t *testing.T) {
+	collections := []config.Collection{{
+		Name: "Projects-tools-qi",
+		Path: filepath.Join(t.TempDir(), "qi"),
+	}}
+	results := []search.Result{
+		{
+			Collection:  "Projects-tools-qi",
+			Path:        "README.md",
+			Title:       "qi - query engine cli for ai agents and humans",
+			HeadingPath: "Search Modes",
+			Snippet:     "Use <b>qi</b> query --mode hybrid.",
+			Score:       0.0328,
+		},
+		{
+			Collection:  "Projects-tools-qi",
+			Path:        "README.md",
+			Title:       "qi - query engine cli for ai agents and humans",
+			HeadingPath: "Install",
+			Snippet:     "Install <b>qi</b> locally.",
+			Score:       0.0310,
+		},
+		{
+			Collection: "Projects-tools-qi",
+			Path:       "skills/qi-cli/SKILL.md",
+			Title:      "qi-cli",
+			Snippet:    "Prefer <b>qi</b> search.",
+			Score:      0.0263,
+		},
+	}
+
+	want := `Using **qi** saves tokens [2].
+
+## Sources
+- [1, 2] **qi - query engine cli for ai agents and humans**
+  ` + "`qi/README.md`" + `
+- [3] **qi-cli**
+  ` + "`qi/skills/qi-cli/SKILL.md`" + `
+`
+
+	for _, format := range []string{"markdown", "md"} {
+		t.Run(format, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := WriteAskResult(&buf, "Using **qi** saves tokens [2].", results, collections, format); err != nil {
+				t.Fatalf("writing markdown ask result: %v", err)
+			}
+			if got := buf.String(); got != want {
+				t.Fatalf("unexpected markdown output:\ngot:\n%s\nwant:\n%s", got, want)
+			}
+			if strings.Contains(buf.String(), "Sources:") {
+				t.Fatalf("markdown output contains plain text sources header:\n%s", buf.String())
+			}
+		})
 	}
 }
 
@@ -125,14 +196,21 @@ func TestWriteAskResultJSON(t *testing.T) {
 		Name: "Projects-tools-qi",
 		Path: filepath.Join(t.TempDir(), "qi"),
 	}}
-	results := []search.Result{{
-		Collection: "Projects-tools-qi",
-		Path:       "README.md",
-		Title:      "qi - query engine cli for ai agents and humans",
-	}}
+	results := []search.Result{
+		{
+			Collection: "Projects-tools-qi",
+			Path:       "README.md",
+			Title:      "qi - query engine cli for ai agents and humans",
+		},
+		{
+			Collection: "Projects-tools-qi",
+			Path:       "README.md",
+			Title:      "qi - query engine cli for ai agents and humans",
+		},
+	}
 
 	var buf bytes.Buffer
-	if err := WriteAskResult(&buf, "Answer [1].", results, collections, "json"); err != nil {
+	if err := WriteAskResult(&buf, "Answer [2].", results, collections, "json"); err != nil {
 		t.Fatalf("writing json ask result: %v", err)
 	}
 
@@ -140,8 +218,8 @@ func TestWriteAskResultJSON(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshalling json output: %v", err)
 	}
-	if got.Answer != "Answer [1]." {
-		t.Fatalf("answer = %q, want %q", got.Answer, "Answer [1].")
+	if got.Answer != "Answer [2]." {
+		t.Fatalf("answer = %q, want %q", got.Answer, "Answer [2].")
 	}
 	if len(got.Sources) != 1 {
 		t.Fatalf("source count = %d, want 1", len(got.Sources))
@@ -151,5 +229,8 @@ func TestWriteAskResultJSON(t *testing.T) {
 	}
 	if got.Sources[0].RelativePath != "README.md" {
 		t.Fatalf("json relative path = %q, want %q", got.Sources[0].RelativePath, "README.md")
+	}
+	if got, want := got.Sources[0].Indices, []int{1, 2}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("json indices = %v, want %v", got, want)
 	}
 }

--- a/internal/output/ask_test.go
+++ b/internal/output/ask_test.go
@@ -1,0 +1,155 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/itsmostafa/qi/internal/config"
+	"github.com/itsmostafa/qi/internal/search"
+)
+
+func TestCompactAskSourcesDeduplicatesAndUsesTreeRelativePaths(t *testing.T) {
+	collections := []config.Collection{{
+		Name: "Projects-tools-qi",
+		Path: filepath.Join(t.TempDir(), "qi"),
+	}}
+	results := []search.Result{
+		{
+			Collection:  "Projects-tools-qi",
+			Path:        "README.md",
+			Title:       "qi - query engine cli for ai agents and humans",
+			HeadingPath: "Intro",
+			Snippet:     "Save tokens by delegating work to <b>qi</b>.",
+			Score:       0.0328,
+		},
+		{
+			Collection:  "Projects-tools-qi",
+			Path:        "README.md",
+			Title:       "qi - query engine cli for ai agents and humans",
+			HeadingPath: "Install",
+			Snippet:     "/plugin install <b>qi</b>",
+			Score:       0.0310,
+		},
+		{
+			Collection: "Projects-tools-qi",
+			Path:       "skills/qi-cli/SKILL.md",
+			Title:      "qi-cli",
+			Snippet:    "Prefer <b>qi</b> query.",
+			Score:      0.0263,
+		},
+	}
+
+	sources := CompactAskSources(results, collections)
+
+	if got, want := len(sources), 2; got != want {
+		t.Fatalf("source count = %d, want %d", got, want)
+	}
+	if got, want := sources[0].Index, 1; got != want {
+		t.Fatalf("first index = %d, want %d", got, want)
+	}
+	if got, want := sources[0].Path, "qi/README.md"; got != want {
+		t.Fatalf("first path = %q, want %q", got, want)
+	}
+	if got, want := sources[1].Index, 2; got != want {
+		t.Fatalf("second index = %d, want %d", got, want)
+	}
+	if got, want := sources[1].Path, "qi/skills/qi-cli/SKILL.md"; got != want {
+		t.Fatalf("second path = %q, want %q", got, want)
+	}
+}
+
+func TestWriteAskResultTextOmitsSearchDetails(t *testing.T) {
+	collections := []config.Collection{{
+		Name: "Projects-tools-qi",
+		Path: filepath.Join(t.TempDir(), "qi"),
+	}}
+	results := []search.Result{
+		{
+			Collection:  "Projects-tools-qi",
+			Path:        "README.md",
+			Title:       "qi - query engine cli for ai agents and humans",
+			HeadingPath: "Search Modes",
+			Snippet:     "Use <b>qi</b> query --mode hybrid.",
+			Score:       0.0328,
+		},
+		{
+			Collection: "Projects-tools-qi",
+			Path:       "skills/qi-cli/SKILL.md",
+			Title:      "qi-cli",
+			Snippet:    "Prefer <b>qi</b> search.",
+			Score:      0.0263,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteAskResult(&buf, "Using qi saves tokens [1].", results, collections, "text"); err != nil {
+		t.Fatalf("writing ask result: %v", err)
+	}
+
+	want := `Using qi saves tokens [1].
+
+Sources:
+[1] qi - query engine cli for ai agents and humans
+    qi/README.md
+[2] qi-cli
+    qi/skills/qi-cli/SKILL.md
+`
+	if got := buf.String(); got != want {
+		t.Fatalf("unexpected text output:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+
+	for _, forbidden := range []string{"score:", "0.0328", "<b>", "</b>", "qi://", "Search Modes", "Use qi"} {
+		if strings.Contains(buf.String(), forbidden) {
+			t.Fatalf("output contains search detail %q:\n%s", forbidden, buf.String())
+		}
+	}
+}
+
+func TestCompactAskSourcesFallsBackToCollectionName(t *testing.T) {
+	sources := CompactAskSources([]search.Result{{
+		Collection: "notes",
+		Path:       "daily.md",
+		Title:      "Daily Notes",
+	}}, nil)
+
+	if got, want := sources[0].Path, "notes/daily.md"; got != want {
+		t.Fatalf("fallback path = %q, want %q", got, want)
+	}
+}
+
+func TestWriteAskResultJSON(t *testing.T) {
+	collections := []config.Collection{{
+		Name: "Projects-tools-qi",
+		Path: filepath.Join(t.TempDir(), "qi"),
+	}}
+	results := []search.Result{{
+		Collection: "Projects-tools-qi",
+		Path:       "README.md",
+		Title:      "qi - query engine cli for ai agents and humans",
+	}}
+
+	var buf bytes.Buffer
+	if err := WriteAskResult(&buf, "Answer [1].", results, collections, "json"); err != nil {
+		t.Fatalf("writing json ask result: %v", err)
+	}
+
+	var got AskOutput
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshalling json output: %v", err)
+	}
+	if got.Answer != "Answer [1]." {
+		t.Fatalf("answer = %q, want %q", got.Answer, "Answer [1].")
+	}
+	if len(got.Sources) != 1 {
+		t.Fatalf("source count = %d, want 1", len(got.Sources))
+	}
+	if got.Sources[0].Path != "qi/README.md" {
+		t.Fatalf("json source path = %q, want %q", got.Sources[0].Path, "qi/README.md")
+	}
+	if got.Sources[0].RelativePath != "README.md" {
+		t.Fatalf("json relative path = %q, want %q", got.Sources[0].RelativePath, "README.md")
+	}
+}

--- a/internal/search/prompt.go
+++ b/internal/search/prompt.go
@@ -7,8 +7,8 @@ import (
 
 const systemPromptTemplate = `You are a knowledgeable assistant with access to a curated knowledge base.
 Answer the user's question using only the provided context. If the context doesn't contain enough information to answer, say so clearly.
-Cite your sources using the qi:// URIs provided with each context passage.
-Format citations inline like: [qi://collection/path].`
+Cite your sources using the numeric citation marker shown before each context passage.
+Format citations inline like: [1] or [1, 2].`
 
 // BuildPrompt constructs a RAG prompt from search results.
 func BuildPrompt(question string, results []Result) (systemPrompt, userPrompt string) {

--- a/internal/search/prompt_test.go
+++ b/internal/search/prompt_test.go
@@ -1,0 +1,39 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPromptUsesNumberedCitationContract(t *testing.T) {
+	systemPrompt, userPrompt := BuildPrompt("How should citations work?", []Result{
+		{
+			Collection:  "notes",
+			Path:        "guide.md",
+			HeadingPath: "Usage > Citations",
+			Snippet:     "Use citations next to claims.",
+		},
+		{
+			Collection: "docs",
+			Path:       "reference.md",
+			Snippet:    "More citation detail.",
+		},
+	})
+
+	if !strings.Contains(systemPrompt, "numeric citation marker") {
+		t.Fatalf("system prompt does not instruct numbered citations:\n%s", systemPrompt)
+	}
+	if strings.Contains(systemPrompt, "[qi://collection/path]") {
+		t.Fatalf("system prompt still instructs URI-shaped citations:\n%s", systemPrompt)
+	}
+
+	for _, want := range []string{
+		"### [1] qi://notes/guide.md (Usage > Citations)",
+		"### [2] qi://docs/reference.md",
+		"## Question\n\nHow should citations work?",
+	} {
+		if !strings.Contains(userPrompt, want) {
+			t.Fatalf("user prompt missing %q:\n%s", want, userPrompt)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Adds a dedicated `WriteAskResult` formatter for the `ask` command that deduplicates chunk-level search hits into document-level source rows, shows tree-relative paths prefixed with the collection folder name, and adds JSON output format support.

## Commits
- `d35ced9` feat(output): add ask result formatter with JSON support
- `482f460` test(output): add tests for ask result formatter

## Changes
- Added `internal/output/ask.go` with `WriteAskResult`, `CompactAskSources`, and `WriteAskSources` functions
- `CompactAskSources` deduplicates multiple chunks from the same document into a single source entry
- Source paths display as `<collection-folder>/<relative-path>` using the collection's configured path base
- JSON format emits a typed `AskOutput` struct with `answer` and `sources` array
- `cmd/ask.go` wired to use the new formatter (passes collection config for path resolution)

## Breaking Changes
None — output format for text mode is equivalent to before, with the added benefit of deduplication and cleaner paths.

## Test Plan
- [x] `task check` passes (build + tests + vet)
- [ ] Run `qi ask "how do I add a new parser?"` and verify sources are deduplicated and shown as `<folder>/<path>`
- [ ] Run `qi ask --format json "..."` and verify JSON output includes `answer` and `sources` array

## Release Notes
`qi ask` now deduplicates source citations (multiple matching chunks from the same document are collapsed into one source) and shows paths relative to the collection folder. JSON output is also now supported via `--format json`.

## Checklist
- [x] Tests pass (`task check`)
- [x] Conventional commit format followed
- [x] No breaking changes