### PR TITLE
build: inject version info at build time and fix homebrew test

### DIFF
--- a/HomebrewFormula/qi.rb
+++ b/HomebrewFormula/qi.rb
@@ -19,6 +19,6 @@ class Qi < Formula
   end
 
   test do
-    assert_match "v#{version}", shell_output("#{bin}/qi version")
+    assert_match "v#{version}", shell_output("#{bin}/qi --version")
   end
 end

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -17,8 +17,15 @@ tasks:
       - go.sum
     generates:
       - "{{.BINARY}}"
+    vars:
+      VERSION:
+        sh: git describe --tags --always --dirty 2>/dev/null || echo "dev"
+      COMMIT:
+        sh: git rev-parse --short HEAD 2>/dev/null || echo "unknown"
+      DATE:
+        sh: date -u +%Y-%m-%dT%H:%M:%SZ
     cmds:
-      - go build -o {{.BINARY}} .
+      - go build -ldflags "-s -w -X github.com/itsmostafa/qi/internal/version.Version={{.VERSION}} -X github.com/itsmostafa/qi/internal/version.Commit={{.COMMIT}} -X github.com/itsmostafa/qi/internal/version.BuildDate={{.DATE}}" -o {{.BINARY}} .
 
   test:
     desc: Run all unit tests


### PR DESCRIPTION
## Summary
Wires up build-time version injection so `qi --version` reports the real tag, commit hash, and build date. Also fixes a broken Homebrew formula test that was invoking the wrong command.

## Commits
- `0afca22` build: inject version, commit, and date via ldflags
- `c3d1741` fix(formula): correct homebrew test to use --version flag

## Changes
- `taskfile.yml`: Build task now resolves `VERSION` via `git describe`, `COMMIT` via `git rev-parse`, and `DATE` via `date -u`, then passes them as `-ldflags` to `go build`, overriding the `dev`/`unknown` defaults in `internal/version`
- `HomebrewFormula/qi.rb`: Test assertion updated from `qi version` (invalid subcommand) to `qi --version` (the actual root flag)

## Breaking Changes
None

## Test Plan
- [ ] `task build` produces a binary where `./qi --version` prints the real tag and commit
- [ ] `brew install --build-from-source ./HomebrewFormula/qi.rb && brew test qi` passes
- [ ] `go test ./...` passes (no regressions)

## Release Notes
`qi --version` now reports the correct version tag, commit hash, and build timestamp instead of the placeholder `dev (built: unknown)`.

## Checklist
- [x] Build verified with `task build`
- [x] Conventional commit format followed
- [x] No new dependencies introduced