### PR TITLE
docs(readme): replace intro paragraph with feature highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,15 @@
 Save tokens by delegating some of your AI Agent's work to qi.
 
 ⚡ Ultra-fast indexing
+
 ⚡ Lower tokens + latency
+
 🧠 Better reasoning (agents focus on thinking, not retrieval)
+
 🔒 Fully local + offline
+
 🧩 Works with Ollama, LM Studio, Claude, OpenAI, MLX, etc.
+
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@
   <img src="assets/img/qi-logo.png" alt="qi logo" width="200" />
 </p>
 
-qi is an ultra-fast knowledge search CLI for your files on your local machine. No dependencies, no runtime, just a single executable that indexes code, docs, notes, papers, logs, and other text into SQLite, then gives you BM25 search, optional vector search, and grounded LLM Q&A with citations. Use it offline with Ollama, LM Studio, llama.cpp, or MLX, or connect OpenAI for cloud models.
-
 Save tokens by delegating some of your AI Agent's work to qi.
+
+⚡ Ultra-fast indexing
+⚡ Lower tokens + latency
+🧠 Better reasoning (agents focus on thinking, not retrieval)
+🔒 Fully local + offline
+🧩 Works with Ollama, LM Studio, Claude, OpenAI, MLX, etc.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,13 @@
   <img src="assets/img/qi-logo.png" alt="qi logo" width="200" />
 </p>
 
-Save tokens by delegating some of your AI Agent's work to qi.
+Save tokens by delegating some of your AI Agent's work to qi. Agent skills included.
 
-⚡ Ultra-fast indexing
-
-⚡ Lower tokens + latency
-
-🧠 Better reasoning (agents focus on thinking, not retrieval)
-
-🔒 Fully local + offline
-
-🧩 Works with Ollama, LM Studio, Claude, OpenAI, MLX, etc.
+- ⚡ Ultra-fast indexing
+- ⚡ Lower tokens + latency
+- 🧠 Better reasoning (agents focus on thinking, not retrieval)
+- 🔒 Fully local + offline
+- 🧩 Works with Ollama, LM Studio, Claude, OpenAI, MLX, etc.
 
 
 ## Features


### PR DESCRIPTION
## Summary
Replaces the dense prose introduction in the README with a concise tagline and scannable emoji-prefixed bullet list, making qi's core value propositions immediately visible.

## Changes
- Removed verbose description paragraph from the top of the README
- Kept the "Save tokens by delegating some of your AI Agent's work to qi" tagline
- Added four emoji-prefixed feature bullets: ultra-fast indexing, lower tokens + latency, better reasoning, fully local + offline, and ecosystem compatibility

## Breaking Changes
None

## Test Plan
- [ ] Verify README renders correctly on GitHub

## Related Issues
None

## Release Notes
Updated README introduction to highlight qi's key capabilities with a scannable bullet list.

## Checklist
- [x] Conventional commit format followed
- [x] Documentation updated