### PR TITLE
docs(skill): add troubleshooting guide for vector search fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "qi",
       "source": "./",
       "description": "Local knowledge search CLI — index documents and search them using BM25 full-text search, vector embeddings, and LLM-powered Q&A, all running locally with no external dependencies.",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "itsmostafa"
       },
@@ -25,7 +25,9 @@
         "sqlite",
         "cli"
       ],
-      "skills": ["./skills/"]
+      "skills": [
+        "./skills/"
+      ]
     }
   ]
 }

--- a/skills/qi-cli/SKILL.md
+++ b/skills/qi-cli/SKILL.md
@@ -37,7 +37,7 @@ qi init
 ```
 
 ### `qi index [path|collection]`
-Indexes documents. SHA-256 content hashing means unchanged files are skipped.
+Indexes documents. SHA-256 content hashing means unchanged files are skipped. Embeddings are generated at index time — if you add an embedding provider to config after an initial index run, re-run `qi index` to populate the missing embeddings.
 
 ```bash
 qi index                              # indexes current working directory
@@ -102,10 +102,10 @@ qi delete notes
 ```
 
 ### `qi stats`
-Show document counts, chunk counts, embedding counts, and database size per collection.
+Show document counts, chunk counts, embedding counts, and database size per collection. If `Embeddings` count is much lower than `Chunks` count, vector search has no data to work with — re-run `qi index`.
 
 ### `qi doctor`
-Health-check config, database, collection paths, and provider connectivity.
+Health-check config, database, collection paths, and provider connectivity. If the embedding provider shows `SKIP` instead of `OK`, `qi query` will silently fall back to BM25 regardless of your config.
 
 ### `qi update`
 Update the binary from GitHub. If installed via Homebrew, it suggests `brew upgrade qi` instead.
@@ -259,3 +259,44 @@ qi stats                          # see document/chunk/embedding counts
 qi query "question" --explain     # see score breakdown
 qi get abc123                     # read the full source document
 ```
+
+---
+
+## Troubleshooting
+
+### `qi query` returns keyword-only results despite embedding provider being configured
+
+Work through these steps in order:
+
+**1. Check if the provider is actually wired up**
+```bash
+qi doctor
+```
+Look for `OK` next to the embedding provider. `SKIP` means qi didn't parse the provider config — common causes: wrong YAML key name (`embedding` not `embeddings`), missing `dimension` field, or bad indentation (must be under `providers:`).
+
+**2. Check if embeddings were actually generated**
+```bash
+qi stats
+```
+If `Embeddings` is 0 or far less than `Chunks`, the vectors were never written. This happens when the embedding provider was added to config *after* the initial `qi index` run — re-index to fix it:
+```bash
+qi index <collection-name>
+```
+Only chunks missing embeddings are re-processed; unchanged files aren't re-parsed.
+
+**3. Verify the provider is reachable at query time**
+`qi query` embeds the query string at runtime. If the provider is down, qi silently falls back to BM25 without an error. Test connectivity:
+```bash
+# Ollama:
+curl http://localhost:11434/v1/embeddings -H "Content-Type: application/json" \
+  -d '{"model":"nomic-embed-text","input":["test"]}'
+```
+Also confirm the model is pulled: `ollama list`.
+
+**4. Use `--explain` to see what's actually happening**
+```bash
+qi query "your question" --explain
+```
+This shows each result's BM25 rank, vector rank, and fused RRF score. If every result is missing a vector rank, the vector path isn't contributing — confirming one of the issues above.
+
+**Note:** hybrid mode also skips vector search if the top BM25 score is more than 3× the second result (intentional optimization for dominant keyword matches). If your queries are exact keyword matches, try a more paraphrased, natural-language query to avoid this shortcut.


### PR DESCRIPTION
## Summary
Adds a Troubleshooting section to the qi-cli skill documentation covering the most common user-reported issue: `qi query` silently falling back to BM25 keyword search despite an embedding provider being configured. Also improves inline command descriptions for `qi index`, `qi stats`, and `qi doctor` to surface diagnostic hints in context.

## Commits
- `bb09ded` chore(plugin): bump marketplace version to 0.5.0
- `ef2ef84` docs(skill): add troubleshooting guide and improve command descriptions

## Changes
- Added **Troubleshooting** section to `skills/qi-cli/SKILL.md` with a 4-step diagnostic guide for the vector-search-falls-back-to-BM25 issue
- Improved `qi index` description: note that embeddings are generated at index time and re-indexing is required if a provider is added after the initial run
- Improved `qi stats` description: hint that low `Embeddings` count relative to `Chunks` means vector search has no data
- Improved `qi doctor` description: hint that `SKIP` on the embedding provider means `qi query` will fall back to BM25 silently
- Bumped marketplace plugin version from `0.4.0` to `0.5.0`

## Breaking Changes
None

## Test Plan
- [ ] Read through the Troubleshooting section and verify all steps are accurate against the current codebase
- [ ] Confirm `qi doctor` outputs `SKIP` when no embedding provider is configured
- [ ] Confirm `qi stats` shows `Embeddings: 0` on a collection indexed without a provider
- [ ] Verify `qi query --explain` output matches the described score breakdown format

## Related Issues
None

## Release Notes
The qi-cli skill documentation now includes a step-by-step troubleshooting guide for diagnosing why vector search may silently fall back to BM25. Key command descriptions (`qi index`, `qi stats`, `qi doctor`) have been updated with actionable hints to help users catch configuration and indexing issues faster.

## Checklist
- [x] No code changes — documentation only
- [x] Conventional commit format followed
- [x] Marketplace version bumped to reflect changes