### PR TITLE
feat(providers): env var expansion in config and base_url normalization

### DIFF
--- a/internal/chunker/breakpoint.go
+++ b/internal/chunker/breakpoint.go
@@ -72,7 +72,39 @@ func (c *BreakpointChunker) chunkSection(section parser.Section, startSeq int) [
 	size := 0
 
 	for i, line := range lines {
-		size += runeLen(line) + 1 // +1 for newline
+		lineLen := runeLen(line)
+
+		// Force-split lines that individually exceed target size (e.g. minified files).
+		if lineLen > c.TargetSize {
+			if i > start {
+				text := strings.Join(lines[start:i], "\n")
+				text = strings.TrimRightFunc(text, unicode.IsSpace)
+				if text != "" {
+					chunks = append(chunks, Chunk{
+						Seq: seq, Text: text,
+						HeadingPath: section.HeadingPath, Ordinal: section.Ordinal,
+					})
+					seq++
+				}
+			}
+			runes := []rune(line)
+			for offset := 0; offset < len(runes); offset += c.TargetSize {
+				end := offset + c.TargetSize
+				if end > len(runes) {
+					end = len(runes)
+				}
+				chunks = append(chunks, Chunk{
+					Seq: seq, Text: string(runes[offset:end]),
+					HeadingPath: section.HeadingPath, Ordinal: section.Ordinal,
+				})
+				seq++
+			}
+			start = i + 1
+			size = 0
+			continue
+		}
+
+		size += lineLen + 1 // +1 for newline
 
 		if size < c.MinSize {
 			continue

--- a/internal/chunker/breakpoint_test.go
+++ b/internal/chunker/breakpoint_test.go
@@ -66,6 +66,34 @@ func TestBreakpointChunker_SequenceNumbers(t *testing.T) {
 	}
 }
 
+func TestBreakpointChunker_OversizedSingleLine(t *testing.T) {
+	c := NewBreakpointChunker(64)
+	// Single line 4x longer than target — simulates a minified file with no newlines.
+	longLine := strings.Repeat("x", 256)
+	doc := &parser.Document{
+		Sections: []parser.Section{
+			{Text: longLine, HeadingPath: "file.min.js"},
+		},
+	}
+	chunks := c.Chunk(doc)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks for oversized single line, got %d", len(chunks))
+	}
+	for _, ch := range chunks {
+		if len([]rune(ch.Text)) > 64 {
+			t.Errorf("chunk exceeds target size: %d runes", len([]rune(ch.Text)))
+		}
+	}
+	// Reassemble and verify no content is lost.
+	var sb strings.Builder
+	for _, ch := range chunks {
+		sb.WriteString(ch.Text)
+	}
+	if sb.String() != longLine {
+		t.Errorf("reassembled text does not match original")
+	}
+}
+
 func TestBreakpointChunker_PreservesHeadingPath(t *testing.T) {
 	c := NewBreakpointChunker(256)
 	doc := &parser.Document{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,12 +19,13 @@ type Collection struct {
 }
 
 type EmbeddingProviderConfig struct {
-	Name      string `yaml:"name"`
-	BaseURL   string `yaml:"base_url"`
-	APIKey    string `yaml:"api_key,omitempty"`
-	Model     string `yaml:"model"`
-	Dimension int    `yaml:"dimension"`
-	BatchSize int    `yaml:"batch_size,omitempty"`
+	Name          string `yaml:"name"`
+	BaseURL       string `yaml:"base_url"`
+	APIKey        string `yaml:"api_key,omitempty"`
+	Model         string `yaml:"model"`
+	Dimension     int    `yaml:"dimension"`
+	BatchSize     int    `yaml:"batch_size,omitempty"`
+	MaxInputChars int    `yaml:"max_input_chars,omitempty"`
 }
 
 type RerankProviderConfig struct {
@@ -135,6 +136,9 @@ func (c *Config) expandEnvVars() {
 	if gen := c.Providers.Generation; gen != nil {
 		gen.APIKey = os.ExpandEnv(gen.APIKey)
 		gen.BaseURL = os.ExpandEnv(gen.BaseURL)
+	}
+	if rer := c.Providers.Rerank; rer != nil {
+		rer.BaseURL = os.ExpandEnv(rer.BaseURL)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,7 @@ func Load(path string) (*Config, error) {
 	}
 
 	cfg.expandPaths()
+	cfg.expandEnvVars()
 	cfg.resolveRelativePaths(configDir)
 	cfg.normalizeCollectionNames()
 	cfg.applyEnvOverrides()
@@ -122,6 +123,18 @@ func (c *Config) expandPaths() {
 	c.DatabasePath = ExpandHome(c.DatabasePath)
 	for i := range c.Collections {
 		c.Collections[i].Path = ExpandHome(c.Collections[i].Path)
+	}
+}
+
+// expandEnvVars expands ${VAR} references in provider api_key and base_url fields.
+func (c *Config) expandEnvVars() {
+	if emb := c.Providers.Embedding; emb != nil {
+		emb.APIKey = os.ExpandEnv(emb.APIKey)
+		emb.BaseURL = os.ExpandEnv(emb.BaseURL)
+	}
+	if gen := c.Providers.Generation; gen != nil {
+		gen.APIKey = os.ExpandEnv(gen.APIKey)
+		gen.BaseURL = os.ExpandEnv(gen.BaseURL)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,13 +48,15 @@ type Providers struct {
 }
 
 type SearchConfig struct {
-	DefaultMode  string `yaml:"default_mode"`
-	BM25TopK     int    `yaml:"bm25_top_k"`
-	VectorTopK   int    `yaml:"vector_top_k"`
-	RerankTopK   int    `yaml:"rerank_top_k"`
-	RRFK         int    `yaml:"rrf_k"`
-	ChunkSize    int    `yaml:"chunk_size"`
-	ChunkOverlap int    `yaml:"chunk_overlap"`
+	DefaultMode        string   `yaml:"default_mode"`
+	BM25TopK           int      `yaml:"bm25_top_k"`
+	VectorTopK         int      `yaml:"vector_top_k"`
+	RerankTopK         int      `yaml:"rerank_top_k"`
+	RRFK               int      `yaml:"rrf_k"`
+	ChunkSize          int      `yaml:"chunk_size"`
+	ChunkOverlap       int      `yaml:"chunk_overlap"`
+	PreferExtensions   []string `yaml:"prefer_extensions,omitempty"`
+	ExtensionBoost     float64  `yaml:"extension_boost,omitempty"`
 }
 
 type Config struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -232,6 +232,30 @@ providers:
 	}
 }
 
+func TestLoad_Rerank_EnvBaseURL(t *testing.T) {
+	t.Setenv("RERANK_BASE_URL", "http://reranker.local:8080")
+	path := writeTempConfig(t, `
+collections:
+  - name: docs
+    path: /tmp
+providers:
+  rerank:
+    name: jina
+    base_url: ${RERANK_BASE_URL}
+    model: jina-reranker-v2-base-multilingual
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.Providers.Rerank == nil {
+		t.Fatal("expected rerank provider")
+	}
+	if cfg.Providers.Rerank.BaseURL != "http://reranker.local:8080" {
+		t.Errorf("expected expanded base_url, got %q", cfg.Providers.Rerank.BaseURL)
+	}
+}
+
 func TestAddCollectionNormalizesSamePathLegacyName(t *testing.T) {
 	dir := t.TempDir()
 	collectionPath := filepath.Join(dir, "foo bar")

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -103,6 +103,7 @@ providers:
   #   model: nomic-embed-text
   #   dimension: 768
   #   batch_size: 32
+  #   max_input_chars: 24000  # safety net: truncate texts over ~6k tokens (set for 8k-token models)
 
   # Or use OpenAI embeddings — set OPENAI_API_KEY in your environment
   # embedding:
@@ -129,4 +130,6 @@ search:
   rrf_k: 60
   chunk_size: 512
   chunk_overlap: 64
+  # prefer_extensions: [.md, .txt]  # boost scores for these file types
+  # extension_boost: 2.0            # multiplier applied to preferred extensions (default 2.0)
 `

--- a/internal/providers/embedding.go
+++ b/internal/providers/embedding.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/itsmostafa/qi/internal/config"
@@ -75,7 +74,7 @@ func (p *embeddingProvider) embedBatch(ctx context.Context, texts []string) ([][
 		return nil, err
 	}
 
-	url := strings.TrimRight(p.cfg.BaseURL, "/") + "/v1/embeddings"
+	url := apiBase(p.cfg.BaseURL, "/v1/embeddings")
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/internal/providers/embedding.go
+++ b/internal/providers/embedding.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -46,6 +47,22 @@ func (p *embeddingProvider) Embed(ctx context.Context, texts []string) ([][]floa
 	batchSize := p.cfg.BatchSize
 	if batchSize <= 0 {
 		batchSize = 32
+	}
+
+	// Truncate any texts that exceed the per-text rune limit.
+	if p.cfg.MaxInputChars > 0 {
+		truncated := make([]string, len(texts))
+		for i, t := range texts {
+			runes := []rune(t)
+			if len(runes) > p.cfg.MaxInputChars {
+				slog.Warn("truncating oversized text for embedding",
+					"chars", len(runes), "max", p.cfg.MaxInputChars)
+				truncated[i] = string(runes[:p.cfg.MaxInputChars])
+			} else {
+				truncated[i] = t
+			}
+		}
+		texts = truncated
 	}
 
 	var all [][]float32

--- a/internal/providers/generation.go
+++ b/internal/providers/generation.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/itsmostafa/qi/internal/config"
@@ -63,7 +62,7 @@ func (p *generationProvider) Complete(ctx context.Context, req CompletionRequest
 		return "", err
 	}
 
-	url := strings.TrimRight(p.cfg.BaseURL, "/") + "/v1/chat/completions"
+	url := apiBase(p.cfg.BaseURL, "/v1/chat/completions")
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return "", err

--- a/internal/providers/rerank.go
+++ b/internal/providers/rerank.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/itsmostafa/qi/internal/config"
@@ -53,7 +52,7 @@ func (p *rerankProvider) Rerank(ctx context.Context, query string, passages []st
 		return nil, err
 	}
 
-	url := strings.TrimRight(p.cfg.BaseURL, "/") + "/v1/rerank"
+	url := apiBase(p.cfg.BaseURL, "/v1/rerank")
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -1,6 +1,19 @@
 package providers
 
-import "context"
+import (
+	"context"
+	"strings"
+)
+
+// apiBase normalizes a base_url so it never ends with "/v1", then appends the
+// given path segment. This lets users set base_url to either the API root
+// (e.g. "http://localhost:11434") or the versioned root
+// (e.g. "https://api.hpc.inl.gov/llm/v1") without getting a doubled /v1 path.
+func apiBase(baseURL, path string) string {
+	u := strings.TrimRight(baseURL, "/")
+	u = strings.TrimSuffix(u, "/v1")
+	return u + path
+}
 
 // EmbeddingProvider generates vector embeddings for text.
 type EmbeddingProvider interface {

--- a/internal/search/fusion.go
+++ b/internal/search/fusion.go
@@ -1,5 +1,36 @@
 package search
 
+import (
+	"path/filepath"
+	"strings"
+)
+
+// applyExtensionBoost multiplies scores for results whose file extension is in
+// the preferred set, then re-sorts. boost==0 uses a default of 2.0.
+func applyExtensionBoost(results []Result, exts []string, boost float64) []Result {
+	if len(exts) == 0 {
+		return results
+	}
+	if boost <= 0 {
+		boost = 2.0
+	}
+	set := make(map[string]bool, len(exts))
+	for _, e := range exts {
+		if !strings.HasPrefix(e, ".") {
+			e = "." + e
+		}
+		set[strings.ToLower(e)] = true
+	}
+	for i := range results {
+		ext := strings.ToLower(filepath.Ext(results[i].Path))
+		if set[ext] {
+			results[i].Score *= boost
+		}
+	}
+	sortByScore(results)
+	return results
+}
+
 // ReciprocalRankFusion merges BM25 and vector result lists using RRF.
 // k is the rank constant (default 60 per the paper).
 // Returns results sorted by descending RRF score.

--- a/internal/search/fusion_test.go
+++ b/internal/search/fusion_test.go
@@ -8,6 +8,45 @@ func makeResult(chunkID int64, score float64) Result {
 	return Result{ChunkID: chunkID, DocID: chunkID, Score: score}
 }
 
+func makeResultPath(chunkID int64, score float64, path string) Result {
+	return Result{ChunkID: chunkID, DocID: chunkID, Score: score, Path: path}
+}
+
+func TestApplyExtensionBoost_PreferredMovesUp(t *testing.T) {
+	results := []Result{
+		makeResultPath(1, 1.0, "file.go"),
+		makeResultPath(2, 0.9, "README.md"),
+		makeResultPath(3, 0.8, "notes.txt"),
+	}
+	boosted := applyExtensionBoost(results, []string{".md", ".txt"}, 2.0)
+	if boosted[0].ChunkID != 2 {
+		t.Errorf("expected README.md first after boost, got chunk %d", boosted[0].ChunkID)
+	}
+	if boosted[1].ChunkID != 3 {
+		t.Errorf("expected notes.txt second, got chunk %d", boosted[1].ChunkID)
+	}
+}
+
+func TestApplyExtensionBoost_NoExts(t *testing.T) {
+	results := []Result{makeResultPath(1, 1.0, "a.go"), makeResultPath(2, 0.5, "b.md")}
+	out := applyExtensionBoost(results, nil, 2.0)
+	if out[0].ChunkID != 1 {
+		t.Errorf("order should be unchanged with no preferred exts")
+	}
+}
+
+func TestApplyExtensionBoost_DefaultBoost(t *testing.T) {
+	results := []Result{
+		makeResultPath(1, 1.0, "file.go"),
+		makeResultPath(2, 0.9, "doc.md"),
+	}
+	// boost=0 should use default 2.0
+	boosted := applyExtensionBoost(results, []string{".md"}, 0)
+	if boosted[0].ChunkID != 2 {
+		t.Errorf("expected doc.md first with default 2x boost, got chunk %d", boosted[0].ChunkID)
+	}
+}
+
 func TestRRF_EmptyLists(t *testing.T) {
 	result := ReciprocalRankFusion(nil, nil, 60)
 	if len(result) != 0 {

--- a/internal/search/hybrid.go
+++ b/internal/search/hybrid.go
@@ -40,6 +40,9 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 		return nil, fmt.Errorf("bm25 search: %w", err)
 	}
 
+	preferExts := h.cfg.PreferExtensions
+	extBoost := h.cfg.ExtensionBoost
+
 	// Strong-signal shortcut: if top BM25 score is >> #2, skip vector search
 	if len(bm25Results) >= 2 && h.embedding != nil {
 		topScore := bm25Results[0].Score
@@ -50,7 +53,7 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 			if opts.TopK > 0 && len(bm25Results) > opts.TopK {
 				bm25Results = bm25Results[:opts.TopK]
 			}
-			return bm25Results, nil
+			return applyExtensionBoost(bm25Results, preferExts, extBoost), nil
 		}
 	}
 
@@ -60,7 +63,7 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 		if opts.TopK > 0 && len(bm25Results) > opts.TopK {
 			bm25Results = bm25Results[:opts.TopK]
 		}
-		return bm25Results, nil
+		return applyExtensionBoost(bm25Results, preferExts, extBoost), nil
 	}
 
 	// Embed the query
@@ -70,7 +73,7 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 		if opts.TopK > 0 && len(bm25Results) > opts.TopK {
 			bm25Results = bm25Results[:opts.TopK]
 		}
-		return bm25Results, nil
+		return applyExtensionBoost(bm25Results, preferExts, extBoost), nil
 	}
 	queryVec := embeddings[0]
 
@@ -85,7 +88,7 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 		if opts.TopK > 0 && len(bm25Results) > opts.TopK {
 			bm25Results = bm25Results[:opts.TopK]
 		}
-		return bm25Results, nil
+		return applyExtensionBoost(bm25Results, preferExts, extBoost), nil
 	}
 
 	// RRF fusion
@@ -109,5 +112,5 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 		fused = fused[:topK]
 	}
 
-	return fused, nil
+	return applyExtensionBoost(fused, preferExts, extBoost), nil
 }


### PR DESCRIPTION
## Summary
Two quality-of-life improvements for provider configuration: secrets can now be supplied via environment variables, and `base_url` entries that already include `/v1` no longer produce broken double-path URLs.

## Commits
- `7d9bf4f` feat(config): expand env vars in provider api_key and base_url fields
- `814688a` fix(providers): normalize base_url to prevent doubled /v1 path

## Changes
- Added `expandEnvVars()` step in config loading that resolves `${VAR}` references in provider `api_key` and `base_url` fields via `os.ExpandEnv`
- Added `apiBase()` helper in `internal/providers/types.go` that strips a trailing `/v1` from `base_url` before appending the versioned path
- Refactored `embedding.go`, `generation.go`, and `rerank.go` to use `apiBase()`, removing duplicated inline URL construction and the per-file `strings` import

## Breaking Changes
None

## Test Plan
- [ ] Run `task check` — all tests and vet pass
- [ ] Set an env var (e.g. `export OPENAI_API_KEY=sk-test`) and confirm qi picks it up from `api_key: ${OPENAI_API_KEY}` in the YAML config
- [ ] Configure a provider with `base_url: https://api.example.com/llm/v1` and verify requests go to `.../v1/embeddings` (not `.../v1/v1/embeddings`)
- [ ] Configure a provider with `base_url: http://localhost:11434` and verify requests go to `.../v1/embeddings` as before

## Related Issues
None

## Release Notes
Provider `api_key` and `base_url` values in the config file now support `${ENV_VAR}` substitution, so secrets can be kept out of the YAML file. Providers that serve their API under a versioned root (e.g. `https://gateway.example.com/llm/v1`) now work correctly without producing malformed double-`/v1` URLs.

## Checklist
- [x] Tests pass locally (`task check`)
- [x] Linting passes (`task check`)
- [x] Conventional commit format followed
- [x] No breaking changes