### PR TITLE
fix: harden indexing and embedding integrity

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -75,6 +75,25 @@ var doctorCmd = &cobra.Command{
 			}
 		}
 
+		if cfg != nil && database != nil && cfg.Providers.Embedding != nil {
+			health, err := database.EmbeddingHealth(ctx, cfg.Providers.Embedding.Fingerprint(), cfg.Providers.Embedding.Dimension, "")
+			if err != nil {
+				fmt.Printf("  WARN  embedding health: could not check (%v)\n", err)
+				ok = false
+			} else {
+				status := "OK"
+				if health.Missing+health.Stale+health.Orphaned > 0 {
+					status = "WARN"
+					ok = false
+				}
+				fmt.Printf("  %-4s  embeddings: %d current / %d missing / %d stale / %d orphaned\n",
+					status, health.Current, health.Missing, health.Stale, health.Orphaned)
+				if status == "WARN" && cfg.Providers.Embedding != nil {
+					fmt.Println("        run `qi index` to repair missing, stale, or orphaned embeddings")
+				}
+			}
+		}
+
 		fmt.Println()
 		if ok {
 			fmt.Println("All checks passed.")

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/itsmostafa/qi/internal/app"
+	"github.com/itsmostafa/qi/internal/db"
+)
+
+func TestDoctorSkipsEmbeddingCompletenessWhenNotConfigured(t *testing.T) {
+	cfgPath := makeDoctorTestConfig(t, false)
+	withIndexTestConfig(t, cfgPath)
+
+	var runErr error
+	output := captureIndexTestOutput(t, func() { runErr = doctorCmd.RunE(doctorCmd, nil) })
+	if runErr != nil {
+		t.Fatalf("lexical-only doctor should pass: %v\n%s", runErr, output)
+	}
+	if strings.Contains(output, "embeddings:") {
+		t.Fatalf("lexical-only doctor reported embedding completeness:\n%s", output)
+	}
+	if !strings.Contains(output, "All checks passed.") {
+		t.Fatalf("expected green lexical-only result:\n%s", output)
+	}
+}
+
+func TestDoctorConfiguredMissingEmbeddingsFails(t *testing.T) {
+	cfgPath := makeDoctorTestConfig(t, true)
+	withIndexTestConfig(t, cfgPath)
+
+	var runErr error
+	output := captureIndexTestOutput(t, func() { runErr = doctorCmd.RunE(doctorCmd, nil) })
+	if runErr == nil {
+		t.Fatalf("configured missing embeddings must fail doctor:\n%s", output)
+	}
+	if !strings.Contains(output, "WARN  embeddings: 0 current / 1 missing") {
+		t.Fatalf("missing embedding health warning not shown:\n%s", output)
+	}
+	if strings.Contains(output, "All checks passed.") {
+		t.Fatalf("unhealthy doctor printed green result:\n%s", output)
+	}
+}
+
+func TestDoctorIndexRepairBecomesHealthy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[1,0],"index":0}]}`))
+	}))
+	defer server.Close()
+	dir := t.TempDir()
+	docs := filepath.Join(dir, "docs")
+	if err := os.Mkdir(docs, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(docs, "a.md"), []byte("# A\nContent."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeIndexTestConfig(t, fmt.Sprintf(`database_path: %s
+collections:
+  - path: %s
+providers:
+  embedding:
+    name: test
+    base_url: %s
+    model: m
+    dimension: 2
+search:
+  chunk_size: 256
+`, filepath.Join(dir, "qi.db"), docs, server.URL))
+	withIndexTestConfig(t, cfgPath)
+	ctx := context.Background()
+	a, err := app.New(ctx, cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.Indexer.Index(ctx, a.Config.Collections[0]); err != nil {
+		t.Fatal(err)
+	}
+	a.Close()
+
+	var doctorErr error
+	before := captureIndexTestOutput(t, func() { doctorErr = doctorCmd.RunE(doctorCmd, nil) })
+	if doctorErr == nil || !strings.Contains(before, "1 missing") {
+		t.Fatalf("doctor did not warn before repair: err=%v\n%s", doctorErr, before)
+	}
+
+	a, err = app.New(ctx, cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var indexErr error
+	captureIndexTestOutput(t, func() { indexErr = runIndex(ctx, a, a.Config.Collections) })
+	a.Close()
+	if indexErr != nil {
+		t.Fatalf("qi index repair failed: %v", indexErr)
+	}
+
+	after := captureIndexTestOutput(t, func() { doctorErr = doctorCmd.RunE(doctorCmd, nil) })
+	if doctorErr != nil || !strings.Contains(after, "1 current / 0 missing / 0 stale / 0 orphaned") || !strings.Contains(after, "All checks passed.") {
+		t.Fatalf("doctor not healthy after repair: err=%v\n%s", doctorErr, after)
+	}
+}
+
+func TestStatsSaysNotConfiguredForLexicalOnlyDatabase(t *testing.T) {
+	cfgPath := makeDoctorTestConfig(t, false)
+	withIndexTestConfig(t, cfgPath)
+
+	var runErr error
+	output := captureIndexTestOutput(t, func() { runErr = statsCmd.RunE(statsCmd, nil) })
+	if runErr != nil {
+		t.Fatal(runErr)
+	}
+	if !strings.Contains(output, "Embeddings: not configured") || strings.Contains(output, "missing") {
+		t.Fatalf("ambiguous lexical-only embedding stats:\n%s", output)
+	}
+}
+
+func makeDoctorTestConfig(t *testing.T, embedding bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "qi.db")
+	database, err := db.Open(context.Background(), dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(`
+		INSERT INTO content(hash, body) VALUES ('h', 'body');
+		INSERT INTO documents(collection, path, content_hash) VALUES ('test', 'a.md', 'h');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, content_length) VALUES ('h', 1, 0, 'body', 4);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+	providers := ""
+	if embedding {
+		providers = "providers:\n  embedding:\n    name: test\n    base_url: http://localhost:1\n    model: m\n    dimension: 2\n"
+	}
+	return writeIndexTestConfig(t, fmt.Sprintf("database_path: %s\n%s", dbPath, providers))
+}

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -141,21 +142,26 @@ func isPathArg(s string) bool {
 }
 
 func runIndex(ctx context.Context, a *app.App, collections []config.Collection) error {
+	var collectionErrs []error
 	for _, col := range collections {
 		fmt.Printf("Indexing %q (%s)...\n", col.Name, col.Path)
 		stats, err := a.Indexer.Index(ctx, col)
 		if err != nil {
+			err = fmt.Errorf("indexing collection %q: %w", col.Name, err)
 			fmt.Printf("  error: %v\n", err)
+			collectionErrs = append(collectionErrs, err)
 			continue
 		}
-		fmt.Printf("  scanned=%d added=%d updated=%d removed=%d time=%s\n",
-			stats.FilesScanned, stats.FilesAdded, stats.FilesUpdated, stats.FilesRemoved, stats.Duration.Round(1000000))
+		fmt.Printf("  scanned=%d added=%d updated=%d removed=%d skipped=%d time=%s\n",
+			stats.FilesScanned, stats.FilesAdded, stats.FilesUpdated, stats.FilesRemoved, stats.FilesSkipped, stats.Duration.Round(1000000))
 		if a.Embedder != nil {
 			fmt.Printf("  embedding chunks...\n")
 			if err := a.Embedder.EmbedCollection(ctx, col.Name); err != nil {
-				return fmt.Errorf("embedding collection %q: %w", col.Name, err)
+				err = fmt.Errorf("embedding collection %q: %w", col.Name, err)
+				fmt.Printf("  error: %v\n", err)
+				collectionErrs = append(collectionErrs, err)
 			}
 		}
 	}
-	return nil
+	return errors.Join(collectionErrs...)
 }

--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -118,7 +118,7 @@ func TestRunIndexEmbedsWhenProviderConfigured(t *testing.T) {
 
 	a := &app.App{
 		Indexer:  indexer.New(database, 256),
-		Embedder: indexer.NewEmbedder(database, testEmbeddingProvider{}),
+		Embedder: indexer.NewEmbedder(database, testEmbeddingProvider{}, "test", "test-fingerprint"),
 	}
 	col := config.Collection{Name: "test", Path: collectionPath, Extensions: []string{".md"}}
 
@@ -145,6 +145,28 @@ func TestRunIndexEmbedsWhenProviderConfigured(t *testing.T) {
 	}
 	if embeddingCount != chunkCount {
 		t.Fatalf("expected embeddings for every chunk, got embeddings=%d chunks=%d", embeddingCount, chunkCount)
+	}
+}
+
+func TestRunIndexPropagatesAllCollectionFailures(t *testing.T) {
+	ctx := context.Background()
+	database, err := db.Open(ctx, filepath.Join(t.TempDir(), "qi.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	a := &app.App{Indexer: indexer.New(database, 256)}
+	cols := []config.Collection{
+		{Name: "missing-one", Path: filepath.Join(t.TempDir(), "gone-one")},
+		{Name: "missing-two", Path: filepath.Join(t.TempDir(), "gone-two")},
+	}
+	var runErr error
+	captureIndexTestOutput(t, func() { runErr = runIndex(ctx, a, cols) })
+	if runErr == nil {
+		t.Fatal("expected collection failures to propagate")
+	}
+	if !strings.Contains(runErr.Error(), "missing-one") || !strings.Contains(runErr.Error(), "missing-two") {
+		t.Fatalf("expected aggregate error to include both collections, got %v", runErr)
 	}
 }
 

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/itsmostafa/qi/internal/app"
+	"github.com/itsmostafa/qi/internal/db"
 	"github.com/spf13/cobra"
 )
 
@@ -24,32 +25,48 @@ var statsCmd = &cobra.Command{
 			name      string
 			documents int
 			chunks    int
-			embeddings int
+			health    db.EmbeddingHealth
 		}
+
+		// Active fingerprint identifies which embeddings match the currently
+		// configured model/dimension/truncation settings; "" when no
+		// embedding provider is configured.
+		fingerprint := a.Config.Providers.Embedding.Fingerprint()
 
 		var collections []collectionStats
 		rows, err := a.DB.QueryContext(ctx, `
 			SELECT
 				d.collection,
-				COUNT(DISTINCT d.id)  AS docs,
-				COUNT(DISTINCT c.id)  AS chunks,
-				COUNT(DISTINCT e.chunk_id) AS embeddings
+				COUNT(DISTINCT d.id) AS docs,
+				COUNT(DISTINCT c.id) AS chunks
 			FROM documents d
 			LEFT JOIN chunks c ON c.doc_id = d.id
-			LEFT JOIN embeddings e ON e.chunk_id = c.id
 			WHERE d.active = 1
 			GROUP BY d.collection
 		`)
 		if err != nil {
 			return fmt.Errorf("querying stats: %w", err)
 		}
-		defer rows.Close()
 		for rows.Next() {
 			var s collectionStats
-			if err := rows.Scan(&s.name, &s.documents, &s.chunks, &s.embeddings); err != nil {
-				continue
+			if err := rows.Scan(&s.name, &s.documents, &s.chunks); err != nil {
+				rows.Close()
+				return fmt.Errorf("scanning stats: %w", err)
 			}
 			collections = append(collections, s)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("reading stats: %w", err)
+		}
+		rows.Close()
+		if a.Config.Providers.Embedding != nil {
+			for i := range collections {
+				collections[i].health, err = a.DB.EmbeddingHealth(ctx, fingerprint, a.Config.Providers.Embedding.Dimension, collections[i].name)
+				if err != nil {
+					return err
+				}
+			}
 		}
 
 		// DB file size
@@ -74,7 +91,12 @@ var statsCmd = &cobra.Command{
 			fmt.Fprintf(os.Stdout, "  Collection: %s\n", s.name)
 			fmt.Fprintf(os.Stdout, "    Documents:  %d\n", s.documents)
 			fmt.Fprintf(os.Stdout, "    Chunks:     %d\n", s.chunks)
-			fmt.Fprintf(os.Stdout, "    Embeddings: %d\n", s.embeddings)
+			if a.Config.Providers.Embedding == nil {
+				fmt.Fprintln(os.Stdout, "    Embeddings: not configured")
+			} else {
+				fmt.Fprintf(os.Stdout, "    Embeddings: %d current / %d missing / %d stale / %d orphaned\n",
+					s.health.Current, s.health.Missing, s.health.Stale, s.health.Orphaned)
+			}
 		}
 		fmt.Fprintf(os.Stdout, "\n  Database size: %s\n", formatBytes(dbSize))
 		fmt.Fprintf(os.Stdout, "  Last indexed:  %s\n", lastRun)

--- a/docs/audit-2026-08-09.md
+++ b/docs/audit-2026-08-09.md
@@ -1,0 +1,592 @@
+# qi Deep Audit Findings
+
+**Date:** 2026-08-09  
+**qi revision:** `ffecb1f456e23630a2807b185d71b94eb3c640d5`  
+**qmd comparison revision:** `e428df76bc0274d9e93eb7ca3e95673315c42e90`  
+**Scope:** Correctness, data integrity, security, reliability, performance, retrieval quality, provider behavior, CLI contracts, and comparison with [tobi/qmd](https://github.com/tobi/qmd).
+
+## Executive summary
+
+The existing build, test, and vet checks pass, but targeted testing found several serious behavioral defects that are not covered by the current suite. The most urgent issues are:
+
+1. **[RESOLVED]** File symlinks can escape a collection and ingest arbitrary readable files.
+2. **[RESOLVED]** Non-ASCII lexical queries, including CJK queries, can become an invalid empty FTS5 expression.
+3. **[RESOLVED]** Embedding model or dimension changes do not invalidate old vectors, silently corrupting hybrid ranking.
+4. Indexing failures are swallowed, can leave stale content searchable, and still produce exit status 0.
+5. Concurrent first startup can fail while applying migrations.
+6. `chunk_size: 0` hangs indexing indefinitely.
+7. Markdown list contents are dropped from the index.
+8. The documented `deep` mode never invokes the configured reranker.
+
+This report separates confirmed defects from lower-confidence risks and feature gaps. No source changes were made as part of the audit.
+
+## Verification baseline
+
+The following checks passed on qi:
+
+```text
+task check
+go vet ./...
+go test ./...
+go build .
+```
+
+All packages passed. Notably, `internal/parser` and `internal/app` currently have no tests, and the existing suite does not cover symlink containment, malformed provider responses, embedding model transitions, concurrent fresh database startup, multilingual queries, partial indexing failures, or CLI exit status on indexing errors.
+
+The repositories were inspected and synchronized with the GitHub CLI. Both working trees were clean before this report was added.
+
+## Priority overview
+
+| Priority | Finding | Severity | Status |
+|---|---|---:|---|
+| P0 | File symlinks escape the collection root | Critical | **Fixed** |
+| P0 | Non-ASCII/CJK queries produce an invalid FTS query | Critical | **Fixed** |
+| P0 | Embedding changes do not invalidate old vectors | Critical | **Fixed** |
+| P0 | Index failures leave stale content and exit successfully | High | Confirmed |
+| P0 | Concurrent startup and migrations race | High | Confirmed |
+| P0 | `chunk_size <= 0` can hang indexing | High | Confirmed |
+| P1 | Markdown lists lose their text; heading-only docs are unsearchable | High | Confirmed |
+| P1 | `deep` mode and reranking configuration are nonfunctional | High | Confirmed |
+| P1 | Search returns duplicate documents by ranking chunks | High | Confirmed |
+| P1 | Ask uses a short display snippet instead of full retrieved chunk text | High | Confirmed by code path |
+| P1 | Embedding vectors and provider response indices are insufficiently validated | High | Confirmed |
+| P1 | Old unreferenced content bodies remain in the database | High | Confirmed |
+| P2 | Large files cause severe memory amplification | Medium | Confirmed |
+| P2 | Database and initial config permissions may expose data locally | Medium | Confirmed |
+| P2 | `qi init --config` initializes the wrong database | Medium | Confirmed |
+| P2 | Self-update requests have no bounded timeout or size limits | Medium | Confirmed by code path |
+| P2 | Several documented configuration fields are ignored or fragile | Medium | Confirmed |
+
+---
+
+## Confirmed findings
+
+### P0: File symlinks escape the collection root
+
+**Locations**
+
+- `internal/indexer/indexer.go:92-122`
+- `internal/indexer/indexer.go:140-143`
+
+`filepath.WalkDir` does not descend through directory symlinks, but a symlinked file is handled as an ordinary file. `os.ReadFile(absPath)` follows that symlink without checking whether the resolved target remains inside the canonical collection root.
+
+**Impact**
+
+A repository or notes directory can contain a seemingly harmless `.md` or `.txt` symlink that points to a secret outside the collection. qi will persist the target contents in SQLite, expose them through search and `get`, and potentially send them to remote embedding or generation providers.
+
+**Reproduction result**
+
+A collection entry named `innocent.md` was symlinked to `../outside-secret.md`, which contained a unique token. Indexing reported `scanned=1 added=1`, and searching for the token returned it under the in-collection `qi://.../innocent.md` path.
+
+**Recommended fix**
+
+Reject file symlinks by default. If following symlinks is ever supported, require an explicit option, resolve every candidate with `filepath.EvalSymlinks`, and verify containment using canonical path components rather than a raw string prefix. Add tests for file symlinks, directory symlinks, nested symlinks, and targets that disappear during indexing.
+
+**Resolution**
+
+`internal/indexer/indexer.go` now canonicalizes the collection root once (`config.CanonicalPath`, matching `cmd/index.go`'s existing helper) and walks that root instead of the raw configured path, so a symlinked collection root indexes correctly instead of silently scanning nothing. For each file, `d.Type()&fs.ModeSymlink` detects a symlink cheaply from the `WalkDir` `Lstat` result; the target is resolved with `filepath.EvalSymlinks` and checked for containment. A dangling target is skipped (counted in a new `Stats.FilesSkipped`, surfaced in `qi index` output) without failing the walk; a target outside the root is skipped and — because it is not added to `seenPaths` — a previously-indexed escaping symlink is deactivated by the existing `deactivateMissing` reconciliation on the next run, purging already-leaked content. A directory whose basename matches the ignore list or starts with a dot (e.g. `~/.notes`, `~/dist`) no longer triggers `SkipDir` on the collection root itself, which previously would have deactivated every document in such a collection.
+
+Containment is checked with `withinRoot`, which tries a cheap lexical `filepath.Rel` comparison first and falls back to a device+inode identity walk (`os.Stat` + `os.SameFile`) up the resolved path's ancestors. The fallback was added after an independent Codex review, run against the built binary rather than static reading, reproduced a false-positive: on macOS's default case-insensitive-but-case-preserving filesystem, `filepath.EvalSymlinks` does not normalize a symlink target's letter case, so a legitimate in-collection symlink whose recorded target happened to be spelled with different case than the canonical root was being wrongly rejected as "escaping." The inode-identity fallback resolves case, alternate mount spellings, and similar filesystem-vs-string mismatches correctly, since it asks the filesystem rather than comparing strings.
+
+Verified: build the binary, create a collection containing a symlink to a file outside it, confirm `qi index` reports it skipped and the leaked content never appears in `qi search`; confirm an escaping-symlink-turned-stale document is deactivated on reindex; confirm in-collection symlinks (including differently-cased targets on a case-insensitive filesystem) still index. Automated coverage: `internal/indexer/symlink_test.go`, `internal/indexer/embedder_test.go` (indirectly, via the shared indexer path). `task check` passes.
+
+**Not attempted:** directory symlinks that themselves point outside the collection are never followed by `filepath.WalkDir` in the first place (pre-existing behavior, unrelated to this fix), so they were not separately re-verified here. Hardlinks are also out of scope: a hardlink to a file outside the collection is, at the `Lstat` level used by the walk, indistinguishable from an ordinary file, so this fix does not and cannot detect it. That gap sits outside the audit's symlink finding — normal document distribution (e.g. a git checkout) can't produce a hardlink to an arbitrary path outside the tree the way a symlink can — so it is recorded here as a known limitation rather than treated as unfinished work.
+
+### P0: Non-ASCII and CJK lexical queries can produce invalid FTS5 syntax
+
+**Locations**
+
+- `internal/search/bm25.go:26-28`
+- `internal/search/bm25.go:183-193`
+
+The query sanitizer retains only ASCII letters and digits. CJK and most other scripts are deleted. qi then executes `MATCH` with the resulting empty string before checking whether there is a usable query.
+
+**Impact**
+
+Chinese, Japanese, Korean, Arabic, Cyrillic, and many accented queries either fail or lose meaningful characters. Hybrid mode cannot gracefully fall back to vectors because BM25 returns a fatal error first.
+
+**Reproduction results**
+
+```text
+qi search 中文
+Error: search failed: sqlite3: SQL logic error: fts5: syntax error near ""
+
+qi search !!!
+Error: search failed: sqlite3: SQL logic error: fts5: syntax error near ""
+```
+
+Queries such as `Café`, `résumé`, `naïve`, and `façade` also returned no results against documents containing those terms because the sanitizer rewrote them incorrectly.
+
+**qmd comparison**
+
+qmd detects and normalizes CJK text, avoids executing empty FTS queries, and has dedicated CJK regression tests in `test/store-cjk-fts.test.ts`.
+
+**Recommended fix**
+
+Use Unicode-aware token classification. Return an empty result without touching FTS when normalization yields no terms. Add multilingual tests for CJK, accented Latin, Arabic, Cyrillic, punctuation-only input, emoji-only input, and mixed-script queries.
+
+**Resolution**
+
+`internal/search/bm25.go`'s term normalizer now keeps `unicode.IsLetter || unicode.IsDigit || unicode.IsMark` runes instead of ASCII `[a-zA-Z0-9]` only, so CJK, Cyrillic, Arabic, and accented Latin (`café`, not `caf`) terms survive into the FTS5 query. `Search` now returns `(nil, nil)` before touching FTS whenever normalization yields no terms at all (punctuation-only, emoji-only, or whitespace-only input), instead of executing an empty `MATCH` expression. A related crash risk in the same input class was also closed: `internal/search/hybrid.go` no longer indexes `embeddings[0]` unconditionally after a query-embedding call — a provider returning an empty slice with a nil error now falls back to BM25 instead of panicking.
+
+Verified against a real built index: `qi search 中文`, `qi search '!!!'`, and `qi search café` all return normally (results or "No results found") instead of `fts5: syntax error near ""`. An independent Codex review additionally fuzzed the normalizer with 20,000 arbitrary byte strings plus targeted multilingual/decomposed-accent/mark-only/emoji/punctuation/whitespace/directive-fallback cases against the built CLI and reported no FTS errors or panics. Automated coverage: `internal/search/bm25_unicode_test.go`. `task check` passes.
+
+**Known limitation, not attempted:** full CJK *sub-token* recall (matching `中文` inside a longer unbroken run like `这是中文文档`) is not implemented — `chunks_fts` is an external-content FTS5 table backed by `unicode61`, which has no CJK word-segmentation notion, and preprocessing would require a shadow column, which was judged out of scope for this fix. What is fixed is that non-ASCII input is no longer deleted by the sanitizer and no longer crashes; queries against space/punctuation-delimited non-ASCII tokens match correctly.
+
+### P0: Embedding model and dimension changes do not invalidate old vectors
+
+**Locations**
+
+- `internal/indexer/embedder.go:23-31`
+- `internal/indexer/embedder.go:71-84`
+- `internal/search/vector.go:42-77`
+- `internal/search/vector.go:101-105`
+
+A chunk is considered embedded when any `embeddings` row exists. The stored provider, model, dimension, input formatting, truncation settings, and chunking settings are not compared with the active configuration. Vector search then loads all vectors without filtering them to the current embedding identity.
+
+**Impact**
+
+After changing embedding models, qi embeds the query using the new model but compares it with corpus vectors from the old model. Same-dimension changes produce plausible but meaningless similarities. Dimension changes silently map mismatches to maximum cosine distance, but the incompatible results can still receive RRF scores and appear in output.
+
+**Reproduction result**
+
+A chunk was embedded with `model-a` at dimension 3. Configuration was changed to `model-b` at dimension 4 and indexing was rerun. No new embedding request occurred. The database still contained metadata for `model-a`, and hybrid query output included that chunk with `vector_distance` approximately 2.
+
+**qmd comparison**
+
+qmd fingerprints the model, embedding formatting, and chunking behavior; selects pending embeddings by model and fingerprint; verifies vector dimensions; and reports stale or mixed fingerprints through health checks.
+
+**Recommended fix**
+
+Create an embedding fingerprint that includes provider, model, actual dimension, input formatting, truncation behavior, and chunking parameters. Re-embed when the fingerprint differs. Filter vector search to the active fingerprint and fail clearly on incompatible dimensions. Extend `doctor` and `stats` to report stale, mixed, malformed, or incomplete embeddings.
+
+**Resolution**
+
+A fingerprint (`config.EmbeddingProviderConfig.Fingerprint()`, `sha256(model|dimension|max_input_chars)`) now identifies which embedding config produced a vector. Migration `004_embedding_fingerprint.sql` adds `embeddings.fingerprint` via a plain additive `ALTER TABLE` (deliberately not migration 003's drop/rebuild pattern, which the audit separately flagged as a concurrency hazard). `internal/indexer/embedder.go` selects pending work as "unembedded OR fingerprint mismatch," so a model/dimension/truncation change causes exactly the affected chunks to be re-embedded on the next `qi index`; vector and metadata are now written in one transaction (`db.UpsertEmbedding`) instead of two independent writes, and the previously hardcoded `provider='http'` now records the real configured provider name. `internal/search/vector.go` joins vector search against the active fingerprint, so a stale-model vector can never reach ranking or RRF, and returns no results when no fingerprint is active (no embedding provider configured) rather than risking an empty string matching legacy rows. A dimension-mismatch defense-in-depth check was kept in the scan loop as a second line of defense. `internal/providers/embedding.go` now validates response indices (rejects negative, out-of-range, and duplicate values) and rejects a returned vector whose length doesn't match the configured dimension, returning an error instead of the previous unbounded-index slice panic or silently storing a truncated/oversized vector. `cmd/doctor.go` and `cmd/stats.go` now report a stale-embedding count (and, in `doctor`, vectors with no matching metadata row) so the condition is visible rather than silently re-embedded on the next run.
+
+**Deliberate deviation from the recommendation:** the fingerprint excludes `chunk_size` and `base_url`. qi never re-chunks existing documents on a config change alone — chunks are rebuilt only when file content changes — so folding `chunk_size` in would force a full re-embed of byte-identical stored text for no benefit; `base_url` is routing, not embedding identity. Existing rows get fingerprint `''` (the pre-upgrade schema never recorded `max_input_chars`, so it can't be backfilled exactly), which matches no active fingerprint — every current user's corpus is re-embedded once on their next `qi index` after upgrading.
+
+Verified: a chunk embedded under one fingerprint is confirmed excluded from `VectorSearch.Search` results when queried under a different active fingerprint, and confirmed re-embedded (not skipped) when the embedder is reconfigured with a new fingerprint; an unchanged fingerprint triggers zero additional provider calls. Provider-response validation was exercised against a mock HTTP server for negative index, out-of-range index, duplicate index, and wrong-dimension responses — all rejected with an error, no panic. Automated coverage: `internal/indexer/embedder_test.go`, `internal/search/vector_test.go`, `internal/providers/embedding_validation_test.go`. `task check` passes.
+
+### P0: Indexing failures leave stale content searchable and return exit status 0
+
+**Locations**
+
+- `internal/indexer/indexer.go:114-121`
+- `internal/indexer/indexer.go:128-137`
+- `internal/indexer/indexer.go:249-277`
+- `cmd/index.go:143-160`
+
+A path is added to `seenPaths` before `indexFile` succeeds. Per-file failures are logged and discarded, so failed files are treated as present during deletion reconciliation. Collection-level errors are printed by `runIndex`, but the command continues and eventually returns `nil`.
+
+**Impact**
+
+Search and Q&A can serve obsolete content indefinitely after a file becomes unreadable or changes into a dangling symlink. CI, cron, scripts, and agents receive a successful exit code and cannot detect the partial or total failure.
+
+**Reproduction results**
+
+After indexing a file containing `oldtoken`, it was replaced with a dangling symlink. Reindexing produced a warning but reported:
+
+```text
+scanned=3 added=0 updated=0 removed=0
+```
+
+The command exited 0, and `qi search oldtoken` still returned the stale document.
+
+A configured collection whose path did not exist printed a walking error but also exited 0.
+
+**Recommended fix**
+
+Track successful, failed, and unseen paths separately. Aggregate per-file failures, persist them in `index_runs`, and return a nonzero aggregate error for any partial or total failure. Only provide best-effort behavior behind an explicit option. Do not deactivate a previously valid document merely because a transient read failed, but mark the index run and document health as stale so the condition is visible.
+
+### P0: Concurrent fresh startup races during WAL setup and migrations
+
+**Locations**
+
+- `internal/db/db.go:25-46`
+- `internal/db/migrate.go:16-64`
+- `internal/db/migrations/003_cascade_chunk_refs.sql`
+
+Multiple qi processes opening a fresh database can race while enabling WAL and applying migrations. Migration discovery and execution are not protected by a single cross-process write transaction or migration lock.
+
+**Impact**
+
+Parallel agents, shell commands, or startup probes can fail nondeterministically. More concerningly, migration 003 rebuilds tables with shared temporary names, so concurrent migration attempts interfere with one another.
+
+**Reproduction results**
+
+Eight concurrent `qi list` processes were launched against a fresh database. Across three repetitions, 2, 3, and 2 processes failed. Observed errors included:
+
+```text
+opening db: enabling WAL: sqlite3: database is locked
+running migrations: applying migration 003_cascade_chunk_refs.sql:
+table chunk_vectors_new already exists
+```
+
+**qmd comparison**
+
+Recent qmd changes explicitly serialize initialization with `BEGIN IMMEDIATE`, double-check schema versions inside the transaction, use busy timeouts, and give concurrent rebuilds process-unique shadow table names.
+
+**Recommended fix**
+
+Set an appropriate busy timeout before mutable pragmas. Serialize migration checks and execution with `BEGIN IMMEDIATE`, then re-read the current version while holding the lock. Make each migration atomic and use unique or transaction-local rebuild names. Add a multi-process fresh-start regression test.
+
+### P0: `chunk_size <= 0` can hang indexing
+
+**Locations**
+
+- `internal/config/config.go:385-405`
+- `internal/chunker/breakpoint.go:24-28`
+- `internal/chunker/breakpoint.go:77-104`
+
+Configuration validation does not require a positive chunk size. With `TargetSize == 0`, oversized-line splitting uses `offset += c.TargetSize`, so the loop never advances.
+
+**Impact**
+
+A syntactically valid configuration can peg a CPU and hang indexing forever. Negative values also produce invalid behavior.
+
+**Reproduction result**
+
+Indexing a 100-character document with `chunk_size: 0` exceeded a three-second process timeout. A targeted test timed out inside `BreakpointChunker.chunkSection`.
+
+**Recommended fix**
+
+Reject `chunk_size <= 0` during config validation and defensively reject or normalize it in `NewBreakpointChunker`. Validate all numeric search settings for sensible ranges.
+
+### P1: Markdown list text is dropped and heading-only documents are unsearchable
+
+**Locations**
+
+- `internal/parser/markdown.go:30-40`
+- `internal/parser/markdown.go:42-79`
+- `internal/parser/markdown.go:84-102`
+
+`extractText` reads a node's direct lines or immediate `ast.Text` children. List item content is nested more deeply, so list items become empty bullet markers. Headings update metadata but are never added to section text; an otherwise empty heading section is discarded.
+
+**Impact**
+
+Markdown knowledge stored in lists is omitted from BM25 and embeddings. Heading-only notes are stored as active documents with zero chunks and cannot be found by their title.
+
+**Reproduction results**
+
+For this input:
+
+```markdown
+# List
+
+- alpha uniqueitem
+- beta seconditem
+```
+
+The stored chunk text was:
+
+```text
+-
+-
+```
+
+Searches for `uniqueitem` returned no results. A file containing only `# Unicorn Project` created a document with zero chunks, and `qi search Unicorn` returned no results.
+
+**Recommended fix**
+
+Traverse descendant inline text while avoiding parent/child double counting. Preserve list structure, links, blockquotes, and code. Include heading text in searchable content or create a heading-only chunk. Add a parser test corpus before changing the implementation.
+
+### P1: `deep` mode is identical to `hybrid`; reranking is dead code
+
+**Locations**
+
+- `cmd/query.go:43-53`
+- `internal/app/app.go:45-67`
+- `internal/providers/rerank.go:19-84`
+- `README.md:116-123`
+
+Both modes call `Hybrid.Search`. `app.New` never constructs `NewRerank`, and no production call site invokes the rerank provider. `rerank_top_k` is reused as the number of context chunks for `ask` rather than as a rerank candidate limit.
+
+**Impact**
+
+Users can configure a reranker and select `deep`, but ranking is unchanged. The documentation and configuration imply behavior that does not exist.
+
+**qmd comparison**
+
+qmd creates a bounded rerank candidate set, reranks selected chunks, blends reranker and retrieval scores, and exposes rerank controls and traces.
+
+**Recommended fix**
+
+Either remove/deprecate the unfinished configuration until implemented, or create a distinct deep-search service that validates rerank responses, reranks a bounded candidate set, blends scores deterministically, and degrades clearly when the provider fails. Add a test proving that deep mode calls the reranker and can alter ranking.
+
+### P1: Search ranks chunks rather than documents, producing duplicates
+
+**Locations**
+
+- `internal/search/bm25.go:62-80`
+- `internal/search/fusion.go:51-95`
+
+BM25 returns one row per chunk, and RRF uses `ChunkID` as its identity key. Several matching chunks from one document therefore remain separate final results.
+
+**Impact**
+
+A verbose document can consume several top-N slots and suppress other relevant documents. `ask` can cite the same file repeatedly as separate evidence.
+
+**Reproduction result**
+
+One document with two matching sections and another with one matching section produced three search hits: two for the first file and one for the second.
+
+**qmd comparison**
+
+qmd fuses by file and performs an additional document-level deduplication pass before final output.
+
+**Recommended fix**
+
+Fuse and cap candidates by document identity. Retain the best chunk as the primary match and optionally preserve additional chunk evidence for context expansion.
+
+### P1: Ask uses display snippets instead of complete retrieved chunks
+
+**Locations**
+
+- `internal/search/bm25.go:62-71`
+- `internal/search/fusion.go:53-75`
+- `internal/search/prompt.go:20-29`
+
+BM25 places SQLite's highlighted 32-token snippet in `Result.Snippet`. When BM25 contributes the retained result, prompt construction inserts that shortened snippet, including `<b>` tags and ellipses, rather than loading the full chunk text.
+
+**Impact**
+
+The correct document may be retrieved, but decisive surrounding conditions or exceptions can be omitted from the generated answer. Citations can look grounded even though the generator saw only a fragment.
+
+**Recommended fix**
+
+Separate display snippets from retrieval context. Before generation, fetch full chunk text by `ChunkID`, strip display markup, enforce a token budget, and optionally include adjacent chunks.
+
+### P1: Embedding responses and stored vectors are insufficiently validated
+
+**Locations**
+
+- `internal/providers/embedding.go:119-133`
+- `internal/indexer/embedder.go:66-84`
+- `internal/db/vec.go:10-39`
+- `internal/search/vector.go:65-77`
+
+Problems confirmed in this path include:
+
+- A negative response index passes `d.Index < len(embeddings)` and causes a slice panic.
+- Duplicate response indices are not rejected.
+- Returned vector length is not checked against configured dimension.
+- Non-finite and zero vectors are not rejected.
+- Vector and metadata writes are separate, so a partial write can leave inconsistent state.
+- BLOB length is not verified to be divisible by four.
+- Search does not join active embedding metadata before comparing vectors.
+
+**Impact**
+
+A buggy or incompatible endpoint can crash qi or permanently store contradictory metadata. Corrupt vectors can silently enter ranking.
+
+**Reproduction results**
+
+A mock provider returning index `-1` triggered `runtime error: index out of range [-1]`. A provider configured for dimension 2 returned a three-element vector; qi accepted it and stored metadata dimension 2 with a 12-byte vector BLOB.
+
+**Recommended fix**
+
+Validate index lower and upper bounds, uniqueness, response cardinality, actual dimension, finiteness, and nonzero norm. Store vector and metadata in one transaction. Treat malformed responses as provider errors, never panics.
+
+### P1: Updated documents retain old unreferenced full-content bodies
+
+**Locations**
+
+- `internal/indexer/indexer.go:175-179`
+- `internal/indexer/indexer.go:217-246`
+- `internal/db/db.go:108-114`
+
+Each new document version inserts a content-addressed body, but a normal update never removes the previous body after the document switches hashes. Orphan cleanup occurs only during collection deletion or legacy collection renaming.
+
+**Impact**
+
+The database grows with every update and retains removed secrets or personal information in plaintext. Search no longer returns the old text, but backups and direct inspection still contain it.
+
+**Reproduction result**
+
+After replacing a document containing `OLD-SECRET-CONTENT` and reindexing, the database had two content rows, one unreferenced row, and one old secret body.
+
+**Recommended fix**
+
+Prune the old hash after a successful update when no document references it. If history retention is intentional, document it explicitly and provide a garbage-collection command with retention controls.
+
+### P2: Large files produce severe memory amplification
+
+**Locations**
+
+- `internal/indexer/indexer.go:140-189`
+- `internal/parser/plaintext.go:16-24`
+- `internal/chunker/breakpoint.go:44-151`
+
+The indexer reads the entire file, converts it to strings and rune slices, splits it, constructs chunks, and then writes all chunks. Several full-size copies can coexist.
+
+**Reproduction result**
+
+Indexing one 50 MB single-line text file completed in about 3.6 seconds but reached approximately 543 MB maximum resident memory, over 10 times the input size.
+
+**Impact**
+
+A moderately large text file can cause memory pressure or process termination. A malicious or accidental giant file inside a collection can create a local denial of service.
+
+**Recommended fix**
+
+Add a configurable file-size cap with explicit skip/error reporting. Stream hashing and parsing where practical, avoid whole-file rune conversion, and place hard limits on chunks per file and total bytes per indexing run.
+
+### P2: Database and initial configuration permissions can expose local data
+
+**Locations**
+
+- `internal/db/db.go:20-25`
+- `cmd/init.go:23-31`
+- `internal/config/config.go:377-383`
+
+SQLite file permissions are inherited from the process umask, and no post-creation chmod is applied. Initial config creation uses mode `0640`, while later rewrites use `0600`.
+
+**Reproduction result**
+
+In the audited environment, a newly created database had mode `0644`; the initial config path was also observed with permissive permissions in a targeted test.
+
+**Impact**
+
+On shared systems, other local accounts may read indexed documents or provider API keys.
+
+**Recommended fix**
+
+Create config and database directories as `0700`, and config/database files as `0600`. Verify permissions for SQLite WAL and SHM files as well. Warn or repair unsafe existing modes in `doctor`.
+
+### P2: `qi init --config` initializes a different database
+
+**Location**
+
+- `cmd/init.go:18-40`
+
+The command honors the custom config path when creating or locating the YAML file, but always opens `config.DefaultDBPath()` instead of loading the selected config's `database_path`.
+
+**Reproduction result**
+
+A temporary custom config specified `<temp>/custom.db`. Running `qi --config <temp>/custom.yaml init` exited 0, did not create `custom.db`, and reported initialization of the global default database.
+
+**Recommended fix**
+
+Load the selected configuration after creation and initialize `cfg.DatabasePath`. Return a nonzero error if the selected config cannot be loaded.
+
+### P2: Self-update network and extraction operations are unbounded
+
+**Locations**
+
+- `cmd/update.go:109-169`
+- `cmd/update.go:189-224`
+
+The updater uses package-level `http.Get`, whose default client has no overall timeout. Checksum bodies use unbounded `io.ReadAll`; archives are copied without a strict size limit; and extracted tar members are copied without enforcing a maximum binary size.
+
+**Impact**
+
+A stalled server can hang `qi update` indefinitely. Oversized responses can consume excessive memory or disk before checksum verification.
+
+**Recommended fix**
+
+Use a dedicated client with connection, response-header, and total deadlines. Propagate command context. Bound release JSON, checksum, archive, and extracted binary sizes. Validate tar member type and declared size before extraction.
+
+### P2: Configuration fields are ignored or fragile
+
+Confirmed examples:
+
+- `search.chunk_overlap` is parsed, defaulted, and documented but never used.
+- `search.default_mode` is parsed and documented, but `qi query` defaults directly to `hybrid` rather than reading it.
+- `providers.rerank` and `rerank_top_k` do not drive reranking.
+- Collection extensions are matched exactly; values such as `md` rather than `.md` can index nothing and cause existing documents to be deactivated.
+- Chunk ordinals are section heading offsets, not actual chunk byte offsets as documented by field comments.
+
+**Recommended fix**
+
+Either implement every public configuration field or reject/deprecate it. Normalize extensions to lowercase with a leading dot. Add configuration contract tests that prove each setting changes behavior.
+
+---
+
+## Additional safeguards and lower-confidence risks
+
+### Provider HTTP handling
+
+Embedding, generation, and rerank clients decode response bodies before validating HTTP status and do not impose response-size limits. HTML proxy errors become misleading JSON errors, and oversized responses can consume excess memory. Check status first, read through a bounded reader, and include a short sanitized error body in diagnostics.
+
+Rerank configuration has no API key field and sends no authorization header, so authenticated reranking endpoints cannot be used.
+
+### Prompt injection from indexed content
+
+`internal/search/prompt.go` places document text and the user question in the same user message. Indexed content is not explicitly delimited as untrusted data. A malicious document may instruct a generation model to ignore grounding or citation requirements. This was identified statically and was not tested against a live generator.
+
+Use strong structured delimiters, state that document content is untrusted, and avoid presenting source text in a way that can be confused with system instructions. This reduces but does not eliminate prompt-injection risk.
+
+### Migration crash durability
+
+Migration 003 performs destructive table rebuilds. Although the concurrent execution failure is confirmed, the separate risk of a process crash between `DROP TABLE` and `ALTER TABLE ... RENAME` was not destructively injected during the audit. Each migration should still be explicitly atomic and restart-safe.
+
+### Agent retrieval interface
+
+Compared with qmd, qi lacks bounded line-range retrieval, explicit ambiguous doc-ID errors, byte-limited multi-get, and an MCP interface. This is not a core correctness bug, but it materially affects agent safety and context efficiency. The most valuable first step is to make `get` support line ranges, byte caps, structured output, and explicit hash-prefix ambiguity before adding MCP.
+
+---
+
+## Recommended implementation order
+
+### Phase 1: Security and index trust
+
+1. Block collection-escaping symlinks.
+2. Return nonzero status and structured failure information for partial indexing.
+3. Fix stale-document handling without deactivating data on transient read failures.
+4. Enforce private config and database permissions.
+
+### Phase 2: Retrieval correctness
+
+1. Make query normalization Unicode-safe and guard empty FTS expressions.
+2. Fix Markdown list and heading indexing.
+3. Deduplicate/fuse by document instead of chunk.
+4. Give `ask` full chunk context rather than display snippets.
+
+### Phase 3: Embedding lifecycle
+
+1. Define and persist embedding fingerprints.
+2. Validate provider responses and actual dimensions.
+3. Atomically write vector and metadata.
+4. Filter search to the active fingerprint.
+5. Add stale/mixed embedding diagnostics and a forced re-embed workflow.
+
+### Phase 4: Database and resource resilience
+
+1. Serialize migrations and set busy timeouts.
+2. Make migrations atomic and restart-safe.
+3. Validate numeric configuration, especially chunk size.
+4. Add file-size and memory limits.
+5. Add content garbage collection.
+
+### Phase 5: Honest feature contracts
+
+1. Implement a real deep reranking path or remove the promise.
+2. Wire or remove unused configuration fields.
+3. Improve bounded retrieval for agents.
+4. Harden updater and provider HTTP clients.
+
+## Suggested regression matrix
+
+At minimum, add automated coverage for:
+
+- File and directory symlink containment. **[covered for file symlinks — `internal/indexer/symlink_test.go`: escaping/in-collection/dangling/symlinked-root/case-different-target. Directory-symlink escape is not applicable: `filepath.WalkDir` never follows directory symlinks, pre-existing and unrelated to this fix.]**
+- Read failure after a previously successful index.
+- Missing collection path returns nonzero.
+- One failed file among many returns a detectable partial failure.
+- CJK, accented Latin, Arabic, Cyrillic, punctuation-only, and mixed-script search. **[covered — `internal/search/bm25_unicode_test.go`.]**
+- Lists, nested lists, links, blockquotes, code blocks, tables, and heading-only Markdown.
+- Embedding model, dimension, formatting, truncation, and chunking changes. **[model/dimension/truncation covered — `internal/indexer/embedder_test.go`, `internal/search/vector_test.go`. Chunking deliberately excluded from the fingerprint (see resolution note above, P0 embedding finding); input-formatting is not a distinct configurable dimension in this codebase.]**
+- Negative, duplicate, missing, malformed, zero, NaN, and infinite embedding vectors. **[negative/out-of-range/duplicate index and wrong-dimension covered — `internal/providers/embedding_validation_test.go`. Zero-vector and non-finite (NaN/Inf) rejection is still open — P1 finding below, not attempted here.]**
+- Concurrent fresh database opens and concurrent opens during upgrade.
+- Zero and negative numeric configuration values.
+- Large files and excessive chunk counts.
+- Multiple matching chunks from one document.
+- Ask prompt receives full clean chunk text.
+- Deep mode invokes reranking and hybrid mode does not.
+- Config and database permission enforcement.
+- Custom config initialization uses its configured database path.
+
+## Conclusion
+
+qi's core architecture is compact and understandable, and the existing tests establish a useful baseline, but several edge cases undermine the trustworthiness of the index and retrieval results. The security boundary around collection files, the embedding lifecycle, failure signaling, Unicode search, and parser correctness should be addressed before expanding features. qmd provides useful reference patterns for embedding fingerprints, concurrent initialization, CJK handling, document-level fusion, bounded retrieval, and health diagnostics.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -42,17 +42,27 @@ func New(ctx context.Context, cfgPath string) (*App, error) {
 		}
 	}
 
+	// The embedding fingerprint identifies which provider endpoint and
+	// model/dimension/truncation config produced a stored vector. Computed once here so the embedder
+	// (writer) and vector search (reader) always agree on the active
+	// identity. Empty when no embedding provider is configured.
+	fingerprint := cfg.Providers.Embedding.Fingerprint()
+
 	a := &App{
 		Config:  cfg,
 		DB:      database,
 		Indexer: indexer.New(database, cfg.Search.ChunkSize),
 		BM25:    search.NewBM25(database),
-		Vector:  search.NewVectorSearch(database),
+		Vector:  search.NewVectorSearch(database, fingerprint),
 	}
 
 	if cfg.Providers.Embedding != nil {
 		embProvider := providers.NewEmbedding(cfg.Providers.Embedding)
-		a.Embedder = indexer.NewEmbedder(database, embProvider)
+		providerTag := cfg.Providers.Embedding.Name
+		if providerTag == "" {
+			providerTag = "http"
+		}
+		a.Embedder = indexer.NewEmbedder(database, embProvider, providerTag, fingerprint)
 		a.Hybrid = search.NewHybrid(a.BM25, a.Vector, embProvider, cfg.Search)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,13 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -28,6 +32,24 @@ type EmbeddingProviderConfig struct {
 	MaxInputChars int    `yaml:"max_input_chars,omitempty"`
 }
 
+// Fingerprint identifies the provider endpoint and embedding settings that
+// produced a vector. API keys and batching are intentionally excluded.
+func (c *EmbeddingProviderConfig) Fingerprint() string {
+	if c == nil {
+		return ""
+	}
+	endpoint := strings.TrimRight(strings.TrimSpace(c.BaseURL), "/")
+	if u, err := url.Parse(endpoint); err == nil {
+		u.Scheme = strings.ToLower(u.Scheme)
+		u.Host = strings.ToLower(u.Host)
+		endpoint = strings.TrimRight(u.String(), "/")
+	}
+	raw := "provider=" + c.Name + "|endpoint=" + endpoint + "|model=" + c.Model +
+		"|dim=" + strconv.Itoa(c.Dimension) + "|maxchars=" + strconv.Itoa(c.MaxInputChars)
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
 type RerankProviderConfig struct {
 	Name    string `yaml:"name"`
 	BaseURL string `yaml:"base_url"`
@@ -48,15 +70,15 @@ type Providers struct {
 }
 
 type SearchConfig struct {
-	DefaultMode        string   `yaml:"default_mode"`
-	BM25TopK           int      `yaml:"bm25_top_k"`
-	VectorTopK         int      `yaml:"vector_top_k"`
-	RerankTopK         int      `yaml:"rerank_top_k"`
-	RRFK               int      `yaml:"rrf_k"`
-	ChunkSize          int      `yaml:"chunk_size"`
-	ChunkOverlap       int      `yaml:"chunk_overlap"`
-	PreferExtensions   []string `yaml:"prefer_extensions,omitempty"`
-	ExtensionBoost     float64  `yaml:"extension_boost,omitempty"`
+	DefaultMode      string   `yaml:"default_mode"`
+	BM25TopK         int      `yaml:"bm25_top_k"`
+	VectorTopK       int      `yaml:"vector_top_k"`
+	RerankTopK       int      `yaml:"rerank_top_k"`
+	RRFK             int      `yaml:"rrf_k"`
+	ChunkSize        int      `yaml:"chunk_size"`
+	ChunkOverlap     int      `yaml:"chunk_overlap"`
+	PreferExtensions []string `yaml:"prefer_extensions,omitempty"`
+	ExtensionBoost   float64  `yaml:"extension_boost,omitempty"`
 }
 
 type Config struct {
@@ -383,6 +405,9 @@ func writeConfigNode(configPath string, doc *yaml.Node) error {
 }
 
 func (c *Config) validate() error {
+	if c.Providers.Embedding != nil && c.Providers.Embedding.Dimension <= 0 {
+		return fmt.Errorf("embedding dimension must be positive, got %d", c.Providers.Embedding.Dimension)
+	}
 	seen := map[string]bool{}
 	seenPaths := map[string]string{}
 	for _, col := range c.Collections {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -422,6 +422,29 @@ func TestCanonicalPathExpandsHome(t *testing.T) {
 	}
 }
 
+func TestEmbeddingFingerprintChangesWithProviderOrEndpoint(t *testing.T) {
+	base := (&EmbeddingProviderConfig{Name: "local", BaseURL: "HTTP://Example.COM/v1/", Model: "m", Dimension: 4}).Fingerprint()
+	if base == (&EmbeddingProviderConfig{Name: "remote", BaseURL: "HTTP://Example.COM/v1/", Model: "m", Dimension: 4}).Fingerprint() {
+		t.Fatal("provider switch must change fingerprint")
+	}
+	if base == (&EmbeddingProviderConfig{Name: "local", BaseURL: "https://example.com/v1", Model: "m", Dimension: 4}).Fingerprint() {
+		t.Fatal("endpoint switch must change fingerprint")
+	}
+	if base != (&EmbeddingProviderConfig{Name: "local", BaseURL: "http://example.com/v1", Model: "m", Dimension: 4}).Fingerprint() {
+		t.Fatal("cosmetic endpoint casing/trailing slash should be stable")
+	}
+}
+
+func TestLoadRejectsNonPositiveEmbeddingDimension(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("providers:\n  embedding:\n    base_url: http://localhost:1\n    model: m\n    dimension: 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected non-positive embedding dimension to be rejected")
+	}
+}
+
 func TestCanonicalPathResolvesSymlink(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target")

--- a/internal/db/concurrent_open_test.go
+++ b/internal/db/concurrent_open_test.go
@@ -1,0 +1,64 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestConcurrentFreshDatabaseOpens(t *testing.T) {
+	for round := 0; round < 3; round++ {
+		round := round
+		t.Run(fmt.Sprintf("round-%d", round), func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			path := filepath.Join(t.TempDir(), "qi.db")
+			start := make(chan struct{})
+			errs := make(chan error, 8)
+			var wg sync.WaitGroup
+			for i := 0; i < 8; i++ {
+				i := i
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					database, err := Open(ctx, path)
+					if err != nil {
+						errs <- fmt.Errorf("open %d: %w", i, err)
+						return
+					}
+					if _, err := database.ExecContext(ctx,
+						`INSERT INTO collections(name, path) VALUES (?, ?)`,
+						fmt.Sprintf("collection-%d", i), fmt.Sprintf("/tmp/%d", i)); err != nil {
+						errs <- fmt.Errorf("write %d: %w", i, err)
+					}
+					if err := database.Close(); err != nil {
+						errs <- fmt.Errorf("close %d: %w", i, err)
+					}
+				}()
+			}
+			close(start)
+			wg.Wait()
+			close(errs)
+			for err := range errs {
+				t.Error(err)
+			}
+			if t.Failed() {
+				return
+			}
+
+			database, err := Open(ctx, path)
+			if err != nil {
+				t.Fatalf("final open: %v", err)
+			}
+			defer database.Close()
+			assertDBCount(t, database, `SELECT COUNT(*) FROM collections`, 8)
+			assertDBCount(t, database, `SELECT COUNT(*) FROM schema_version WHERE version BETWEEN 1 AND 4`, 4)
+			assertDBCount(t, database, `SELECT COUNT(*) FROM schema_version WHERE version = 0`, 0)
+			assertDBCount(t, database, `SELECT COUNT(*) FROM pragma_table_info('embeddings') WHERE name = 'fingerprint'`, 1)
+			assertDBCount(t, database, `SELECT COUNT(*) FROM pragma_foreign_key_list('embeddings') WHERE "table" = 'chunks' AND on_delete = 'CASCADE'`, 1)
+		})
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	_ "github.com/ncruces/go-sqlite3/driver"
 )
@@ -27,10 +29,16 @@ func Open(ctx context.Context, path string) (*DB, error) {
 		return nil, fmt.Errorf("opening sqlite3: %w", err)
 	}
 
-	// Single writer to avoid SQLITE_BUSY under WAL
+	// Single writer per process, plus a bounded cross-process wait before any
+	// lock-prone initialization. This must precede journal-mode setup and
+	// migrations so simultaneous first starts wait instead of failing BUSY.
 	sqlDB.SetMaxOpenConns(1)
+	if _, err := sqlDB.ExecContext(ctx, `PRAGMA busy_timeout=10000`); err != nil {
+		_ = sqlDB.Close()
+		return nil, fmt.Errorf("setting SQLite busy timeout: %w", err)
+	}
 
-	if _, err := sqlDB.ExecContext(ctx, `PRAGMA journal_mode=WAL`); err != nil {
+	if err := execBusyRetry(ctx, sqlDB, `PRAGMA journal_mode=WAL`, 10*time.Second); err != nil {
 		_ = sqlDB.Close()
 		return nil, fmt.Errorf("enabling WAL: %w", err)
 	}
@@ -48,6 +56,33 @@ func Open(ctx context.Context, path string) (*DB, error) {
 	}
 
 	return db, nil
+}
+
+// journal_mode can return SQLITE_BUSY immediately even with busy_timeout, so
+// retry lock failures within the same bounded initialization window.
+func execBusyRetry(ctx context.Context, database *sql.DB, statement string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	delay := 5 * time.Millisecond
+	for {
+		_, err := database.ExecContext(ctx, statement)
+		if err == nil {
+			return nil
+		}
+		message := strings.ToLower(err.Error())
+		if (!strings.Contains(message, "locked") && !strings.Contains(message, "busy")) || time.Now().After(deadline) {
+			return err
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+		if delay < 100*time.Millisecond {
+			delay *= 2
+		}
+	}
 }
 
 // Ping verifies the database connection.

--- a/internal/db/embedding_health.go
+++ b/internal/db/embedding_health.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// EmbeddingHealth partitions active chunks into mutually exclusive states.
+// Orphaned means one side is absent or the vector/metadata pair is invalid.
+type EmbeddingHealth struct {
+	Current  int
+	Missing  int
+	Stale    int
+	Orphaned int
+}
+
+func (db *DB) EmbeddingHealth(ctx context.Context, fingerprint string, dimension int, collection string) (EmbeddingHealth, error) {
+	var h EmbeddingHealth
+	filter := ""
+	args := []any{}
+	if collection != "" {
+		filter = "AND d.collection = ?"
+		args = append(args, collection)
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT cv.chunk_id, cv.vector, em.chunk_id, em.dimension, em.fingerprint
+		FROM chunks c
+		JOIN documents d ON d.id = c.doc_id
+		LEFT JOIN chunk_vectors cv ON cv.chunk_id = c.id
+		LEFT JOIN embeddings em ON em.chunk_id = c.id
+		WHERE d.active = 1 `+filter, args...)
+	if err != nil {
+		return h, fmt.Errorf("querying embedding health: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var vectorID, metadataID, storedDimension sql.NullInt64
+		var blob []byte
+		var storedFingerprint sql.NullString
+		if err := rows.Scan(&vectorID, &blob, &metadataID, &storedDimension, &storedFingerprint); err != nil {
+			return h, fmt.Errorf("scanning embedding health: %w", err)
+		}
+		switch {
+		case !vectorID.Valid && !metadataID.Valid:
+			h.Missing++
+		case !vectorID.Valid || !metadataID.Valid:
+			h.Orphaned++
+		case !storedDimension.Valid || storedDimension.Int64 != int64(dimension) || ValidateEmbeddingBlob(blob, dimension) != nil:
+			h.Orphaned++
+		case fingerprint != "" && storedFingerprint.Valid && storedFingerprint.String == fingerprint:
+			h.Current++
+		default:
+			h.Stale++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return h, fmt.Errorf("reading embedding health: %w", err)
+	}
+	return h, nil
+}

--- a/internal/db/embedding_health_test.go
+++ b/internal/db/embedding_health_test.go
@@ -1,0 +1,73 @@
+package db
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+func TestEmbeddingHealthClassifiesAllStates(t *testing.T) {
+	ctx := context.Background()
+	database := openMemoryDB(t)
+	defer database.Close()
+
+	for i := 0; i < 7; i++ {
+		insertHealthChunk(t, database, i)
+	}
+	// chunk 1 current, chunk 2 stale, chunk 3 missing, chunk 4 one-sided/orphaned.
+	if err := database.UpsertEmbedding(ctx, 1, []float32{1}, "p", "m", 1, "current"); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpsertEmbedding(ctx, 2, []float32{1}, "p", "m", 1, "old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.InsertEmbedding(ctx, 4, []float32{1}); err != nil {
+		t.Fatal(err)
+	}
+	for id, vector := range map[int][]float32{
+		5: {0},
+		6: {float32(math.NaN())},
+		7: {float32(math.Inf(1))},
+	} {
+		if _, err := database.ExecContext(ctx, `INSERT INTO chunk_vectors(chunk_id, vector) VALUES (?, ?)`, id, serializeFloat32(vector)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := database.ExecContext(ctx, `INSERT INTO embeddings(chunk_id, provider, model, dimension, fingerprint) VALUES (?, 'p', 'm', 1, 'current')`, id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	health, err := database.EmbeddingHealth(ctx, "current", 1, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health != (EmbeddingHealth{Current: 1, Missing: 1, Stale: 1, Orphaned: 4}) {
+		t.Fatalf("unexpected health: %+v", health)
+	}
+}
+
+func openMemoryDB(t *testing.T) *DB {
+	t.Helper()
+	database, err := Open(context.Background(), t.TempDir()+"/qi.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return database
+}
+
+func insertHealthChunk(t *testing.T, database *DB, i int) {
+	t.Helper()
+	ctx := context.Background()
+	hash := string(rune('a' + i))
+	if _, err := database.ExecContext(ctx, `INSERT INTO content(hash, body) VALUES (?, 'x')`, hash); err != nil {
+		t.Fatal(err)
+	}
+	result, err := database.ExecContext(ctx, `INSERT INTO documents(collection, path, content_hash) VALUES ('test', ?, ?)`, hash, hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	docID, _ := result.LastInsertId()
+	if _, err := database.ExecContext(ctx, `INSERT INTO chunks(id, content_hash, doc_id, seq, text, content_length) VALUES (?, ?, ?, 0, 'x', 1)`, i+1, hash, docID); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -23,12 +23,6 @@ func runMigrations(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("creating schema_version: %w", err)
 	}
 
-	var current int
-	row := db.QueryRowContext(ctx, `SELECT COALESCE(MAX(version), 0) FROM schema_version`)
-	if err := row.Scan(&current); err != nil {
-		return fmt.Errorf("reading schema version: %w", err)
-	}
-
 	entries, err := migrationsFS.ReadDir("migrations")
 	if err != nil {
 		return fmt.Errorf("reading migrations dir: %w", err)
@@ -37,6 +31,25 @@ func runMigrations(ctx context.Context, db *sql.DB) error {
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Name() < entries[j].Name()
 	})
+
+	// A write statement before reading schema_version serializes migration
+	// runners across processes. Version 0 is a transaction-local lock row: it
+	// is removed before commit and excluded from the version query. Crucially,
+	// the version is read only after this write lock is held, so waiters observe
+	// migrations committed by the process ahead of them and cannot rerun 003.
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning migration transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO schema_version(version) VALUES (0)`); err != nil {
+		return fmt.Errorf("acquiring migration lock: %w", err)
+	}
+
+	var current int
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(version), 0) FROM schema_version WHERE version > 0`).Scan(&current); err != nil {
+		return fmt.Errorf("reading schema version: %w", err)
+	}
 
 	for _, entry := range entries {
 		name := entry.Name()
@@ -56,12 +69,50 @@ func runMigrations(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("reading migration %s: %w", name, err)
 		}
 
-		if _, err := db.ExecContext(ctx, string(data)); err != nil {
+		// Early builds of migration 004 could commit the ALTER TABLE before
+		// recording schema_version. Treat that exact state as already applied;
+		// all new applications execute the DDL and version marker atomically.
+		alreadyApplied := false
+		if ver == 4 {
+			alreadyApplied, err = columnExists(ctx, tx, "embeddings", "fingerprint")
+		}
+		if err == nil && !alreadyApplied {
+			_, err = tx.ExecContext(ctx, string(data))
+		}
+		if err == nil && alreadyApplied {
+			_, err = tx.ExecContext(ctx, `INSERT OR IGNORE INTO schema_version(version) VALUES (?)`, ver)
+		}
+		if err != nil {
 			return fmt.Errorf("applying migration %s: %w", name, err)
 		}
+		current = ver
 	}
 
+	if _, err := tx.ExecContext(ctx, `DELETE FROM schema_version WHERE version = 0`); err != nil {
+		return fmt.Errorf("releasing migration lock: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing migrations: %w", err)
+	}
 	return nil
+}
+
+func columnExists(ctx context.Context, tx *sql.Tx, table, column string) (bool, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT name FROM pragma_table_info(?)`, table)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 func parseMigrationVersion(name string) (int, error) {

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -1,0 +1,38 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestMigration004RecoversAfterColumnAddedWithoutVersion(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "qi.db")
+	database, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, `DELETE FROM schema_version WHERE version = 4`); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err = Open(ctx, path)
+	if err != nil {
+		t.Fatalf("reopening partially applied migration: %v", err)
+	}
+	defer database.Close()
+	var versions, columns int
+	if err := database.QueryRowContext(ctx, `SELECT COUNT(*) FROM schema_version WHERE version = 4`).Scan(&versions); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_table_info('embeddings') WHERE name = 'fingerprint'`).Scan(&columns); err != nil {
+		t.Fatal(err)
+	}
+	if versions != 1 || columns != 1 {
+		t.Fatalf("recovery left version=%d columns=%d, want 1/1", versions, columns)
+	}
+}

--- a/internal/db/migrations/004_embedding_fingerprint.sql
+++ b/internal/db/migrations/004_embedding_fingerprint.sql
@@ -1,0 +1,14 @@
+-- Track which embedding identity (model, dimension, truncation behavior)
+-- produced each vector, so a model/dimension/truncation change invalidates
+-- old vectors instead of silently comparing them against a new model's
+-- query embeddings. Plain additive ALTER TABLE — unlike migration 003, this
+-- does not need a table rebuild, so it carries no concurrent-migration risk.
+--
+-- Existing rows get '' (no prior config recorded max_input_chars, so exact
+-- backfill isn't possible). '' matches no active fingerprint, so every
+-- pre-upgrade chunk is treated as stale and gets re-embedded once on the
+-- next `qi index` run.
+
+ALTER TABLE embeddings ADD COLUMN fingerprint TEXT NOT NULL DEFAULT '';
+
+INSERT OR IGNORE INTO schema_version(version) VALUES (4);

--- a/internal/db/vec.go
+++ b/internal/db/vec.go
@@ -8,13 +8,92 @@ import (
 )
 
 // InsertEmbedding stores a vector embedding for a chunk as a raw BLOB.
+// Retained for tests that only need a vector row without metadata.
 func (db *DB) InsertEmbedding(ctx context.Context, chunkID int64, embedding []float32) error {
+	if err := validateEmbedding(embedding, len(embedding)); err != nil {
+		return err
+	}
 	blob := serializeFloat32(embedding)
 	_, err := db.ExecContext(ctx,
 		`INSERT OR REPLACE INTO chunk_vectors(chunk_id, vector) VALUES (?, ?)`,
 		chunkID, blob)
 	if err != nil {
 		return fmt.Errorf("inserting embedding: %w", err)
+	}
+	return nil
+}
+
+// UpsertEmbedding stores a chunk's vector and its embedding metadata
+// (provider, model, dimension, fingerprint) atomically in one transaction,
+// so a vector can never persist without matching metadata (or vice versa).
+func (db *DB) UpsertEmbedding(ctx context.Context, chunkID int64, embedding []float32, provider, model string, dimension int, fingerprint string) error {
+	if err := validateEmbedding(embedding, dimension); err != nil {
+		return err
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning embedding transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	blob := serializeFloat32(embedding)
+	if _, err := tx.ExecContext(ctx,
+		`INSERT OR REPLACE INTO chunk_vectors(chunk_id, vector) VALUES (?, ?)`,
+		chunkID, blob); err != nil {
+		return fmt.Errorf("storing vector: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR REPLACE INTO embeddings(chunk_id, provider, model, dimension, fingerprint)
+		VALUES (?, ?, ?, ?, ?)
+	`, chunkID, provider, model, dimension, fingerprint); err != nil {
+		return fmt.Errorf("storing embedding metadata: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// ValidateEmbeddingBlob validates a little-endian float32 vector against its
+// metadata dimension without allocating. It is shared by health checks and
+// repair selection so both agree on what can safely participate in search.
+func ValidateEmbeddingBlob(blob []byte, dimension int) error {
+	if dimension <= 0 {
+		return fmt.Errorf("embedding dimension must be positive, got %d", dimension)
+	}
+	if len(blob)%4 != 0 || len(blob)/4 != dimension {
+		return fmt.Errorf("embedding blob has %d bytes, expected %d float32 values", len(blob), dimension)
+	}
+	var norm float64
+	for i := 0; i < dimension; i++ {
+		value := math.Float32frombits(binary.LittleEndian.Uint32(blob[i*4:]))
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return fmt.Errorf("embedding contains non-finite value at dimension %d", i)
+		}
+		norm += float64(value) * float64(value)
+	}
+	if norm == 0 {
+		return fmt.Errorf("embedding has zero norm")
+	}
+	return nil
+}
+
+func validateEmbedding(embedding []float32, dimension int) error {
+	if dimension <= 0 {
+		return fmt.Errorf("embedding dimension must be positive, got %d", dimension)
+	}
+	if len(embedding) != dimension {
+		return fmt.Errorf("embedding has dimension %d, expected %d", len(embedding), dimension)
+	}
+	var norm float64
+	for i, value := range embedding {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return fmt.Errorf("embedding contains non-finite value at dimension %d", i)
+		}
+		norm += float64(value) * float64(value)
+	}
+	if norm == 0 {
+		return fmt.Errorf("embedding has zero norm")
 	}
 	return nil
 }

--- a/internal/db/vec_test.go
+++ b/internal/db/vec_test.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+func TestInsertEmbeddingRejectsInvalidVectors(t *testing.T) {
+	database := openMemoryDB(t)
+	defer database.Close()
+	for name, vector := range map[string][]float32{
+		"empty":      {},
+		"zero norm":  {0, 0},
+		"non-finite": {1, math.Float32frombits(0x7fc00000)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := database.InsertEmbedding(context.Background(), 1, vector); err == nil {
+				t.Fatal("expected invalid vector rejection")
+			}
+		})
+	}
+}

--- a/internal/indexer/deactivate_test.go
+++ b/internal/indexer/deactivate_test.go
@@ -1,0 +1,37 @@
+package indexer
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type failingRows struct {
+	scanErr error
+	rowsErr error
+	next    bool
+}
+
+func (r *failingRows) Next() bool {
+	if r.next {
+		r.next = false
+		return true
+	}
+	return false
+}
+func (r *failingRows) Scan(...any) error { return r.scanErr }
+func (r *failingRows) Err() error        { return r.rowsErr }
+
+func TestMissingDocumentIDsReturnsScanError(t *testing.T) {
+	_, err := missingDocumentIDs(&failingRows{next: true, scanErr: errors.New("scan failed")}, nil)
+	if err == nil || !strings.Contains(err.Error(), "scan failed") {
+		t.Fatalf("expected scan error, got %v", err)
+	}
+}
+
+func TestMissingDocumentIDsReturnsRowsError(t *testing.T) {
+	_, err := missingDocumentIDs(&failingRows{rowsErr: errors.New("iteration failed")}, nil)
+	if err == nil || !strings.Contains(err.Error(), "iteration failed") {
+		t.Fatalf("expected rows error, got %v", err)
+	}
+}

--- a/internal/indexer/embedder.go
+++ b/internal/indexer/embedder.go
@@ -2,6 +2,8 @@ package indexer
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -9,25 +11,34 @@ import (
 	"github.com/itsmostafa/qi/internal/providers"
 )
 
-// Embedder generates and stores embeddings for unembedded chunks.
+// Embedder generates and atomically stores embeddings for chunks whose
+// vector/metadata pair is missing, stale, or invalid.
 type Embedder struct {
-	db       *db.DB
-	provider providers.EmbeddingProvider
+	db          *db.DB
+	provider    providers.EmbeddingProvider
+	providerTag string
+	fingerprint string
 }
 
-func NewEmbedder(database *db.DB, provider providers.EmbeddingProvider) *Embedder {
-	return &Embedder{db: database, provider: provider}
+func NewEmbedder(database *db.DB, provider providers.EmbeddingProvider, providerTag, fingerprint string) *Embedder {
+	return &Embedder{db: database, provider: provider, providerTag: providerTag, fingerprint: fingerprint}
 }
 
-// EmbedCollection embeds all unembedded chunks in a collection.
+// EmbedCollection repairs every chunk that does not have a valid vector and
+// matching current metadata.
 func (e *Embedder) EmbedCollection(ctx context.Context, collection string) error {
-	// Fetch chunks that don't have an embedding yet
+	dimension := e.provider.Dimension()
+	if dimension <= 0 {
+		return fmt.Errorf("embedding provider dimension must be positive, got %d", dimension)
+	}
 	rows, err := e.db.QueryContext(ctx, `
-		SELECT c.id, c.text
+		SELECT c.id, c.text, cv.chunk_id, cv.vector,
+		       em.chunk_id, em.dimension, em.fingerprint
 		FROM chunks c
 		JOIN documents d ON d.id = c.doc_id
+		LEFT JOIN chunk_vectors cv ON cv.chunk_id = c.id
 		LEFT JOIN embeddings em ON em.chunk_id = c.id
-		WHERE d.collection = ? AND d.active = 1 AND em.chunk_id IS NULL
+		WHERE d.collection = ? AND d.active = 1
 	`, collection)
 	if err != nil {
 		return fmt.Errorf("fetching unembedded chunks: %w", err)
@@ -42,13 +53,24 @@ func (e *Embedder) EmbedCollection(ctx context.Context, collection string) error
 	var pending []chunkRow
 	for rows.Next() {
 		var row chunkRow
-		if err := rows.Scan(&row.id, &row.text); err != nil {
-			return err
+		var vectorID, metadataID, storedDimension sql.NullInt64
+		var blob []byte
+		var storedFingerprint sql.NullString
+		if err := rows.Scan(&row.id, &row.text, &vectorID, &blob, &metadataID, &storedDimension, &storedFingerprint); err != nil {
+			return fmt.Errorf("scanning embeddings to repair: %w", err)
 		}
-		pending = append(pending, row)
+		valid := vectorID.Valid && metadataID.Valid && storedDimension.Valid &&
+			int(storedDimension.Int64) == dimension && storedFingerprint.Valid &&
+			storedFingerprint.String == e.fingerprint && db.ValidateEmbeddingBlob(blob, dimension) == nil
+		if !valid {
+			pending = append(pending, row)
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return err
+		return fmt.Errorf("reading embeddings to repair: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing embeddings to repair: %w", err)
 	}
 
 	if len(pending) == 0 {
@@ -67,21 +89,23 @@ func (e *Embedder) EmbedCollection(ctx context.Context, collection string) error
 	if err != nil {
 		return fmt.Errorf("generating embeddings: %w", err)
 	}
+	if len(embeddings) != len(pending) {
+		return fmt.Errorf("embedding provider returned %d vectors for %d texts", len(embeddings), len(pending))
+	}
 
-	// Store embeddings
+	// Store vector + metadata atomically per chunk, so a partial write can
+	// never leave a vector without matching metadata (or the reverse).
 	model := e.provider.ModelName()
+	var persistErrs []error
 	for i, row := range pending {
-		if err := e.db.InsertEmbedding(ctx, row.id, embeddings[i]); err != nil {
+		if err := e.db.UpsertEmbedding(ctx, row.id, embeddings[i], e.providerTag, model, dimension, e.fingerprint); err != nil {
+			err = fmt.Errorf("chunk %d: %w", row.id, err)
 			slog.Warn("storing embedding", "chunk_id", row.id, "error", err)
-			continue
+			persistErrs = append(persistErrs, err)
 		}
-		_, err := e.db.ExecContext(ctx, `
-			INSERT OR REPLACE INTO embeddings(chunk_id, provider, model, dimension)
-			VALUES (?, 'http', ?, ?)
-		`, row.id, model, e.provider.Dimension())
-		if err != nil {
-			slog.Warn("recording embedding metadata", "chunk_id", row.id, "error", err)
-		}
+	}
+	if len(persistErrs) > 0 {
+		return fmt.Errorf("persisting %d of %d embeddings: %w", len(persistErrs), len(pending), errors.Join(persistErrs...))
 	}
 
 	return nil

--- a/internal/indexer/embedder_test.go
+++ b/internal/indexer/embedder_test.go
@@ -1,0 +1,313 @@
+package indexer
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/itsmostafa/qi/internal/config"
+)
+
+// fakeEmbeddingProvider returns deterministic vectors and counts how many
+// times Embed is invoked, so tests can assert re-embedding did or didn't
+// happen without depending on wall-clock timing.
+type fakeEmbeddingProvider struct {
+	model     string
+	dimension int
+	calls     int
+	texts     int
+}
+
+func (p *fakeEmbeddingProvider) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	p.calls++
+	p.texts += len(texts)
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		vec := make([]float32, p.dimension)
+		vec[0] = 1
+		out[i] = vec
+	}
+	return out, nil
+}
+
+func (p *fakeEmbeddingProvider) ModelName() string { return p.model }
+func (p *fakeEmbeddingProvider) Dimension() int    { return p.dimension }
+
+func TestEmbedder_EmbedsPendingChunksWithFingerprint(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+	col := makeTestCollection(t, map[string]string{"a.md": "# A\nSome content about Go."})
+	if _, err := idx.Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &fakeEmbeddingProvider{model: "model-a", dimension: 4}
+	fp := (&config.EmbeddingProviderConfig{Model: "model-a", Dimension: 4}).Fingerprint()
+	emb := NewEmbedder(database, provider, "test-provider", fp)
+	if err := emb.EmbedCollection(context.Background(), "test"); err != nil {
+		t.Fatalf("EmbedCollection failed: %v", err)
+	}
+	if provider.calls != 1 {
+		t.Fatalf("expected 1 embed call, got %d", provider.calls)
+	}
+
+	var storedFingerprint, storedProvider, storedModel string
+	var storedDim int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT fingerprint, provider, model, dimension FROM embeddings LIMIT 1`).
+		Scan(&storedFingerprint, &storedProvider, &storedModel, &storedDim); err != nil {
+		t.Fatalf("querying stored embedding: %v", err)
+	}
+	if storedFingerprint != fp {
+		t.Errorf("expected stored fingerprint %q, got %q", fp, storedFingerprint)
+	}
+	if storedProvider != "test-provider" {
+		t.Errorf("expected real provider tag %q, got %q (must not be hardcoded 'http')", "test-provider", storedProvider)
+	}
+	if storedModel != "model-a" || storedDim != 4 {
+		t.Errorf("expected model=model-a dimension=4, got model=%q dimension=%d", storedModel, storedDim)
+	}
+}
+
+func TestEmbedder_NoOpWhenFingerprintUnchanged(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+	col := makeTestCollection(t, map[string]string{"a.md": "# A\nSome content about Go."})
+	if _, err := idx.Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &fakeEmbeddingProvider{model: "model-a", dimension: 4}
+	fp := (&config.EmbeddingProviderConfig{Model: "model-a", Dimension: 4}).Fingerprint()
+	emb := NewEmbedder(database, provider, "test-provider", fp)
+	if err := emb.EmbedCollection(context.Background(), "test"); err != nil {
+		t.Fatal(err)
+	}
+	if provider.calls != 1 {
+		t.Fatalf("expected 1 embed call after first run, got %d", provider.calls)
+	}
+
+	// Re-run with the same fingerprint: nothing should be re-embedded.
+	if err := emb.EmbedCollection(context.Background(), "test"); err != nil {
+		t.Fatal(err)
+	}
+	if provider.calls != 1 {
+		t.Fatalf("expected no additional embed calls when the fingerprint is unchanged, got %d total", provider.calls)
+	}
+}
+
+func TestEmbedder_ReEmbedsAfterFingerprintChange(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+	col := makeTestCollection(t, map[string]string{"a.md": "# A\nSome content about Go."})
+	if _, err := idx.Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+
+	fpA := (&config.EmbeddingProviderConfig{Model: "model-a", Dimension: 4}).Fingerprint()
+	providerA := &fakeEmbeddingProvider{model: "model-a", dimension: 4}
+	embA := NewEmbedder(database, providerA, "test-provider", fpA)
+	if err := embA.EmbedCollection(context.Background(), "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	var chunkID int64
+	if err := database.QueryRowContext(context.Background(), `SELECT id FROM chunks LIMIT 1`).Scan(&chunkID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Switch to a different model/dimension — a distinct provider config.
+	fpB := (&config.EmbeddingProviderConfig{Model: "model-b", Dimension: 8}).Fingerprint()
+	if fpA == fpB {
+		t.Fatal("expected different fingerprints for different models/dimensions")
+	}
+	providerB := &fakeEmbeddingProvider{model: "model-b", dimension: 8}
+	embB := NewEmbedder(database, providerB, "test-provider", fpB)
+	if err := embB.EmbedCollection(context.Background(), "test"); err != nil {
+		t.Fatalf("re-embed after fingerprint change failed: %v", err)
+	}
+	if providerB.calls != 1 {
+		t.Fatalf("expected the stale-fingerprint chunk to be re-embedded, got %d calls", providerB.calls)
+	}
+
+	var storedFingerprint, storedModel string
+	var storedDim int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT fingerprint, model, dimension FROM embeddings WHERE chunk_id = ?`, chunkID).
+		Scan(&storedFingerprint, &storedModel, &storedDim); err != nil {
+		t.Fatalf("querying updated embedding: %v", err)
+	}
+	if storedFingerprint != fpB || storedModel != "model-b" || storedDim != 8 {
+		t.Errorf("expected chunk to now carry fingerprint=%q model=model-b dimension=8, got fingerprint=%q model=%q dimension=%d",
+			fpB, storedFingerprint, storedModel, storedDim)
+	}
+
+	var vecLen int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT length(vector) FROM chunk_vectors WHERE chunk_id = ?`, chunkID).Scan(&vecLen); err != nil {
+		t.Fatalf("querying updated vector: %v", err)
+	}
+	if vecLen != 8*4 {
+		t.Errorf("expected the stored vector to be re-written at the new dimension (8 float32s = 32 bytes), got %d bytes", vecLen)
+	}
+}
+
+func TestEmbedderRepairsEveryInvalidVectorState(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+	idx := New(database, 256)
+	files := map[string]string{}
+	for _, name := range []string{"metadata-only.md", "vector-only.md", "malformed.md", "wrong-size.md", "wrong-dimension.md", "zero.md", "nan.md", "inf.md"} {
+		files[name] = "# " + name + "\nContent."
+	}
+	col := makeTestCollection(t, files)
+	if _, err := idx.Index(ctx, col); err != nil {
+		t.Fatal(err)
+	}
+	provider := &fakeEmbeddingProvider{model: "model", dimension: 2}
+	embedder := NewEmbedder(database, provider, "provider", "current")
+	if err := embedder.EmbedCollection(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	provider.calls, provider.texts = 0, 0
+
+	ids := map[string]int64{}
+	rows, err := database.QueryContext(ctx, `SELECT d.path, c.id FROM chunks c JOIN documents d ON d.id=c.doc_id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for rows.Next() {
+		var path string
+		var id int64
+		if err := rows.Scan(&path, &id); err != nil {
+			t.Fatal(err)
+		}
+		ids[path] = id
+	}
+	rows.Close()
+	if _, err := database.ExecContext(ctx, `DELETE FROM chunk_vectors WHERE chunk_id=?`, ids["metadata-only.md"]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, `DELETE FROM embeddings WHERE chunk_id=?`, ids["vector-only.md"]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, `UPDATE embeddings SET dimension=1 WHERE chunk_id=?`, ids["wrong-dimension.md"]); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := map[string][]byte{
+		"malformed.md":  {1, 2, 3},
+		"wrong-size.md": vectorBlob(1),
+		"zero.md":       vectorBlob(0, 0),
+		"nan.md":        vectorBlob(float32(math.NaN()), 1),
+		"inf.md":        vectorBlob(float32(math.Inf(1)), 1),
+	}
+	for path, blob := range corrupt {
+		if _, err := database.ExecContext(ctx, `UPDATE chunk_vectors SET vector=? WHERE chunk_id=?`, blob, ids[path]); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	health, err := database.EmbeddingHealth(ctx, "current", 2, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health.Current != 0 || health.Orphaned != 8 {
+		t.Fatalf("invalid states classified as healthy: %+v", health)
+	}
+	if err := embedder.EmbedCollection(ctx, "test"); err != nil {
+		t.Fatalf("repair failed: %v", err)
+	}
+	if provider.calls != 1 || provider.texts != 8 {
+		t.Fatalf("expected all 8 invalid chunks to be re-embedded, calls=%d texts=%d", provider.calls, provider.texts)
+	}
+	health, err = database.EmbeddingHealth(ctx, "current", 2, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health.Current != 8 || health.Missing+health.Stale+health.Orphaned != 0 {
+		t.Fatalf("repair did not produce fully current embeddings: %+v", health)
+	}
+}
+
+func vectorBlob(values ...float32) []byte {
+	blob := make([]byte, len(values)*4)
+	for i, value := range values {
+		binary.LittleEndian.PutUint32(blob[i*4:], math.Float32bits(value))
+	}
+	return blob
+}
+
+// Guard against silently swallowing a provider that returns the wrong
+// number of vectors (a truncated/malformed batch response).
+func TestEmbedder_ErrorsOnMismatchedResponseCount(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+	col := makeTestCollection(t, map[string]string{
+		"a.md": "# A\nContent one.",
+		"b.md": "# B\nContent two.",
+	})
+	if _, err := idx.Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+
+	emb := NewEmbedder(database, shortProvider{}, "test-provider", "fp")
+	err := emb.EmbedCollection(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected an error when the provider returns fewer vectors than requested")
+	}
+}
+
+func TestEmbedderReturnsAggregatePersistenceErrors(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+	col := makeTestCollection(t, map[string]string{
+		"a.md": "# A\nContent one.",
+		"b.md": "# B\nContent two.",
+	})
+	if _, err := idx.Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(context.Background(), `
+		CREATE TRIGGER fail_one_vector BEFORE INSERT ON chunk_vectors
+		WHEN new.chunk_id = (SELECT MIN(id) FROM chunks)
+		BEGIN SELECT RAISE(FAIL, 'forced vector failure'); END
+	`); err != nil {
+		t.Fatal(err)
+	}
+	err := NewEmbedder(database, mixedValidityProvider{}, "p", "fp").EmbedCollection(context.Background(), "test")
+	if err == nil || !strings.Contains(err.Error(), "forced vector failure") {
+		t.Fatalf("expected failed vector write to be returned, got %v", err)
+	}
+	var stored int
+	if scanErr := database.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM embeddings`).Scan(&stored); scanErr != nil {
+		t.Fatal(scanErr)
+	}
+	if stored != 1 {
+		t.Fatalf("valid writes should persist while invalid writes are aggregated; got %d", stored)
+	}
+}
+
+type mixedValidityProvider struct{}
+
+func (mixedValidityProvider) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = []float32{1, 0}
+	}
+	return out, nil
+}
+func (mixedValidityProvider) ModelName() string { return "mixed" }
+func (mixedValidityProvider) Dimension() int    { return 2 }
+
+type shortProvider struct{}
+
+func (shortProvider) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	return [][]float32{{1, 2, 3, 4}}, nil // always returns exactly one, regardless of input size
+}
+func (shortProvider) ModelName() string { return "short" }
+func (shortProvider) Dimension() int    { return 4 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -25,11 +24,11 @@ var defaultIgnoreDirs = map[string]bool{
 	".git": true, ".hg": true, ".svn": true,
 	".venv": true, "venv": true, ".env": true,
 	"node_modules": true,
-	"vendor": true,
-	".tox": true, ".mypy_cache": true, ".pytest_cache": true, "__pycache__": true,
+	"vendor":       true,
+	".tox":         true, ".mypy_cache": true, ".pytest_cache": true, "__pycache__": true,
 	".ruff_cache": true, ".hypothesis": true,
-	"target": true,        // Rust/Java/Maven
-	"dist": true, "build": true, "out": true,
+	"target": true, // Rust/Java/Maven
+	"dist":   true, "build": true, "out": true,
 	".gradle": true, ".idea": true, ".vscode": true,
 	".DS_Store": true,
 }
@@ -46,13 +45,15 @@ type Stats struct {
 	FilesAdded   int
 	FilesUpdated int
 	FilesRemoved int
+	FilesSkipped int
 	Duration     time.Duration
 }
 
 // Indexer walks a collection and upserts documents into the DB.
 type Indexer struct {
-	db      *db.DB
-	chunker chunker.Chunker
+	db         *db.DB
+	chunker    chunker.Chunker
+	beforeRead func(string) // test hook; called after discovery, before secure open
 }
 
 func New(database *db.DB, chunkSize int) *Indexer {
@@ -86,16 +87,43 @@ func (idx *Indexer) Index(ctx context.Context, col config.Collection) (Stats, er
 		ignoreSet[ig] = true
 	}
 
-	// Track which paths we've seen to detect deletions
-	seenPaths := map[string]bool{}
+	// Canonicalize the collection root once so a configured symlinked root is
+	// pinned to its target. Entries below it are never followed through links.
+	// Keep col.Path/col.Name unchanged because document keys use the configured
+	// collection identity.
+	canonicalRoot, err := config.CanonicalPath(col.Path)
+	if err != nil {
+		canonicalRoot = filepath.Clean(col.Path)
+	}
 
-	err = filepath.WalkDir(col.Path, func(path string, d fs.DirEntry, err error) error {
+	root, err := openSecureRoot(canonicalRoot)
+	if err != nil {
+		runErr := fmt.Errorf("opening collection root %s: %w", col.Path, err)
+		if finishErr := idx.finishRun(ctx, runID, stats, runErr); finishErr != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("finishing index run: %w", finishErr))
+		}
+		return stats, runErr
+	}
+	defer root.Close()
+
+	// Track which paths we've seen to detect deletions and collect every file
+	// failure rather than reporting a successful (but stale) collection run.
+	seenPaths := map[string]bool{}
+	var fileErrs []error
+
+	err = filepath.WalkDir(canonicalRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
 			name := d.Name()
-			if defaultIgnoreDirs[name] || ignoreSet[name] || (strings.HasPrefix(name, ".") && name != ".") {
+			// Never skip the root itself based on its own basename — a
+			// collection rooted at a dot-directory or a name that matches
+			// the ignore/default-ignore sets (e.g. ~/.notes, ~/dist) would
+			// otherwise return SkipDir immediately, yielding an empty
+			// seenPaths and deactivating every document in the collection.
+			if path != canonicalRoot &&
+				(defaultIgnoreDirs[name] || ignoreSet[name] || (strings.HasPrefix(name, ".") && name != ".")) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -106,7 +134,17 @@ func (idx *Indexer) Index(ctx context.Context, col config.Collection) (Stats, er
 			return nil
 		}
 
-		relPath, err := filepath.Rel(col.Path, path)
+		// Never follow file symlinks. Containment checks followed by os.ReadFile
+		// are racy: an attacker can replace the checked entry before it opens.
+		// Regular files are opened descriptor-relatively below with O_NOFOLLOW
+		// on every component.
+		if d.Type()&fs.ModeSymlink != 0 {
+			slog.Warn("skipping symlink", "path", path)
+			stats.FilesSkipped++
+			return nil
+		}
+
+		relPath, err := filepath.Rel(canonicalRoot, path)
 		if err != nil {
 			return err
 		}
@@ -114,35 +152,45 @@ func (idx *Indexer) Index(ctx context.Context, col config.Collection) (Stats, er
 		stats.FilesScanned++
 		seenPaths[relPath] = true
 
-		if err := idx.indexFile(ctx, col, relPath, path, &stats); err != nil {
+		if idx.beforeRead != nil {
+			idx.beforeRead(path)
+		}
+		data, err := root.ReadFile(relPath)
+		if err == nil {
+			err = idx.indexFile(ctx, col, relPath, data, &stats)
+		}
+		if err != nil {
+			err = fmt.Errorf("indexing %s: %w", relPath, err)
 			slog.Warn("failed to index file", "path", relPath, "error", err)
+			fileErrs = append(fileErrs, err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		_ = idx.finishRun(ctx, runID, stats, err)
-		return stats, fmt.Errorf("walking %s: %w", col.Path, err)
+		runErr := errors.Join(errors.Join(fileErrs...), fmt.Errorf("walking %s: %w", col.Path, err))
+		if finishErr := idx.finishRun(ctx, runID, stats, runErr); finishErr != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("finishing index run: %w", finishErr))
+		}
+		return stats, runErr
 	}
 
 	// Deactivate documents that no longer exist on disk
-	removed, err := idx.deactivateMissing(ctx, col.Name, seenPaths)
-	if err != nil {
-		slog.Warn("deactivating missing files", "error", err)
-	}
+	removed, deactivateErr := idx.deactivateMissing(ctx, col.Name, seenPaths)
 	stats.FilesRemoved = removed
+	if deactivateErr != nil {
+		fileErrs = append(fileErrs, fmt.Errorf("deactivating missing files: %w", deactivateErr))
+	}
 
 	stats.Duration = time.Since(start)
-	_ = idx.finishRun(ctx, runID, stats, nil)
-	return stats, nil
+	runErr := errors.Join(fileErrs...)
+	if finishErr := idx.finishRun(ctx, runID, stats, runErr); finishErr != nil {
+		runErr = errors.Join(runErr, fmt.Errorf("finishing index run: %w", finishErr))
+	}
+	return stats, runErr
 }
 
-func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPath, absPath string, stats *Stats) error {
-	data, err := os.ReadFile(absPath)
-	if err != nil {
-		return err
-	}
-
+func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPath string, data []byte, stats *Stats) error {
 	hash := sha256sum(data)
 
 	// Check if document exists (active or deactivated) and whether content changed
@@ -254,27 +302,47 @@ func (idx *Indexer) deactivateMissing(ctx context.Context, collection string, se
 	}
 	defer rows.Close()
 
-	var toDeactivate []int64
+	toDeactivate, err := missingDocumentIDs(rows, seen)
+	if err != nil {
+		return 0, err
+	}
+
+	var errs []error
+	removed := 0
+	for _, id := range toDeactivate {
+		if _, err := idx.db.ExecContext(ctx,
+			`UPDATE documents SET active=0, updated_at=datetime('now') WHERE id=?`, id); err != nil {
+			errs = append(errs, fmt.Errorf("document %d: %w", id, err))
+			continue
+		}
+		removed++
+	}
+
+	return removed, errors.Join(errs...)
+}
+
+type rowIterator interface {
+	Next() bool
+	Scan(...any) error
+	Err() error
+}
+
+func missingDocumentIDs(rows rowIterator, seen map[string]bool) ([]int64, error) {
+	var missing []int64
 	for rows.Next() {
 		var id int64
 		var path string
 		if err := rows.Scan(&id, &path); err != nil {
-			continue
+			return nil, fmt.Errorf("scanning active document: %w", err)
 		}
 		if !seen[path] {
-			toDeactivate = append(toDeactivate, id)
+			missing = append(missing, id)
 		}
 	}
-
-	for _, id := range toDeactivate {
-		_, err := idx.db.ExecContext(ctx,
-			`UPDATE documents SET active=0, updated_at=datetime('now') WHERE id=?`, id)
-		if err != nil {
-			slog.Warn("deactivating document", "id", id, "error", err)
-		}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading active documents: %w", err)
 	}
-
-	return len(toDeactivate), nil
+	return missing, nil
 }
 
 func (idx *Indexer) startRun(ctx context.Context, collection string) (int64, error) {

--- a/internal/indexer/secure_open_unix.go
+++ b/internal/indexer/secure_open_unix.go
@@ -1,0 +1,88 @@
+//go:build aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris
+
+package indexer
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+type secureRoot struct {
+	fd int
+}
+
+// openSecureRoot traverses an absolute directory path from the filesystem root
+// without following a component replaced by a symlink after canonicalization.
+func openSecureRoot(path string) (*secureRoot, error) {
+	if !filepath.IsAbs(path) {
+		return nil, fmt.Errorf("collection root is not absolute: %q", path)
+	}
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	for _, part := range strings.Split(strings.TrimPrefix(filepath.Clean(path), string(filepath.Separator)), string(filepath.Separator)) {
+		if part == "" {
+			continue
+		}
+		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		_ = unix.Close(fd)
+		if openErr != nil {
+			return nil, openErr
+		}
+		fd = next
+	}
+	return &secureRoot{fd: fd}, nil
+}
+
+func (r *secureRoot) Close() error {
+	return unix.Close(r.fd)
+}
+
+// ReadFile opens every component relative to the pinned root. O_NOFOLLOW
+// closes final-file and intermediate-directory symlink replacement races.
+func (r *secureRoot) ReadFile(relPath string) ([]byte, error) {
+	parts := strings.Split(filepath.ToSlash(filepath.Clean(relPath)), "/")
+	if len(parts) == 0 || relPath == "." {
+		return nil, fmt.Errorf("invalid relative path %q", relPath)
+	}
+	fd, err := unix.Dup(r.fd)
+	if err != nil {
+		return nil, err
+	}
+	for i, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			_ = unix.Close(fd)
+			return nil, fmt.Errorf("unsafe path component %q", part)
+		}
+		flags := unix.O_RDONLY | unix.O_CLOEXEC | unix.O_NOFOLLOW
+		if i < len(parts)-1 {
+			flags |= unix.O_DIRECTORY
+		}
+		next, openErr := unix.Openat(fd, part, flags, 0)
+		_ = unix.Close(fd)
+		if openErr != nil {
+			return nil, openErr
+		}
+		fd = next
+	}
+	file := os.NewFile(uintptr(fd), relPath)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("creating file handle")
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file")
+	}
+	return io.ReadAll(file)
+}

--- a/internal/indexer/secure_open_unsupported.go
+++ b/internal/indexer/secure_open_unsupported.go
@@ -1,0 +1,19 @@
+//go:build !windows && !aix && !android && !darwin && !dragonfly && !freebsd && !hurd && !illumos && !ios && !linux && !netbsd && !openbsd && !solaris
+
+package indexer
+
+import "fmt"
+
+// Unsupported platforms fail closed until they gain a descriptor-relative,
+// no-follow implementation.
+type secureRoot struct{}
+
+func openSecureRoot(path string) (*secureRoot, error) {
+	return nil, fmt.Errorf("secure no-follow indexing is not supported on this platform for collection %q", path)
+}
+
+func (*secureRoot) Close() error { return nil }
+
+func (*secureRoot) ReadFile(string) ([]byte, error) {
+	return nil, fmt.Errorf("secure no-follow indexing is not supported on this platform")
+}

--- a/internal/indexer/secure_open_windows.go
+++ b/internal/indexer/secure_open_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package indexer
+
+import "fmt"
+
+// Windows needs handle-relative opens with reparse-point checks to provide the
+// same guarantee as openat(O_NOFOLLOW). Until that implementation exists,
+// indexing is disabled rather than falling back to path checks followed by
+// os.ReadFile, which would reintroduce symlink/junction traversal races.
+type secureRoot struct{}
+
+func openSecureRoot(path string) (*secureRoot, error) {
+	return nil, fmt.Errorf("secure no-follow indexing is not supported on Windows for collection %q", path)
+}
+
+func (*secureRoot) Close() error { return nil }
+
+func (*secureRoot) ReadFile(string) ([]byte, error) {
+	return nil, fmt.Errorf("secure no-follow indexing is not supported on Windows")
+}

--- a/internal/indexer/secure_open_windows_test.go
+++ b/internal/indexer/secure_open_windows_test.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package indexer
+
+import "testing"
+
+func TestWindowsSecureOpenFailsClosed(t *testing.T) {
+	if root, err := openSecureRoot(`C:\collection`); err == nil || root != nil {
+		t.Fatalf("Windows secure-open policy must fail closed, root=%v err=%v", root, err)
+	}
+}

--- a/internal/indexer/symlink_test.go
+++ b/internal/indexer/symlink_test.go
@@ -1,0 +1,351 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/itsmostafa/qi/internal/config"
+)
+
+func TestIndexer_RejectsEscapingFileSymlink(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+
+	outsideDir := t.TempDir()
+	secretPath := filepath.Join(outsideDir, "secret.md")
+	if err := os.WriteFile(secretPath, []byte("TOKEN-OUTSIDE-COLLECTION"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	collDir := t.TempDir()
+	linkPath := filepath.Join(collDir, "innocent.md")
+	if err := os.Symlink(secretPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	col := config.Collection{Name: "test", Path: collDir, Extensions: []string{".md"}}
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("Index failed: %v", err)
+	}
+	if stats.FilesAdded != 0 {
+		t.Errorf("expected 0 added, got %d", stats.FilesAdded)
+	}
+	if stats.FilesSkipped != 1 {
+		t.Errorf("expected 1 skipped, got %d", stats.FilesSkipped)
+	}
+
+	var docCount int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM documents WHERE collection='test'`).Scan(&docCount); err != nil {
+		t.Fatalf("querying documents: %v", err)
+	}
+	if docCount != 0 {
+		t.Errorf("expected no documents indexed, got %d", docCount)
+	}
+
+	var contentCount int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM content`).Scan(&contentCount); err != nil {
+		t.Fatalf("querying content: %v", err)
+	}
+	if contentCount != 0 {
+		t.Errorf("expected the outside file's content to never be stored, got %d rows", contentCount)
+	}
+}
+
+func TestIndexer_DeactivatesPreviouslyLeakedSymlinkOnReindex(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+	collDir := t.TempDir()
+	col := config.Collection{Name: "test", Path: collDir, Extensions: []string{".md"}}
+
+	// Simulate a document that was indexed before this fix existed (e.g. from
+	// an escaping symlink that used to be accepted).
+	if _, err := database.ExecContext(context.Background(),
+		`INSERT INTO content(hash, body) VALUES ('deadbeef', 'leaked secret')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(context.Background(),
+		`INSERT INTO documents(collection, path, title, content_hash, active, indexed_at, updated_at)
+		 VALUES ('test', 'innocent.md', 'innocent.md', 'deadbeef', 1, datetime('now'), datetime('now'))`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reindex an empty collection — the stale row must be deactivated since
+	// nothing in the current walk (correctly) produces that path.
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("Index failed: %v", err)
+	}
+	if stats.FilesRemoved != 1 {
+		t.Errorf("expected 1 removed, got %d", stats.FilesRemoved)
+	}
+
+	var active int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT active FROM documents WHERE collection='test' AND path='innocent.md'`).Scan(&active); err != nil {
+		t.Fatalf("querying document: %v", err)
+	}
+	if active != 0 {
+		t.Errorf("expected leaked document to be deactivated, got active=%d", active)
+	}
+}
+
+func TestIndexer_RejectsInCollectionSymlink(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+
+	collDir := t.TempDir()
+	realPath := filepath.Join(collDir, "real.md")
+	if err := os.WriteFile(realPath, []byte("# Real\nActual content."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	linkPath := filepath.Join(collDir, "alias.md")
+	if err := os.Symlink(realPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	col := config.Collection{Name: "test", Path: collDir, Extensions: []string{".md"}}
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("Index failed: %v", err)
+	}
+	if stats.FilesAdded != 1 {
+		t.Errorf("expected only real.md to be added, got %d", stats.FilesAdded)
+	}
+	if stats.FilesSkipped != 1 {
+		t.Errorf("expected the alias to be skipped, got %d", stats.FilesSkipped)
+	}
+}
+
+func TestIndexer_SkipsDanglingSymlink(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+
+	collDir := t.TempDir()
+	missingTarget := filepath.Join(collDir, "gone.md")
+	linkPath := filepath.Join(collDir, "dangling.md")
+	if err := os.Symlink(missingTarget, linkPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(collDir, "ok.md"), []byte("# OK\nFine."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	col := config.Collection{Name: "test", Path: collDir, Extensions: []string{".md"}}
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("Index failed (walk must not fail on a dangling symlink): %v", err)
+	}
+	if stats.FilesSkipped != 1 {
+		t.Errorf("expected 1 skipped, got %d", stats.FilesSkipped)
+	}
+	if stats.FilesAdded != 1 {
+		t.Errorf("expected 1 added (ok.md), got %d", stats.FilesAdded)
+	}
+}
+
+func TestIndexer_SymlinkedCollectionRootIndexesFiles(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+
+	realDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(realDir, "a.md"), []byte("# A\nContent."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := t.TempDir()
+	linkRoot := filepath.Join(parent, "collection-link")
+	if err := os.Symlink(realDir, linkRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	col := config.Collection{Name: "test", Path: linkRoot, Extensions: []string{".md"}}
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("Index failed: %v", err)
+	}
+	if stats.FilesScanned != 1 || stats.FilesAdded != 1 {
+		t.Errorf("expected the symlinked root to be walked, got scanned=%d added=%d", stats.FilesScanned, stats.FilesAdded)
+	}
+}
+
+func TestIndexer_IgnoreListedRootNameIsNotWiped(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+
+	parent := t.TempDir()
+	// "dist" is in defaultIgnoreDirs — a collection rooted there must not be
+	// treated as an ignored subdirectory of itself.
+	collDir := filepath.Join(parent, "dist")
+	if err := os.Mkdir(collDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(collDir, "a.md"), []byte("# A\nContent."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	col := config.Collection{Name: "test", Path: collDir, Extensions: []string{".md"}}
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("Index failed: %v", err)
+	}
+	if stats.FilesScanned != 1 || stats.FilesAdded != 1 {
+		t.Errorf("expected the ignore-listed root name to still be walked, got scanned=%d added=%d", stats.FilesScanned, stats.FilesAdded)
+	}
+}
+
+func TestIndexer_DotNamedRootIsNotWiped(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+
+	parent := t.TempDir()
+	collDir := filepath.Join(parent, ".notes")
+	if err := os.Mkdir(collDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(collDir, "a.md"), []byte("# A\nContent."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	col := config.Collection{Name: "test", Path: collDir, Extensions: []string{".md"}}
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("Index failed: %v", err)
+	}
+	if stats.FilesScanned != 1 || stats.FilesAdded != 1 {
+		t.Errorf("expected the dot-named root to still be walked, got scanned=%d added=%d", stats.FilesScanned, stats.FilesAdded)
+	}
+}
+
+func TestIndexer_RelPathUsesCanonicalRoot(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+
+	collDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(collDir, "a.md"), []byte("# A\nContent."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	col := config.Collection{Name: "test", Path: collDir, Extensions: []string{".md"}}
+	if _, err := idx.Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+
+	var path string
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT path FROM documents WHERE collection='test'`).Scan(&path); err != nil {
+		t.Fatalf("querying document: %v", err)
+	}
+	if path != "a.md" {
+		t.Errorf("expected relative path %q, got %q (Rel must use the canonicalized root, not the raw configured path)", "a.md", path)
+	}
+}
+
+// isCaseInsensitiveFS reports whether the filesystem backing dir treats
+// paths differing only in letter case as the same file (the macOS/Windows
+// default; typically false on Linux).
+func isCaseInsensitiveFS(t *testing.T, dir string) bool {
+	t.Helper()
+	lower := filepath.Join(dir, "case-probe.txt")
+	if err := os.WriteFile(lower, []byte("x"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	upper := filepath.Join(dir, "CASE-PROBE.TXT")
+	_, err := os.Stat(upper)
+	return err == nil
+}
+
+// Even an in-collection target is rejected: consistently not following links
+// is what makes the descriptor-relative open race-free.
+func TestIndexer_RejectsInCollectionSymlinkWithDifferentCaseTarget(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+
+	collDir := t.TempDir()
+	if !isCaseInsensitiveFS(t, collDir) {
+		t.Skip("filesystem is case-sensitive; this scenario does not apply")
+	}
+
+	subDir := filepath.Join(collDir, "sub")
+	if err := os.Mkdir(subDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	realPath := filepath.Join(subDir, "real.md")
+	if err := os.WriteFile(realPath, []byte("# Real\nContent."), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	// EvalSymlinks resolves collDir itself before we ever compare against
+	// it, so build the differently-cased target from *that* resolved form
+	// rather than the raw TempDir path.
+	canonicalColl, err := config.CanonicalPath(collDir)
+	if err != nil {
+		t.Fatalf("canonicalizing: %v", err)
+	}
+	differentCaseTarget := strings.ToUpper(filepath.Join(canonicalColl, "sub", "real.md"))
+	linkPath := filepath.Join(collDir, "alias.md")
+	if err := os.Symlink(differentCaseTarget, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	col := config.Collection{Name: "test", Path: collDir, Extensions: []string{".md"}}
+	stats, err := idx.Index(context.Background(), col)
+	if err != nil {
+		t.Fatalf("Index failed: %v", err)
+	}
+	if stats.FilesSkipped != 1 {
+		t.Errorf("expected the symlink to be skipped, got %d", stats.FilesSkipped)
+	}
+	if stats.FilesAdded != 1 {
+		t.Errorf("expected only real.md to be indexed, got %d", stats.FilesAdded)
+	}
+}
+
+func TestIndexer_RejectsFileReplacedBySymlinkBeforeOpen(t *testing.T) {
+	database := openTestDB(t)
+	idx := New(database, 256)
+	collDir := t.TempDir()
+	path := filepath.Join(collDir, "note.md")
+	if err := os.WriteFile(path, []byte("safe"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "secret.md")
+	if err := os.WriteFile(outside, []byte("TOCTOU-SECRET"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	idx.beforeRead = func(string) {
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, path); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stats, err := idx.Index(context.Background(), config.Collection{Name: "test", Path: collDir, Extensions: []string{".md"}})
+	if err == nil {
+		t.Fatal("expected replacement race to be reported")
+	}
+	if stats.FilesAdded != 0 {
+		t.Fatalf("replacement target was indexed: %+v", stats)
+	}
+	var leaked int
+	if err := database.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM content WHERE body = 'TOCTOU-SECRET'`).Scan(&leaked); err != nil {
+		t.Fatal(err)
+	}
+	if leaked != 0 {
+		t.Fatal("outside symlink target leaked into the index")
+	}
+	var recordedErr string
+	if err := database.QueryRowContext(context.Background(), `SELECT error FROM index_runs ORDER BY id DESC LIMIT 1`).Scan(&recordedErr); err != nil {
+		t.Fatal(err)
+	}
+	if recordedErr == "" {
+		t.Fatal("per-file failure was not recorded on the index run")
+	}
+}

--- a/internal/providers/embedding.go
+++ b/internal/providers/embedding.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"time"
 
@@ -44,6 +45,9 @@ type embeddingResponse struct {
 }
 
 func (p *embeddingProvider) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if p.cfg.Dimension <= 0 {
+		return nil, fmt.Errorf("embedding dimension must be positive, got %d", p.cfg.Dimension)
+	}
 	batchSize := p.cfg.BatchSize
 	if batchSize <= 0 {
 		batchSize = 32
@@ -116,12 +120,31 @@ func (p *embeddingProvider) embedBatch(ctx context.Context, texts []string) ([][
 		return nil, fmt.Errorf("embedding API error: %s", result.Error.Message)
 	}
 
-	// Sort by index to preserve order
+	// Sort by index to preserve order. Validate bounds, uniqueness, and
+	// dimension so a buggy or incompatible endpoint returns an error instead
+	// of crashing qi or letting a corrupt vector into storage.
 	embeddings := make([][]float32, len(texts))
 	for _, d := range result.Data {
-		if d.Index < len(embeddings) {
-			embeddings[d.Index] = d.Embedding
+		if d.Index < 0 || d.Index >= len(embeddings) {
+			return nil, fmt.Errorf("embedding response index %d out of range for %d inputs", d.Index, len(texts))
 		}
+		if embeddings[d.Index] != nil {
+			return nil, fmt.Errorf("embedding response has duplicate index %d", d.Index)
+		}
+		if len(d.Embedding) != p.cfg.Dimension {
+			return nil, fmt.Errorf("embedding at index %d has dimension %d, expected %d", d.Index, len(d.Embedding), p.cfg.Dimension)
+		}
+		var norm float64
+		for j, value := range d.Embedding {
+			if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+				return nil, fmt.Errorf("embedding at index %d contains non-finite value at dimension %d", d.Index, j)
+			}
+			norm += float64(value) * float64(value)
+		}
+		if norm == 0 {
+			return nil, fmt.Errorf("embedding at index %d has zero norm", d.Index)
+		}
+		embeddings[d.Index] = d.Embedding
 	}
 
 	for i, e := range embeddings {

--- a/internal/providers/embedding_validation_test.go
+++ b/internal/providers/embedding_validation_test.go
@@ -1,0 +1,108 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/itsmostafa/qi/internal/config"
+)
+
+func newRawEmbeddingServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestEmbeddingProvider_RejectsNegativeIndex(t *testing.T) {
+	srv := newRawEmbeddingServer(t, `{"data":[{"embedding":[1,2,3,4],"index":-1}]}`)
+	cfg := &config.EmbeddingProviderConfig{BaseURL: srv.URL, Model: "m", Dimension: 4}
+	p := NewEmbedding(cfg)
+
+	_, err := p.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatal("expected an error for a negative response index, got nil (must not panic either)")
+	}
+}
+
+func TestEmbeddingProvider_RejectsOutOfRangeIndex(t *testing.T) {
+	srv := newRawEmbeddingServer(t, `{"data":[{"embedding":[1,2,3,4],"index":5}]}`)
+	cfg := &config.EmbeddingProviderConfig{BaseURL: srv.URL, Model: "m", Dimension: 4}
+	p := NewEmbedding(cfg)
+
+	_, err := p.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatal("expected an error for an out-of-range response index")
+	}
+}
+
+func TestEmbeddingProvider_RejectsDuplicateIndex(t *testing.T) {
+	srv := newRawEmbeddingServer(t, `{"data":[
+		{"embedding":[1,2,3,4],"index":0},
+		{"embedding":[5,6,7,8],"index":0}
+	]}`)
+	cfg := &config.EmbeddingProviderConfig{BaseURL: srv.URL, Model: "m", Dimension: 4}
+	p := NewEmbedding(cfg)
+
+	_, err := p.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatal("expected an error for a duplicate response index")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("expected error to mention duplicate index, got: %v", err)
+	}
+}
+
+func TestEmbeddingProvider_RejectsWrongDimension(t *testing.T) {
+	// Configured for dimension 2 but the endpoint returns 3 elements.
+	srv := newRawEmbeddingServer(t, `{"data":[{"embedding":[1,2,3],"index":0}]}`)
+	cfg := &config.EmbeddingProviderConfig{BaseURL: srv.URL, Model: "m", Dimension: 2}
+	p := NewEmbedding(cfg)
+
+	_, err := p.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatal("expected an error when the returned vector length does not match the configured dimension")
+	}
+}
+
+func TestEmbeddingProviderRejectsZeroNormVector(t *testing.T) {
+	srv := newRawEmbeddingServer(t, `{"data":[{"embedding":[0,0],"index":0}]}`)
+	p := NewEmbedding(&config.EmbeddingProviderConfig{BaseURL: srv.URL, Model: "m", Dimension: 2})
+	if _, err := p.Embed(context.Background(), []string{"hello"}); err == nil || !strings.Contains(err.Error(), "zero norm") {
+		t.Fatalf("expected zero-norm error, got %v", err)
+	}
+}
+
+func TestEmbeddingProviderRejectsMalformedNonFiniteVector(t *testing.T) {
+	srv := newRawEmbeddingServer(t, `{"data":[{"embedding":[1e999,1],"index":0}]}`)
+	p := NewEmbedding(&config.EmbeddingProviderConfig{BaseURL: srv.URL, Model: "m", Dimension: 2})
+	if _, err := p.Embed(context.Background(), []string{"hello"}); err == nil {
+		t.Fatal("expected non-finite/overflow JSON number to be rejected")
+	}
+}
+
+func TestEmbeddingProviderRejectsNonPositiveDimension(t *testing.T) {
+	p := NewEmbedding(&config.EmbeddingProviderConfig{BaseURL: "http://unused", Model: "m", Dimension: 0})
+	if _, err := p.Embed(context.Background(), []string{"hello"}); err == nil {
+		t.Fatal("expected non-positive dimension to be rejected before request")
+	}
+}
+
+// Sanity: valid responses still marshal fine via the normal embeddingResponse
+// path (guards against a typo turning json field names invalid).
+func TestEmbeddingProvider_ValidResponseStillMarshals(t *testing.T) {
+	var resp embeddingResponse
+	if err := json.Unmarshal([]byte(`{"data":[{"embedding":[1,2],"index":0}]}`), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].Index != 0 {
+		t.Fatalf("unexpected decode: %+v", resp)
+	}
+}

--- a/internal/search/bm25.go
+++ b/internal/search/bm25.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/itsmostafa/qi/internal/db"
 )
@@ -25,6 +26,12 @@ func (b *BM25) Search(ctx context.Context, opts SearchOpts) ([]Result, error) {
 
 	// Escape FTS5 query: wrap each token in quotes to avoid syntax errors
 	ftsQuery := sanitizeFTSQuery(opts.Query)
+	if ftsQuery == "" {
+		// Normalization yielded no usable terms (punctuation-only, emoji-only,
+		// or entirely whitespace input). An empty MATCH expression is an
+		// FTS5 syntax error, so return no results rather than touching FTS.
+		return nil, nil
+	}
 	results, err := b.searchFTS(ctx, opts, ftsQuery)
 	if err != nil {
 		return nil, err
@@ -183,9 +190,13 @@ func ftsQueryTermsWithoutDirectives(q string) []string {
 func ftsQueryTermsFiltered(q string, dropDirectives bool) []string {
 	terms := strings.Fields(q)
 
+	// Keep letters, digits, and combining marks from any script — not just
+	// ASCII — so CJK, Cyrillic, Arabic, and accented Latin terms survive
+	// instead of collapsing to "". IsMark matters for decomposed diacritics
+	// (e.g. "e" + combining acute accent).
 	stripPunct := func(t string) string {
 		return strings.Map(func(r rune) rune {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r) {
 				return r
 			}
 			return -1

--- a/internal/search/bm25_unicode_test.go
+++ b/internal/search/bm25_unicode_test.go
@@ -1,0 +1,111 @@
+package search
+
+import (
+	"context"
+	"testing"
+)
+
+// TestBM25_MultilingualAndPunctuationQueries proves that queries in any
+// script, or with no letters/digits at all, never reach FTS5 as an invalid
+// empty MATCH expression.
+func TestBM25_MultilingualAndPunctuationQueries(t *testing.T) {
+	database := openTestDB(t)
+	ctx := context.Background()
+
+	if _, err := database.ExecContext(ctx, `
+		INSERT INTO content(hash, body) VALUES ('hcjk', 'body-cjk');
+		INSERT INTO documents(collection, path, title, content_hash)
+			VALUES ('test', 'cjk.md', 'CJK Doc', 'hcjk');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
+			VALUES ('hcjk', 1, 0, '这是 中文 文档 内容', 'Intro', 0, 9);
+
+		INSERT INTO content(hash, body) VALUES ('hcyr', 'body-cyr');
+		INSERT INTO documents(collection, path, title, content_hash)
+			VALUES ('test', 'cyr.md', 'Cyrillic Doc', 'hcyr');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
+			VALUES ('hcyr', 2, 0, 'привет мир программирование', 'Intro', 0, 27);
+
+		INSERT INTO content(hash, body) VALUES ('hara', 'body-ara');
+		INSERT INTO documents(collection, path, title, content_hash)
+			VALUES ('test', 'ara.md', 'Arabic Doc', 'hara');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
+			VALUES ('hara', 3, 0, 'مرحبا بالعالم برمجة', 'Intro', 0, 20);
+
+		INSERT INTO content(hash, body) VALUES ('hacc', 'body-acc');
+		INSERT INTO documents(collection, path, title, content_hash)
+			VALUES ('test', 'acc.md', 'Accented Doc', 'hacc');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
+			VALUES ('hacc', 4, 0, 'Le café et le résumé sont sur la façade naïve.', 'Intro', 0, 47);
+	`); err != nil {
+		t.Fatalf("seeding multilingual data: %v", err)
+	}
+
+	bm25 := NewBM25(database)
+
+	scriptCases := []struct {
+		name  string
+		query string
+		title string
+	}{
+		{"cjk", "中文", "CJK Doc"},
+		{"cyrillic", "программирование", "Cyrillic Doc"},
+		{"arabic", "برمجة", "Arabic Doc"},
+		{"accented", "café", "Accented Doc"},
+	}
+	// Note: the seeded CJK text uses spaces between logical words. FTS5's
+	// unicode61 tokenizer has no notion of CJK word segmentation, so a
+	// continuous run of CJK characters with no separators becomes one
+	// opaque token and substring queries against it won't match — that is
+	// a known, deliberately deferred limitation (see plan/audit), not
+	// something this fix attempts to solve. What this fix does guarantee is
+	// that non-ASCII runes are no longer deleted by the sanitizer and no
+	// longer produce an invalid empty MATCH expression.
+	for _, tc := range scriptCases {
+		t.Run(tc.name, func(t *testing.T) {
+			results, err := bm25.Search(ctx, SearchOpts{Query: tc.query, TopK: 10})
+			if err != nil {
+				t.Fatalf("Search(%q) returned an error instead of results: %v", tc.query, err)
+			}
+			found := false
+			for _, r := range results {
+				if r.Title == tc.title {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("Search(%q) expected to find %q, got: %+v", tc.query, tc.title, results)
+			}
+		})
+	}
+
+	emptyResultCases := []struct {
+		name  string
+		query string
+	}{
+		{"punctuation_only", "???!!!"},
+		{"emoji_only", "🎉🚀😀"},
+		{"whitespace_only", "   "},
+		{"empty", ""},
+	}
+	for _, tc := range emptyResultCases {
+		t.Run(tc.name, func(t *testing.T) {
+			results, err := bm25.Search(ctx, SearchOpts{Query: tc.query, TopK: 10})
+			if err != nil {
+				t.Fatalf("Search(%q) must not error on unusable input, got: %v", tc.query, err)
+			}
+			if len(results) != 0 {
+				t.Errorf("Search(%q) expected no results, got: %+v", tc.query, results)
+			}
+		})
+	}
+
+	t.Run("mixed_script", func(t *testing.T) {
+		results, err := bm25.Search(ctx, SearchOpts{Query: "café программирование 中文", TopK: 10})
+		if err != nil {
+			t.Fatalf("Search on mixed-script query errored: %v", err)
+		}
+		if len(results) == 0 {
+			t.Error("expected mixed-script query to return at least one result across the seeded docs")
+		}
+	})
+}

--- a/internal/search/hybrid.go
+++ b/internal/search/hybrid.go
@@ -68,8 +68,12 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 
 	// Embed the query
 	embeddings, err := h.embedding.Embed(ctx, []string{opts.Query})
-	if err != nil {
-		slog.Warn("embedding query failed, falling back to BM25", "error", err)
+	if err != nil || len(embeddings) == 0 {
+		if err == nil {
+			slog.Warn("embedding provider returned no vectors for query, falling back to BM25")
+		} else {
+			slog.Warn("embedding query failed, falling back to BM25", "error", err)
+		}
 		if opts.TopK > 0 && len(bm25Results) > opts.TopK {
 			bm25Results = bm25Results[:opts.TopK]
 		}

--- a/internal/search/vector.go
+++ b/internal/search/vector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"log/slog"
 	"math"
 	"sort"
 
@@ -14,11 +15,12 @@ import (
 // Embeddings are loaded from the DB and compared in memory.
 // For large corpora, a dedicated vector index (sqlite-vec, etc.) is preferred.
 type VectorSearch struct {
-	db *db.DB
+	db          *db.DB
+	fingerprint string
 }
 
-func NewVectorSearch(database *db.DB) *VectorSearch {
-	return &VectorSearch{db: database}
+func NewVectorSearch(database *db.DB, fingerprint string) *VectorSearch {
+	return &VectorSearch{db: database, fingerprint: fingerprint}
 }
 
 type vecCandidate struct {
@@ -28,12 +30,21 @@ type vecCandidate struct {
 
 // Search returns up to topK results nearest to the query embedding.
 func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, topK int, collection string) ([]Result, error) {
+	if err := validateVector(queryEmbedding); err != nil {
+		return nil, fmt.Errorf("invalid query embedding: %w", err)
+	}
 	if topK <= 0 {
 		topK = 10
 	}
+	if v.fingerprint == "" {
+		// No active embedding config (or, defensively, an unset fingerprint
+		// that would otherwise match every pre-upgrade legacy row). Vector
+		// search is meaningless without a configured embedder.
+		return nil, nil
+	}
 
 	var collectionFilter string
-	var args []any
+	args := []any{v.fingerprint}
 	if collection != "" {
 		collectionFilter = "AND d.collection = ?"
 		args = append(args, collection)
@@ -52,7 +63,9 @@ func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, top
 		FROM chunk_vectors cv
 		JOIN chunks c ON c.id = cv.chunk_id
 		JOIN documents d ON d.id = c.doc_id
+		JOIN embeddings em ON em.chunk_id = cv.chunk_id
 		WHERE d.active = 1
+		  AND em.fingerprint = ?
 		  %s
 	`, collectionFilter)
 
@@ -71,6 +84,13 @@ func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, top
 			&r.Title, &r.HeadingPath, &r.Snippet, &blob,
 		); err != nil {
 			return nil, err
+		}
+		if err := db.ValidateEmbeddingBlob(blob, len(queryEmbedding)); err != nil {
+			// Defense in depth: fingerprint matching should exclude stale
+			// dimensions, while shared validation also rejects malformed,
+			// non-finite, and zero-norm legacy vectors.
+			slog.Warn("skipping invalid stored vector", "chunk_id", r.ChunkID, "error", err)
+			continue
 		}
 		vec := deserializeFloat32(blob)
 		dist := cosineDistance(queryEmbedding, vec)
@@ -96,6 +116,23 @@ func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, top
 		results[i] = r
 	}
 	return results, nil
+}
+
+func validateVector(v []float32) error {
+	if len(v) == 0 {
+		return fmt.Errorf("empty vector")
+	}
+	var norm float64
+	for i, value := range v {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return fmt.Errorf("non-finite value at dimension %d", i)
+		}
+		norm += float64(value) * float64(value)
+	}
+	if norm == 0 {
+		return fmt.Errorf("zero-norm vector")
+	}
+	return nil
 }
 
 // cosineDistance returns 1 - cosine_similarity (range [0, 2]).

--- a/internal/search/vector_test.go
+++ b/internal/search/vector_test.go
@@ -1,0 +1,126 @@
+package search
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+func TestVectorSearch_FiltersByFingerprint(t *testing.T) {
+	database := openTestDB(t)
+	ctx := context.Background()
+
+	if _, err := database.ExecContext(ctx, `
+		INSERT INTO content(hash, body) VALUES ('h1', 'b1');
+		INSERT INTO documents(collection, path, title, content_hash) VALUES ('test', 'a.md', 'A', 'h1');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
+			VALUES ('h1', 1, 0, 'chunk from current model', 'Intro', 0, 25);
+
+		INSERT INTO content(hash, body) VALUES ('h2', 'b2');
+		INSERT INTO documents(collection, path, title, content_hash) VALUES ('test', 'b.md', 'B', 'h2');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
+			VALUES ('h2', 2, 0, 'chunk from stale model', 'Intro', 0, 23);
+	`); err != nil {
+		t.Fatalf("seeding documents/chunks: %v", err)
+	}
+
+	var currentChunkID, staleChunkID int64
+	if err := database.QueryRowContext(ctx, `SELECT id FROM chunks WHERE doc_id=1`).Scan(&currentChunkID); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRowContext(ctx, `SELECT id FROM chunks WHERE doc_id=2`).Scan(&staleChunkID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := database.UpsertEmbedding(ctx, currentChunkID, []float32{1, 0, 0, 0}, "test", "model-b", 4, "fp-current"); err != nil {
+		t.Fatalf("upserting current embedding: %v", err)
+	}
+	if err := database.UpsertEmbedding(ctx, staleChunkID, []float32{1, 0, 0, 0}, "test", "model-a", 4, "fp-stale"); err != nil {
+		t.Fatalf("upserting stale embedding: %v", err)
+	}
+
+	vs := NewVectorSearch(database, "fp-current")
+	results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 10, "")
+	if err != nil {
+		t.Fatalf("Search failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 result (only the current-fingerprint chunk), got %d: %+v", len(results), results)
+	}
+	if results[0].Path != "a.md" {
+		t.Errorf("expected result from a.md (current fingerprint), got %q", results[0].Path)
+	}
+}
+
+func TestVectorSearch_EmptyFingerprintReturnsNoResults(t *testing.T) {
+	database := openTestDB(t)
+	ctx := context.Background()
+
+	if _, err := database.ExecContext(ctx, `
+		INSERT INTO content(hash, body) VALUES ('h1', 'b1');
+		INSERT INTO documents(collection, path, title, content_hash) VALUES ('test', 'a.md', 'A', 'h1');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
+			VALUES ('h1', 1, 0, 'chunk text', 'Intro', 0, 10);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	var chunkID int64
+	if err := database.QueryRowContext(ctx, `SELECT id FROM chunks`).Scan(&chunkID); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a legacy pre-upgrade row: fingerprint defaults to ''.
+	if err := database.UpsertEmbedding(ctx, chunkID, []float32{1, 0, 0, 0}, "test", "model", 4, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	vs := NewVectorSearch(database, "")
+	results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 10, "")
+	if err != nil {
+		t.Fatalf("Search failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected an empty (unconfigured) active fingerprint to match nothing, got %d results", len(results))
+	}
+}
+
+func TestVectorSearchRejectsZeroNormAndNonFiniteQueries(t *testing.T) {
+	vs := NewVectorSearch(openTestDB(t), "fp")
+	if _, err := vs.Search(context.Background(), []float32{0, 0}, 10, ""); err == nil {
+		t.Fatal("expected zero-norm query rejection")
+	}
+	if _, err := vs.Search(context.Background(), []float32{1, math.Float32frombits(0x7fc00000)}, 10, ""); err == nil {
+		t.Fatal("expected non-finite query rejection")
+	}
+}
+
+func TestVectorSearch_SkipsMismatchedDimensionDefensively(t *testing.T) {
+	database := openTestDB(t)
+	ctx := context.Background()
+
+	if _, err := database.ExecContext(ctx, `
+		INSERT INTO content(hash, body) VALUES ('h1', 'b1');
+		INSERT INTO documents(collection, path, title, content_hash) VALUES ('test', 'a.md', 'A', 'h1');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
+			VALUES ('h1', 1, 0, 'chunk text', 'Intro', 0, 10);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	var chunkID int64
+	if err := database.QueryRowContext(ctx, `SELECT id FROM chunks`).Scan(&chunkID); err != nil {
+		t.Fatal(err)
+	}
+	// Same fingerprint, but a shorter vector than the query — should never
+	// happen after the fingerprint join, but must not crash if it does.
+	if err := database.UpsertEmbedding(ctx, chunkID, []float32{1, 0, 0}, "test", "model", 3, "fp-x"); err != nil {
+		t.Fatal(err)
+	}
+
+	vs := NewVectorSearch(database, "fp-x")
+	results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 10, "")
+	if err != nil {
+		t.Fatalf("Search must not error on a dimension mismatch: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected the mismatched-dimension vector to be skipped, got %d results", len(results))
+	}
+}


### PR DESCRIPTION
## Summary
- prevent collection symlink escapes and propagate indexing failures
- make database migrations atomic, recoverable, and safe under concurrent startup
- fingerprint, validate, diagnose, and repair missing, stale, orphaned, or corrupt embeddings
- support Unicode lexical queries and reject malformed provider vectors
- add the full audit report and focused regression coverage

## Verification
- `task check`
- `git diff --check`
- `go test -race ./cmd ./internal/config ./internal/db ./internal/indexer ./internal/providers ./internal/search`
- migration, concurrent-open, embedding-repair, and stale-document tests repeated 50 times
- Linux amd64/arm64, macOS amd64/arm64, and Windows amd64 cross-builds
- 160 concurrent fresh CLI startups with zero failures

## Known tradeoffs
- file symlinks inside collections are skipped
- Windows indexing fails closed until secure handle-relative traversal is implemented
- embedding repair discovery validates stored vectors linearly during indexing
