### PR TITLE
ci: gate release publication on asset verification and sync plugin version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "qi",
       "source": "./",
       "description": "Local knowledge search CLI — index documents and search them using BM25 full-text search, vector embeddings, and LLM-powered Q&A, all running locally with no external dependencies.",
-      "version": "0.5.0",
+      "version": "0.11.0",
       "author": {
         "name": "itsmostafa"
       },

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -108,5 +108,9 @@ jobs:
           for asset in qi-darwin-amd64.tar.gz qi-darwin-arm64.tar.gz qi-linux-amd64.tar.gz qi-linux-arm64.tar.gz SHA256SUMS.txt; do
             echo "$ASSETS" | grep -q "^${asset}$" && echo "✓ $asset" || { echo "✗ Missing: $asset"; exit 1; }
           done
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "${{ needs.release-please.outputs.tag_name }}" --draft=false --repo ${{ github.repository }}
       - name: Verify install.sh end to end
         run: QI_INSTALL_DIR="$RUNNER_TEMP/bin" sh install.sh

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,9 @@
       "release-type": "go",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": false,
+      "draft": true,
+      "force-tag-creation": true
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,14 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "draft": true,
-      "force-tag-creation": true
+      "force-tag-creation": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "jsonpath": "$.plugins[0].version"
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary

Two release-pipeline fixes. Releases now stay hidden until their binaries are verified, and the plugin marketplace version stops drifting from the project version.

## Commits

- `de07bea` ci: publish releases only after asset verification
- `dcdce33` ci: sync plugin marketplace version on release

## Changes

**Draft-until-verified releases**

- `draft: true` — release-please creates the GitHub release hidden. It stays off the releases page, and `/releases/latest` skips it.
- `force-tag-creation: true` — required alongside `draft`. A draft release holds a tag *name* but never creates the ref, and `build-binaries` checks out by tag. Without this the build job has nothing to check out.
- New `Publish release` step in `verify-release` flips the draft public with `gh release edit --draft=false`, but only after the preceding step confirms all five assets are attached.

A build that dies halfway now leaves a hidden draft instead of a public release with missing binaries that `install.sh` would fail on.

**Marketplace version sync**

- `.claude-plugin/marketplace.json` was maintained by hand and had drifted to `0.5.0` while the project sat at `0.11.0`. Corrected to `0.11.0`.
- An `extra-files` entry pins `$.plugins[0].version` so release-please writes it on every future release.

## Breaking Changes

None. Both changes are CI-only; no Go code is touched.

## Test Plan

- [ ] Merge and let the next release run end to end
- [ ] Confirm the tag ref is pushed while the release is still a draft
- [ ] Confirm the release flips public only after `Verify assets` passes
- [ ] Confirm release-please's next release PR bumps `.claude-plugin/marketplace.json` on its own

## Notes for review

Two things this deliberately does not solve:

1. **A failed run strands a draft plus its tag.** release-please will then consider that version released and will not re-propose it. Cleanup is `gh release delete` plus `git push --delete origin <tag>`. Left manual until it happens more than once.
2. **`Verify install.sh end to end` cannot gate anything.** It has to run after publication because `install.sh` resolves `/releases/latest`, which ignores drafts. It is a smoke test, not a guard. This is inherent to the install script's design, not an ordering mistake.

## Release Notes

No user-facing change. Internal release tooling only.

## Checklist

- [x] Conventional commit format followed
- [x] Commits use non-releasing types (`ci:`), so this does not itself trigger a version bump
- [x] Breaking changes documented (none)
- [ ] Tests pass locally — not applicable, no Go code changed