### PR TITLE
feat: fix markdown indexing, add recency search, and reclaim database space

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,11 @@ Always run `task check` before finishing any code change to ensure all checks pa
 - **Content-addressable storage**: `content` table keyed by SHA-256 hash; `documents` references by hash. Enables deduplication and O(1) change detection.
 - **Break-point chunker**: Scores chunk boundaries by type (heading=100, code fence=80, blank line=20) with distance decay from target size.
 - **Graceful degradation**: Vector search is optional — BM25 always works.
-- **Auto-generated collection names**: Collection names are derived from full path segments (e.g. `~/Projects/tools/qi` → `tools-qi`). The `--name` flag was removed from `index`; use the derived slug or configure an alias. Legacy names are normalized on startup.
+- **Auto-generated collection names**: A collection is named after its own directory (`~/Projects/tools/qi` → `qi`). Colliding names absorb leading path segments until unique (`work-notes`, `personal-notes`). The `--name` flag was removed from `index`. Legacy names are normalized on startup and indexed rows migrate via `RenameCollectionData`.
 - **Query relaxation**: BM25 search automatically falls back from conjunctive to disjunctive matching for natural-language queries that return zero results.
+- **Frontmatter is document metadata, not body text**: `internal/parser/frontmatter.go` strips YAML frontmatter before goldmark parses. `title`, `timestamp`/`date` and `tags` become document-level fields; the useful ones are re-emitted as one leading section of plain prose so they stay searchable.
+- **Post-retrieval pass**: `search.Finalize` (`internal/search/postprocess.go`) applies date sort, duplicate-snippet collapse and a 2-chunk-per-document cap over the whole candidate pool, then truncates to the caller's limit. Retrievers no longer truncate; commands call `Finalize`.
+- **Compaction on index**: every `qi index` prunes orphaned content blobs, runs FTS5 `optimize`, and `VACUUM`s when the freelist exceeds a quarter of the file.
 - **Auto-embed on index**: When an embedder is configured, chunks are embedded immediately after indexing without a separate step.
 - **Config**: Raw `gopkg.in/yaml.v3`, no viper. `~` expansion + relative path resolution.
 
@@ -38,7 +41,7 @@ internal/
   app/                Wires config + db + services
   config/             Config loading, defaults, path expansion
   db/                 SQLite open/migrate/WAL, embedding blob storage
-    migrations/       Embedded SQL migrations (001_init.sql … 005_drop_llm_cache.sql)
+    migrations/       Embedded SQL migrations (001_init.sql … 006_document_metadata.sql)
   chunker/            Break-point chunker (chunker.Chunker interface)
   indexer/            Filesystem walker, SHA-256 change detection, embedder
   output/             Text/JSON formatters
@@ -60,7 +63,7 @@ Tests use real in-memory SQLite (no mocking). Provider tests use `httptest.NewSe
 
 ## Adding a New Migration
 
-Add `internal/db/migrations/00N_description.sql` — the runner applies them in alphabetical order and skips versions already recorded in `schema_version`. Current migrations: `001_init.sql` … `005_drop_llm_cache.sql`.
+Add `internal/db/migrations/00N_description.sql` — the runner applies them in alphabetical order and skips versions already recorded in `schema_version`. Current migrations: `001_init.sql` … `006_document_metadata.sql`. An `ALTER TABLE ... ADD COLUMN` migration must also register one added column in `addedColumns` (`migrate.go`), since SQLite has no `IF NOT EXISTS` for it.
 
 ## sqlite-vec Note
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -36,10 +36,9 @@ var deleteCmd = &cobra.Command{
 			return fmt.Errorf("collection %q not found", name)
 		}
 
-		if err := a.DB.DeleteCollection(ctx, targetName); err != nil {
-			return fmt.Errorf("deleting collection data: %w", err)
-		}
-
+		// Config first: a failure here leaves the data intact and the command
+		// repeatable. The other order deletes the documents and then reports an
+		// error, with the collection still listed and nothing left to delete.
 		if inConfig {
 			cfgPath := cfgFile
 			if cfgPath == "" {
@@ -48,6 +47,10 @@ var deleteCmd = &cobra.Command{
 			if err := config.RemoveCollection(cfgPath, targetName); err != nil {
 				return fmt.Errorf("removing collection from config: %w", err)
 			}
+		}
+
+		if err := a.DB.DeleteCollection(ctx, targetName); err != nil {
+			return fmt.Errorf("deleting collection data: %w", err)
 		}
 
 		fmt.Printf("Deleted collection %q\n", targetName)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -85,9 +85,8 @@ func collectionExistsInDB(ctx context.Context, database *db.DB, name string) (bo
 		SELECT CASE WHEN
 			EXISTS (SELECT 1 FROM documents WHERE collection = ?)
 			OR EXISTS (SELECT 1 FROM index_runs WHERE collection = ?)
-			OR EXISTS (SELECT 1 FROM collections WHERE name = ?)
 		THEN 1 ELSE 0 END
-	`, name, name, name).Scan(&exists)
+	`, name, name).Scan(&exists)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -12,7 +12,7 @@ import (
 
 var doctorCmd = &cobra.Command{
 	Use:   "doctor",
-	Short: "Check configuration, database, and provider health",
+	Short: "Check configuration, database, collection paths, and embedding coverage",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ok := true
 		check := func(label string, err error) {

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var indexForce bool
+
 var indexCmd = &cobra.Command{
 	Use:   "index [path|collection]",
 	Short: "Index documents into the knowledge base",
@@ -23,8 +25,12 @@ With no arguments, indexes the current directory (named from path).
 With a path argument (absolute, relative, or starting with ~), indexes that directory (named from path).
 With a collection name, indexes the collection from config.
 
+Unchanged files are skipped by content hash. After upgrading qi, use --force to
+rebuild chunks and embeddings with the current parser.
+
 A collection name is derived automatically from the directory path:
-  /Users/alice/Projects/tools/qi -> Projects-tools-qi`,
+  /Users/alice/Projects/tools/qi -> qi
+Colliding names take on leading path segments until unique.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		a, err := app.New(ctx, cfgFile)
@@ -87,7 +93,15 @@ func autoCollection(a *app.App, absPath string) (config.Collection, error) {
 		}
 		return *existing, nil
 	}
-	slug := config.SlugFromPath(absPath)
+	// Name the new collection alongside the existing ones, or a colliding
+	// basename would be written to config and then disambiguated differently
+	// in memory on every load.
+	paths := make([]string, 0, len(a.Config.Collections)+1)
+	for _, c := range a.Config.Collections {
+		paths = append(paths, c.Path)
+	}
+	paths = append(paths, absPath)
+	slug := config.AssignCollectionNames(paths)[len(paths)-1]
 	col := config.Collection{Name: slug, Path: absPath}
 	if err := saveCollection(col); err != nil {
 		return config.Collection{}, err
@@ -142,6 +156,7 @@ func isPathArg(s string) bool {
 }
 
 func runIndex(ctx context.Context, a *app.App, collections []config.Collection) error {
+	a.Indexer.Force = indexForce
 	var collectionErrs []error
 	for _, col := range collections {
 		fmt.Printf("Indexing %q (%s)...\n", col.Name, col.Path)
@@ -164,4 +179,9 @@ func runIndex(ctx context.Context, a *app.App, collections []config.Collection) 
 		}
 	}
 	return errors.Join(collectionErrs...)
+}
+
+func init() {
+	indexCmd.Flags().BoolVar(&indexForce, "force", false,
+		"reindex files whose content is unchanged (needed after a qi upgrade changes parsing)")
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -17,6 +17,9 @@ var (
 	queryExplain    bool
 	queryCollection string
 	queryTopK       int
+	querySince      string
+	queryUntil      string
+	querySort       string
 )
 
 var queryCmd = &cobra.Command{
@@ -36,8 +39,15 @@ var queryCmd = &cobra.Command{
 			Query:      q,
 			Collection: queryCollection,
 			TopK:       queryTopK,
+			Pool:       a.Config.Search.BM25TopK,
 			Mode:       queryMode,
 			Explain:    queryExplain,
+			Since:      querySince,
+			Until:      queryUntil,
+			Sort:       querySort,
+		}
+		if err := validateSearchOpts(opts); err != nil {
+			return err
 		}
 
 		var results []search.Result
@@ -57,6 +67,7 @@ var queryCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("query failed: %w", err)
 		}
+		results = search.Finalize(results, opts)
 
 		formatter := output.New(format)
 		return formatter.WriteResults(os.Stdout, results)
@@ -64,8 +75,9 @@ var queryCmd = &cobra.Command{
 }
 
 func init() {
-	queryCmd.Flags().StringVar(&queryMode, "mode", "hybrid", "search mode: lexical, hybrid, deep")
+	queryCmd.Flags().StringVar(&queryMode, "mode", "hybrid", "search mode: lexical or hybrid (deep is currently an alias for hybrid)")
 	queryCmd.Flags().BoolVar(&queryExplain, "explain", false, "show scoring breakdown")
 	queryCmd.Flags().StringVarP(&queryCollection, "collection", "c", "", "limit to a specific collection")
 	queryCmd.Flags().IntVarP(&queryTopK, "limit", "n", 10, "number of results to return")
+	addRecencyFlags(queryCmd, &querySince, &queryUntil, &querySort)
 }

--- a/cmd/recency.go
+++ b/cmd/recency.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/itsmostafa/qi/internal/search"
+	"github.com/spf13/cobra"
+)
+
+const dateLayout = "2006-01-02"
+
+// addRecencyFlags registers the date filters shared by search and query.
+func addRecencyFlags(cmd *cobra.Command, since, until, sort *string) {
+	cmd.Flags().StringVar(since, "since", "", "only documents dated on or after YYYY-MM-DD")
+	cmd.Flags().StringVar(until, "until", "", "only documents dated on or before YYYY-MM-DD")
+	cmd.Flags().StringVar(sort, "sort", "", "result order: relevance (default) or date")
+}
+
+func validateSearchOpts(opts search.SearchOpts) error {
+	for name, value := range map[string]string{"since": opts.Since, "until": opts.Until} {
+		if value == "" {
+			continue
+		}
+		if _, err := time.Parse(dateLayout, value); err != nil {
+			return fmt.Errorf("--%s must be YYYY-MM-DD, got %q", name, value)
+		}
+	}
+	switch opts.Sort {
+	case "", "relevance", "date":
+		return nil
+	}
+	return fmt.Errorf("unknown --sort %q: use relevance or date", opts.Sort)
+}

--- a/cmd/recency.go
+++ b/cmd/recency.go
@@ -18,13 +18,20 @@ func addRecencyFlags(cmd *cobra.Command, since, until, sort *string) {
 }
 
 func validateSearchOpts(opts search.SearchOpts) error {
-	for name, value := range map[string]string{"since": opts.Since, "until": opts.Until} {
+	checkDate := func(name, value string) error {
 		if value == "" {
-			continue
+			return nil
 		}
 		if _, err := time.Parse(dateLayout, value); err != nil {
 			return fmt.Errorf("--%s must be YYYY-MM-DD, got %q", name, value)
 		}
+		return nil
+	}
+	if err := checkDate("since", opts.Since); err != nil {
+		return err
+	}
+	if err := checkDate("until", opts.Until); err != nil {
+		return err
 	}
 	switch opts.Sort {
 	case "", "relevance", "date":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/itsmostafa/qi/internal/version"
@@ -20,6 +21,12 @@ var rootCmd = &cobra.Command{
 	Short:        "Local-first knowledge search",
 	Long:         `qi indexes your local documents and lets you search and query them using BM25 and vector search.`,
 	SilenceUsage: true,
+	// --verbose was parsed but never read, so debug logging was unreachable.
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if verbose {
+			slog.SetLogLoggerLevel(slog.LevelDebug)
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if showVersion {
 			fmt.Println(version.String())
@@ -37,7 +44,7 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: ~/.config/qi/config.yaml)")
-	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "verbose output")
+	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "log debug detail to stderr")
 	rootCmd.PersistentFlags().StringVarP(&format, "format", "f", "text", "output format: text, json, markdown")
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "print version")
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"bytes"
+	"log"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// --verbose parsed but was read by nothing, so slog.Debug output was
+// unreachable from the CLI.
+func TestVerboseEnablesDebugLogging(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(nil) })
+
+	prev := slog.SetLogLoggerLevel(slog.LevelInfo)
+	t.Cleanup(func() { slog.SetLogLoggerLevel(prev) })
+	t.Cleanup(func() { verbose = false })
+
+	verbose = false
+	rootCmd.PersistentPreRun(rootCmd, nil)
+	slog.Debug("quiet-marker")
+	if strings.Contains(buf.String(), "quiet-marker") {
+		t.Error("debug output logged without --verbose")
+	}
+
+	verbose = true
+	rootCmd.PersistentPreRun(rootCmd, nil)
+	slog.Debug("verbose-marker")
+	if !strings.Contains(buf.String(), "verbose-marker") {
+		t.Error("--verbose did not enable debug logging")
+	}
+}
+
+func TestVersionShorthandIsNotVerbose(t *testing.T) {
+	if f := rootCmd.PersistentFlags().Lookup("verbose"); f == nil || f.Shorthand != "" {
+		t.Error("--verbose must not claim -v; -v is --version")
+	}
+	if f := rootCmd.Flags().Lookup("version"); f == nil || f.Shorthand != "v" {
+		t.Error("-v should be --version")
+	}
+}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -15,6 +15,9 @@ import (
 var (
 	searchCollection string
 	searchTopK       int
+	searchSince      string
+	searchUntil      string
+	searchSort       string
 )
 
 var searchCmd = &cobra.Command{
@@ -34,13 +37,21 @@ var searchCmd = &cobra.Command{
 			Query:      query,
 			Collection: searchCollection,
 			TopK:       searchTopK,
+			Pool:       a.Config.Search.BM25TopK,
 			Mode:       "lexical",
+			Since:      searchSince,
+			Until:      searchUntil,
+			Sort:       searchSort,
+		}
+		if err := validateSearchOpts(opts); err != nil {
+			return err
 		}
 
 		results, err := a.BM25.Search(ctx, opts)
 		if err != nil {
 			return fmt.Errorf("search failed: %w", err)
 		}
+		results = search.Finalize(results, opts)
 
 		formatter := output.New(format)
 		return formatter.WriteResults(os.Stdout, results)
@@ -50,4 +61,5 @@ var searchCmd = &cobra.Command{
 func init() {
 	searchCmd.Flags().StringVarP(&searchCollection, "collection", "c", "", "limit to a specific collection")
 	searchCmd.Flags().IntVarP(&searchTopK, "limit", "n", 10, "number of results to return")
+	addRecencyFlags(searchCmd, &searchSince, &searchUntil, &searchSort)
 }

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/itsmostafa/qi/internal/app"
 	"github.com/itsmostafa/qi/internal/db"
@@ -80,6 +81,12 @@ var statsCmd = &cobra.Command{
 		_ = runRow.Scan(&lastRun)
 		if lastRun == "" {
 			lastRun = "never"
+		} else {
+			// SQLite's datetime('now') is UTC. Printed raw it reads as a local
+			// time that is hours off — sometimes a date that has not happened.
+			if t, err := time.ParseInLocation("2006-01-02 15:04:05", lastRun, time.UTC); err == nil {
+				lastRun = t.Local().Format("2006-01-02 15:04:05 MST")
+			}
 		}
 
 		// Print

--- a/docs/audit-2026-09-03.md
+++ b/docs/audit-2026-09-03.md
@@ -2,10 +2,11 @@
 
 **Original audit:** 2026-08-09 against qi `ffecb1f456e23630a2807b185d71b94eb3c640d5`  
 **Re-review:** 2026-09-03 against qi `30b2fcbc` (`main`)  
+**Update:** 2026-09-03 against qi `3fd0a51` (branch `fix/parser-search-storage`)  
 **qmd comparison revision:** `e428df76bc0274d9e93eb7ca3e95673315c42e90`  
 **Scope:** Correctness, data integrity, security, reliability, performance, retrieval quality, provider behavior, CLI contracts, and comparison with [tobi/qmd](https://github.com/tobi/qmd).
 
-Findings keep their original wording and evidence. Each carries a **Status (2026-09-03)** line recording what `main` does today. No source changes were made in either pass.
+Findings keep their original wording and evidence. Each carries a **Status (2026-09-03)** line recording what `main` does today. No source changes were made in either pass. Findings that `fix/parser-search-storage` touches carry a further **Status (2026-09-03, `fix/parser-search-storage`)** line; the earlier lines are left as written, so the change is legible rather than overwritten.
 
 ## Executive summary
 
@@ -13,27 +14,28 @@ The original audit listed 17 numbered findings plus 4 lower-confidence risks. As
 
 | | Numbered findings | Lower-confidence risks |
 |---|---:|---:|
-| Resolved | 5 | 1 |
-| Partly resolved | 1 | 0 |
+| Resolved | 6 | 1 |
+| Partly resolved | 3 | 0 |
 | Moot (code removed) | 1 | 1 |
-| Open | 10 | 2 |
+| Open | 7 | 2 |
 
-One resolved finding had regressed under a dependency bump; it is repaired as of 2026-09-03 and `task check` passes again. That repair is the only source change made in this pass.
+Counts are as of the `fix/parser-search-storage` branch. Against `main` alone they were 5 / 1 / 1 / 10.
 
-**Resolved.** Symlink escape; non-ASCII and CJK FTS queries; embedding fingerprinting; embedding response and vector validation; concurrent startup and migrations (*regressed by the go-sqlite3 v0.35 bump, repaired — see below*). Among the lower-confidence risks, migration crash durability is addressed.
+One resolved finding had regressed under a dependency bump; it is repaired as of 2026-09-03 and `task check` passes again. That repair was the only source change made in the re-review pass. The `fix/parser-search-storage` branch, reviewed afterwards, is the first set of source changes aimed at the findings themselves.
 
-**Partly resolved.** Indexing failures now return a nonzero exit status and land in `index_runs.error`, but a file that fails to re-read still serves its stale text with no staleness marker.
+**Resolved.** Symlink escape; non-ASCII and CJK FTS queries; embedding fingerprinting; embedding response and vector validation; concurrent startup and migrations (*regressed by the go-sqlite3 v0.35 bump, repaired — see below*); old unreferenced content bodies (*on the branch*). Among the lower-confidence risks, migration crash durability is addressed.
+
+**Partly resolved.** Indexing failures now return a nonzero exit status and land in `index_runs.error`, but a file that fails to re-read still serves its stale text with no staleness marker. On the branch: Markdown list text is indexed but heading-only documents still produce nothing searchable, and duplicate results are capped per document without fusion identity changing.
 
 **Moot.** The two `ask`-related items — display snippets reaching the generation prompt, and prompt injection from indexed content — no longer apply. `ede05be feat!: remove the ask command and generation provider` deleted that code path.
 
 **Still open, highest value first.**
 
 1. `chunk_size: 0` hangs indexing indefinitely.
-2. Markdown list contents are dropped from the index; heading-only documents are unsearchable.
-3. Search ranks chunks rather than documents, so one file can occupy several result slots.
-4. The documented `deep` mode never invokes the configured reranker.
-5. Updated documents retain old unreferenced content bodies, including removed secrets.
-6. `qi get` still has no line ranges, byte caps, or ambiguity reporting — now qi's only interface for agent consumption.
+2. Heading-only documents are still unsearchable — the other half of the Markdown finding.
+3. Search still fuses by chunk rather than by document; the branch caps the symptom at two chunks per file.
+4. `deep` mode still never invokes a reranker. The branch stopped the docs from claiming it does, which leaves dead configuration rather than false documentation.
+5. `qi get` still has no line ranges, byte caps, or ambiguity reporting — now qi's only interface for agent consumption.
 
 ## Regression: concurrent startup fix, broken by a dependency bump, now repaired
 
@@ -102,31 +104,33 @@ At the start of the 2026-09-03 re-review `go test ./...` failed in `internal/db`
 
 Test coverage has improved substantially since the original audit. `internal/indexer/symlink_test.go`, `internal/search/bm25_unicode_test.go`, `internal/search/vector_test.go`, `internal/providers/embedding_validation_test.go`, `internal/db/concurrent_open_test.go`, and `internal/db/embedding_health_test.go` all postdate it. `internal/parser` and `internal/app` still have no tests, which is why the Markdown parser defects below survived untouched.
 
+**Update (`fix/parser-search-storage`):** `internal/parser` now has a test package — `internal/parser/markdown_test.go` — and the branch also adds `internal/search/postprocess_test.go`, `internal/indexer/compact_test.go`, `internal/db/migrate_test.go`, and `cmd/root_test.go`. `internal/app` still has none. `task check` passes on the branch: build, `go test ./...`, and `go vet ./...` all clean.
+
 The repositories were inspected and synchronized with the GitHub CLI. Both working trees were clean before this report was added.
 
 ## Priority overview
 
 Status columns are separated so the change since the original audit is legible at a glance.
 
-| Priority | Finding | Severity | 2026-08-09 | 2026-09-03 |
-|---|---|---:|---|---|
-| P0 | File symlinks escape the collection root | Critical | Fixed | **Fixed** (hardened further) |
-| P0 | Non-ASCII/CJK queries produce an invalid FTS query | Critical | Fixed | **Fixed** |
-| P0 | Embedding changes do not invalidate old vectors | Critical | Fixed | **Fixed** |
-| P0 | Index failures leave stale content and exit successfully | High | Confirmed | **Partly fixed** — exit code yes, staleness visibility no |
-| P0 | Concurrent startup and migrations race | High | Confirmed | **Fixed** — regressed by the v0.35 bump, repaired 2026-09-03 |
-| P0 | `chunk_size <= 0` can hang indexing | High | Confirmed | Open |
-| P1 | Markdown lists lose their text; heading-only docs are unsearchable | High | Confirmed | Open |
-| P1 | `deep` mode and reranking configuration are nonfunctional | High | Confirmed | Open |
-| P1 | Search returns duplicate documents by ranking chunks | High | Confirmed | Open |
-| P1 | Ask uses a short display snippet instead of full retrieved chunk text | High | Confirmed by code path | **Moot** — `ask` removed |
-| P1 | Embedding vectors and provider response indices are insufficiently validated | High | Confirmed | **Fixed** |
-| P1 | Old unreferenced content bodies remain in the database | High | Confirmed | Open |
-| P2 | Large files cause severe memory amplification | Medium | Confirmed | Open |
-| P2 | Database and initial config permissions may expose data locally | Medium | Confirmed | Open |
-| P2 | `qi init --config` initializes the wrong database | Medium | Confirmed | Open |
-| P2 | Self-update requests have no bounded timeout or size limits | Medium | Confirmed by code path | Open |
-| P2 | Several documented configuration fields are ignored or fragile | Medium | Confirmed | Open |
+| Priority | Finding | Severity | 2026-08-09 | 2026-09-03 (`main`) | `fix/parser-search-storage` |
+|---|---|---:|---|---|---|
+| P0 | File symlinks escape the collection root | Critical | Fixed | **Fixed** (hardened further) | — |
+| P0 | Non-ASCII/CJK queries produce an invalid FTS query | Critical | Fixed | **Fixed** | — |
+| P0 | Embedding changes do not invalidate old vectors | Critical | Fixed | **Fixed** | — |
+| P0 | Index failures leave stale content and exit successfully | High | Confirmed | **Partly fixed** — exit code yes, staleness visibility no | — |
+| P0 | Concurrent startup and migrations race | High | Confirmed | **Fixed** — regressed by the v0.35 bump, repaired 2026-09-03 | — |
+| P0 | `chunk_size <= 0` can hang indexing | High | Confirmed | Open | Open |
+| P1 | Markdown lists lose their text; heading-only docs are unsearchable | High | Confirmed | Open | **Partly fixed** — lists yes, heading-only no |
+| P1 | `deep` mode and reranking configuration are nonfunctional | High | Confirmed | Open | Open in code; docs no longer claim otherwise |
+| P1 | Search returns duplicate documents by ranking chunks | High | Confirmed | Open | **Partly fixed** — 2-chunk-per-doc cap, fusion identity unchanged |
+| P1 | Ask uses a short display snippet instead of full retrieved chunk text | High | Confirmed by code path | **Moot** — `ask` removed | — |
+| P1 | Embedding vectors and provider response indices are insufficiently validated | High | Confirmed | **Fixed** | — |
+| P1 | Old unreferenced content bodies remain in the database | High | Confirmed | Open | **Fixed** for updates; deactivated documents still retained |
+| P2 | Large files cause severe memory amplification | Medium | Confirmed | Open | Open |
+| P2 | Database and initial config permissions may expose data locally | Medium | Confirmed | Open | Open |
+| P2 | `qi init --config` initializes the wrong database | Medium | Confirmed | Open | Open |
+| P2 | Self-update requests have no bounded timeout or size limits | Medium | Confirmed by code path | Open | Open |
+| P2 | Several documented configuration fields are ignored or fragile | Medium | Confirmed | Open | Open — one item downgraded from wrong to unimplemented |
 
 ---
 
@@ -412,6 +416,28 @@ stored: 0 sections (title set, nothing searchable)
 
 `internal/parser` still has no test package, which is why this survived three releases untouched.
 
+**Status (2026-09-03, `fix/parser-search-storage`): partly fixed — list text yes, heading-only documents no.**
+
+`extractText` is replaced by `nodeText` (`internal/parser/markdown.go`), which walks every *descendant* of a node instead of its direct lines or immediate `ast.Text` children. List items, nested lists, blockquotes, autolinks, and code blocks now contribute their words. `*ast.ListItem` takes the whole item in one pass and returns `ast.WalkSkipChildren`, so a loose item's inner paragraph is not emitted a second time by the `*ast.Paragraph` case; `*ast.Blockquote` was dropped from the outer switch for the same reason and reaches the buffer through its paragraphs.
+
+Verified against the branch, using the finding's own input:
+
+```text
+input:  "# List\n\n- alpha uniqueitem\n- beta seconditem\n"
+stored: "- alpha uniqueitem\n- beta seconditem"
+```
+
+The heading-only half is unchanged. Headings still update `currentHeadings` without contributing to section text:
+
+```text
+input:  "# Unicorn Project\n"
+stored: title="Unicorn Project", 0 sections
+```
+
+A heading-only file *with* YAML frontmatter is now searchable, but only incidentally: the branch promotes frontmatter to document metadata and re-emits `title`, `description` and `tags` as one leading prose section (`Meta.Summary`, `internal/parser/frontmatter.go`). So `title: Unicorn Project` in frontmatter yields a chunk where a bare `# Unicorn Project` still yields none.
+
+Coverage: `internal/parser/markdown_test.go` covers lists, nested lists, loose items, blockquotes, frontmatter stripping, and ordinal offsets. Nothing covers heading-only documents or tables. The finding's closing sentence — that the absence of a parser test package is why this survived — no longer applies.
+
 ### P1: `deep` mode is identical to `hybrid`; reranking is dead code
 
 **Locations**
@@ -438,6 +464,12 @@ Either remove/deprecate the unfinished configuration until implemented, or creat
 **Status (2026-09-03): open.**
 
 `cmd/query.go:44` still routes `case "hybrid", "deep"` to the same `a.Hybrid.Search`. `providers.NewRerank` has no caller outside its own file, and `internal/app/app.go` never constructs it. `search.Result.RerankScore` is still declared and never written.
+
+**Status (2026-09-03, `fix/parser-search-storage`): open in code; the documentation half is resolved.**
+
+`cmd/query.go` still routes `case "hybrid", "deep"` to the same `a.Hybrid.Search`, `providers.NewRerank` still has no caller, and `RerankScore` is still never written. What changed is that qi stopped claiming otherwise. `docs/configuration.md` marks `providers.rerank` "parsed but currently unused" and `rerank_top_k` "Unused: no reranker is implemented"; `skills/qi-cli/SKILL.md` describes `deep` as currently identical to `hybrid`; the `--mode` flag help says "deep is currently an alias for hybrid".
+
+The finding's impact — "the documentation and configuration imply behavior that does not exist" — no longer holds. The dead configuration surface does, and the recommended fix (implement reranking, or remove the config keys) is untaken.
 
 ### P1: Search ranks chunks rather than documents, producing duplicates
 
@@ -469,6 +501,19 @@ Fuse and cap candidates by document identity. Retain the best chunk as the prima
 `internal/search/fusion.go:52` still keys the fusion map by `ChunkID`, and `BM25.searchFTS` still returns one row per chunk with no document-level cap.
 
 Verified against a real index: one file with two matching sections and one file with a single match produced three hits, the first file taking slots 1 and 3.
+
+**Status (2026-09-03, `fix/parser-search-storage`): partly fixed — capped, not fused.**
+
+`ReciprocalRankFusion` still keys its map on `ChunkID` (`internal/search/fusion.go:52`), so the finding's root cause stands. What is new is a post-retrieval pass. `search.Finalize` (`internal/search/postprocess.go`) runs over the whole candidate pool before truncation and applies `capResults`, which drops any chunk beyond the second from a single document and collapses byte-identical snippets. Retrievers no longer truncate to `TopK` themselves — every early-return path in `Hybrid.Search` lost its slice — and `cmd/search.go` and `cmd/query.go` call `Finalize` instead. `poolSize` keeps the retrieved pool at least as large as `-n`, so a `bm25_top_k` below the caller's limit no longer caps the result count.
+
+Two limits are deliberate and recorded in the source as `ponytail:` comments:
+
+- Duplicate identity is the snippet string. The same chunk reached through BM25 (a 32-token `snippet()` window) and through vector search (the whole `chunks.text`) does not compare equal, so cross-retriever duplicates of one chunk are not collapsed.
+- The per-document cap is a fixed `2`, not a configuration key.
+
+One behavioural consequence is worth stating because it changes what the qmd comparison means here: identical snippets collapse *across* documents, not only within one. A query matching a boilerplate banner repeated verbatim in twelve files now returns one of them rather than twelve. That is the intent, but it is document suppression, not document-level fusion — a document whose only match is shared boilerplate becomes unreachable by that phrase.
+
+Coverage: `internal/search/postprocess_test.go` asserts the cap, the collapse, that empty snippets are not treated as duplicates, and that `--sort date` orders the pool before the limit rather than reordering the top N.
 
 ### P1: Ask uses display snippets instead of complete retrieved chunks
 
@@ -556,6 +601,17 @@ Prune the old hash after a successful update when no document references it. If 
 **Status (2026-09-03): open.**
 
 `Indexer.indexFile` inserts the new content row and repoints the document, but never prunes the previous hash. Orphan pruning still exists only in `DB.DeleteCollection` and `DB.RenameCollectionData`. There is no garbage-collection command.
+
+**Status (2026-09-03, `fix/parser-search-storage`): fixed for the case the finding names.**
+
+`Indexer.compact` (`internal/indexer/indexer.go`) runs at the end of every `Index` call and deletes `content` rows whose hash no document references, so a superseded body no longer outlives the update that replaced it. The same pass also addresses the storage growth the finding's impact paragraph describes from the other direction: it runs FTS5 `optimize`, which merges segments SQLite otherwise never merges — the case that prompted it held 27 MiB of index behind 241 chunks — and `VACUUM`s once the freelist exceeds a quarter of the file, since neither `DELETE` nor `optimize` returns pages to the filesystem. Failures are logged, not returned: a successful index run does not fail because housekeeping did.
+
+Two boundaries, neither of which the finding as titled covers:
+
+- The prune keys on `SELECT DISTINCT content_hash FROM documents` with no `active = 1` filter, so a *deactivated* document — a file deleted from disk — keeps its body, deliberately, for the reactivation fast-path. The finding's impact sentence ("retains removed secrets") therefore remains true for deleted files until the collection itself is deleted.
+- `compact` is called once per collection, from `runIndex`'s loop, so a multi-collection `qi index` repeats the `optimize` and the freelist check N times.
+
+The recommended fix's alternative — a `qi gc` command with retention controls — is still unbuilt. Coverage: `internal/indexer/compact_test.go` (`TestIndexReclaimsSpaceAfterChurn`, `TestCompactKeepsSearchWorking`).
 
 ### P2: Large files produce severe memory amplification
 
@@ -666,6 +722,14 @@ Either implement every public configuration field or reject/deprecate it. Normal
 - Collection extensions are still matched raw: `internal/indexer/indexer.go` lowercases the file's extension but builds `allowedExts` straight from `col.Extensions`, so a configured `md` matches nothing and deactivates the collection.
 - Chunk ordinals are still section heading offsets.
 
+**Status (2026-09-03, `fix/parser-search-storage`): open, with one item downgraded from wrong to unimplemented.**
+
+- `search.chunk_overlap` — unchanged.
+- `search.default_mode` — unchanged; `cmd/query.go` still hardcodes `"hybrid"` as the flag default.
+- `providers.rerank` and `rerank_top_k` — still drive nothing, but both are now documented as unused rather than as working features. See the `deep` mode status above.
+- Collection extensions — unchanged; a configured `md` still matches nothing.
+- Chunk ordinals — still section heading offsets rather than chunk byte offsets. The branch adds the stripped frontmatter's byte length back onto them (`internal/parser/markdown.go`), which keeps them honest as offsets into the original file without making them what the field comment claims.
+
 ---
 
 ## Additional safeguards and lower-confidence risks
@@ -700,25 +764,39 @@ Compared with qmd, qi lacks bounded line-range retrieval, explicit ambiguous doc
 
 ---
 
+## Branch changes outside the audit's findings
+
+`fix/parser-search-storage` also carries work this audit never raised. It is listed here only so a later reader can tell what else moved under the findings above.
+
+- **Frontmatter is stripped and promoted** (`internal/parser/frontmatter.go`). A closed `---` block is frontmatter whether or not its YAML decodes, so an undecodable block is still kept out of chunk text instead of being indexed raw. `title`, `timestamp` and `tags` become document columns via migration `006_document_metadata.sql`.
+- **Date filters.** `--since`, `--until` and `--sort date` on `search` and `query`, filtered in SQL against `documents.doc_timestamp`. Documents indexed before migration 006 have a NULL timestamp and are excluded until reindexed, which is what `qi index --force` is for.
+- **`qi index --force`.** Change detection is by content hash, so a parser or chunker fix was previously invisible to everything already indexed.
+- **The `collections` table is dropped** (migration 006). It was written only by a collection rename, never by indexing, so `qi list` and `qi stats` could disagree. Config is now the sole source of truth for which collections exist, `documents` for which are indexed.
+- **`RenameCollectionData` no longer deletes real documents.** It matched duplicates on relative path alone, so migrating into a destination name occupied by a different directory sharing a filename destroyed data. It now requires a matching content hash and strands rather than overwrites, with a warning.
+- **Collection names are assigned over the whole set** (`config.AssignCollectionNames`), replacing a per-path slug plus a fixed depth cap that could collapse two distinct deep paths onto one name.
+- **`--verbose` is wired up.** It was parsed and read by nothing, so `slog.Debug` was unreachable from the CLI.
+- **FTS5 highlight markers are sentinels, not markup.** `<b>` tags used to reach JSON output and piped text; they are now `\x02`/`\x03`, rendered as ANSI bold on a terminal and stripped everywhere else. JSON also encodes `[]` rather than `null` for an empty result set.
+- **`qi stats` prints local time.** `datetime('now')` is UTC and was printed raw.
+
 ## Recommended implementation order
 
-Rewritten on 2026-09-03 to cover only what remains. The original five-phase plan is preserved in git history at `docs/audit-2026-08-09.md`. The `busy_timeout` regression that stood at the head of this list is fixed.
+Rewritten on 2026-09-03 to cover only what remains. The original five-phase plan is preserved in git history at `docs/audit-2026-08-09.md`. The `busy_timeout` regression that stood at the head of this list is fixed. Items `fix/parser-search-storage` has taken up are annotated inline.
 
 ### Phase 1: Stop the index from losing or hanging on real input
 
 1. Reject `chunk_size <= 0` in `Config.validate`, and clamp defensively in `NewBreakpointChunker`. Validate the other numeric search settings while there.
-2. Fix the Markdown parser: traverse descendant inline text so list items keep their content, and give heading-only documents searchable text. Add the `internal/parser` test corpus first — its absence is why this defect outlived three releases.
+2. Fix the Markdown parser: traverse descendant inline text so list items keep their content, and give heading-only documents searchable text. Add the `internal/parser` test corpus first — its absence is why this defect outlived three releases. — *Descendant traversal and the test corpus are done on `fix/parser-search-storage`. Heading-only documents still produce zero sections; that is what remains of this item.*
 3. Normalize collection extensions to lowercase with a leading dot, so a configured `md` cannot silently empty a collection.
 
 ### Phase 2: Retrieval quality
 
-1. Fuse and cap by document identity rather than `ChunkID`, keeping the best chunk as the primary match.
-2. Decide `deep` mode's fate: implement real reranking over a bounded candidate set, or remove `deep`, `providers.rerank`, and `rerank_top_k` from the config surface and the docs. Either is honest; the current state is not.
+1. Fuse and cap by document identity rather than `ChunkID`, keeping the best chunk as the primary match. — *Open. `fix/parser-search-storage` caps at two chunks per document in `search.Finalize` as a post-retrieval stopgap; fusion identity is unchanged.*
+2. Decide `deep` mode's fate: implement real reranking over a bounded candidate set, or remove `deep`, `providers.rerank`, and `rerank_top_k` from the config surface and the docs. Either is honest; the current state is not. — *`fix/parser-search-storage` took the third option: keep the surface and document it as unimplemented. Honest, but the dead config keys remain.*
 3. Wire or delete `search.default_mode` and `search.chunk_overlap`.
 
 ### Phase 3: Data hygiene and resource limits
 
-1. Prune the previous content hash after a successful update when no document references it, or add a `qi gc` command with documented retention.
+1. Prune the previous content hash after a successful update when no document references it, or add a `qi gc` command with documented retention. — *Done on `fix/parser-search-storage` as an end-of-run sweep (`Indexer.compact`), together with FTS5 `optimize` and a conditional `VACUUM`. Deactivated documents' bodies are still retained on purpose, and there is no `qi gc`.*
 2. Add a file-size cap with explicit skip reporting, plus per-run chunk and byte budgets.
 3. Enforce `0600` on the database and config files and `0700` on their directories; have `qi doctor` warn on unsafe modes.
 4. Surface per-document staleness when a file fails to re-read, so the deliberate decision not to deactivate on a transient failure stays visible.
@@ -732,7 +810,7 @@ Rewritten on 2026-09-03 to cover only what remains. The original five-phase plan
 
 ## Suggested regression matrix
 
-Coverage status as of 2026-09-03.
+Coverage status as of 2026-09-03, including `fix/parser-search-storage`.
 
 | Case | Status |
 |---|---|
@@ -741,13 +819,18 @@ Coverage status as of 2026-09-03.
 | Missing collection path returns nonzero | Verified against the built binary, indexing by collection name; not pinned in a test |
 | One failed file among many returns a detectable partial failure | Covered — `internal/indexer/symlink_test.go:309` and `cmd/index_test.go:151` |
 | CJK, accented Latin, Arabic, Cyrillic, punctuation-only, mixed-script search | Covered — `internal/search/bm25_unicode_test.go` |
-| Lists, nested lists, links, blockquotes, code blocks, tables, heading-only Markdown | **Not covered** — `internal/parser` has no tests at all |
+| Lists, nested lists, links, blockquotes, code blocks, tables, heading-only Markdown | Mostly covered — `internal/parser/markdown_test.go` covers lists, nested lists, loose items, blockquotes, and code/autolink text. Tables and heading-only documents are **not covered**, and heading-only documents still yield zero sections |
 | Embedding model, dimension, formatting, truncation, chunking changes | Covered for model/dimension/truncation — `internal/indexer/embedder_test.go`, `internal/search/vector_test.go`. Chunking is deliberately excluded from the fingerprint |
 | Negative, duplicate, missing, malformed, zero, NaN, and infinite embedding vectors | Covered — `internal/providers/embedding_validation_test.go`, `internal/db/vec_test.go`. Zero-norm and non-finite rejection, open at the original audit, is now closed |
 | Concurrent fresh database opens and opens during upgrade | Covered — `internal/db/concurrent_open_test.go`, passing again as of 2026-09-03, and now also asserting the busy timeout is the configured one rather than the driver default |
 | Zero and negative numeric configuration values | **Not covered** |
 | Large files and excessive chunk counts | **Not covered** |
-| Multiple matching chunks from one document | **Not covered** |
+| Multiple matching chunks from one document | Covered — `internal/search/postprocess_test.go` asserts the two-chunk-per-document cap and the duplicate-snippet collapse. Document-level fusion has no test because it does not exist |
+| YAML frontmatter: stripping, metadata promotion, malformed and undecodable blocks, scalar and flow tag lists | Covered — `internal/parser/markdown_test.go` |
+| Orphaned content pruned and space reclaimed after reindex churn | Covered — `internal/indexer/compact_test.go` |
+| Collection rename into a name already held by different files | Covered — `internal/db/db_test.go` (`TestRenameCollectionDataKeepsDifferentFilesSharingAPath`) |
+| Collection names stay distinct across colliding and deep paths | Covered — `internal/config/config_test.go` |
+| Date filters and `--sort date` against undated documents | Partly — `internal/search/postprocess_test.go` covers the sort and the SQL builder; no test indexes a dated corpus end to end |
 | Ask prompt receives full clean chunk text | Moot — `ask` removed |
 | Deep mode invokes reranking and hybrid mode does not | **Not covered** — nothing to cover until deep mode exists |
 | Config and database permission enforcement | **Not covered** |
@@ -760,3 +843,5 @@ The first pass of remediation went to the right places. The three critical findi
 Two things temper that. A dependency bump silently undid a P0 fix and shipped through two releases with a red test — exactly the failure mode a green suite exists to prevent. It is repaired now, and the repair was instructive: the original timeout had never worked, because the statement that set it was itself the first thing to take a lock. The bump only removed the slack that had been hiding it. Second, the untested packages are precisely where defects survived. `internal/parser` still has no tests, and its list-dropping and heading-only bugs remain reproducible byte for byte from the original audit.
 
 The remaining work clusters usefully. Retrieval quality — document-level fusion, the Markdown parser, deep mode's honesty — is what users feel. Data hygiene and resource limits are what a long-lived local index needs. And with `ask` gone, `qi get` is the whole contract between qi and the agents that read from it, which makes bounded retrieval the most valuable single addition left on the list.
+
+**Addendum, `fix/parser-search-storage`.** That branch is the first remediation pass aimed at these findings, and it went at the cluster the conclusion above named. Storage hygiene is closed for the case the finding states. The parser is half closed, and — more usefully — `internal/parser` finally has tests, which removes the condition that let the defect outlive three releases. Retrieval duplication and `deep` mode are handled at the symptom rather than the cause: a per-document cap instead of document-level fusion, and honest documentation instead of a reranker. Both are defensible as interim positions and neither should be mistaken for the fix the finding asks for. `chunk_size <= 0`, extension normalization, file-size caps, permissions, `qi init --config`, the updater's unbounded HTTP, and `qi get`'s missing contract are all untouched.

--- a/docs/audit-2026-09-03.md
+++ b/docs/audit-2026-09-03.md
@@ -104,7 +104,7 @@ At the start of the 2026-09-03 re-review `go test ./...` failed in `internal/db`
 
 Test coverage has improved substantially since the original audit. `internal/indexer/symlink_test.go`, `internal/search/bm25_unicode_test.go`, `internal/search/vector_test.go`, `internal/providers/embedding_validation_test.go`, `internal/db/concurrent_open_test.go`, and `internal/db/embedding_health_test.go` all postdate it. `internal/parser` and `internal/app` still have no tests, which is why the Markdown parser defects below survived untouched.
 
-**Update (`fix/parser-search-storage`):** `internal/parser` now has a test package — `internal/parser/markdown_test.go` — and the branch also adds `internal/search/postprocess_test.go`, `internal/indexer/compact_test.go`, `internal/db/migrate_test.go`, and `cmd/root_test.go`. `internal/app` still has none. `task check` passes on the branch: build, `go test ./...`, and `go vet ./...` all clean.
+**Update (`fix/parser-search-storage`):** `internal/parser` now has a test package — `internal/parser/markdown_test.go` — and the branch also adds `internal/search/postprocess_test.go`, `internal/indexer/compact_test.go`, `internal/db/migrate_test.go`, and `cmd/root_test.go`, and `internal/app/app_test.go`. `task check` passes on the branch: build, `go test ./...`, and `go vet ./...` all clean.
 
 The repositories were inspected and synchronized with the GitHub CLI. Both working trees were clean before this report was added.
 
@@ -773,7 +773,8 @@ Compared with qmd, qi lacks bounded line-range retrieval, explicit ambiguous doc
 - **`qi index --force`.** Change detection is by content hash, so a parser or chunker fix was previously invisible to everything already indexed.
 - **The `collections` table is dropped** (migration 006). It was written only by a collection rename, never by indexing, so `qi list` and `qi stats` could disagree. Config is now the sole source of truth for which collections exist, `documents` for which are indexed.
 - **`RenameCollectionData` no longer deletes real documents.** It matched duplicates on relative path alone, so migrating into a destination name occupied by a different directory sharing a filename destroyed data. It now requires a matching content hash and strands rather than overwrites, with a warning.
-- **Collection names are assigned over the whole set** (`config.AssignCollectionNames`), replacing a per-path slug plus a fixed depth cap that could collapse two distinct deep paths onto one name.
+- **Collection names are assigned over the whole set** (`config.AssignCollectionNames`), replacing a per-path slug plus a fixed depth cap that could collapse two distinct deep paths onto one name. `AddCollection` and `RemoveCollection` both use it, so a name lengthened by a collision resolves the same way everywhere.
+- **Legacy renames are staged.** One collection's old name can be another's new name; renaming each in place mixed their documents. `DB.RenameCollections` moves the whole set through staged names inside one transaction, and refuses — rolling back — any set it cannot land without merging unrelated collections.
 - **`--verbose` is wired up.** It was parsed and read by nothing, so `slog.Debug` was unreachable from the CLI.
 - **FTS5 highlight markers are sentinels, not markup.** `<b>` tags used to reach JSON output and piped text; they are now `\x02`/`\x03`, rendered as ANSI bold on a terminal and stripped everywhere else. JSON also encodes `[]` rather than `null` for an empty result set.
 - **`qi stats` prints local time.** `datetime('now')` is UTC and was printed raw.
@@ -828,7 +829,7 @@ Coverage status as of 2026-09-03, including `fix/parser-search-storage`.
 | Multiple matching chunks from one document | Covered — `internal/search/postprocess_test.go` asserts the two-chunk-per-document cap and the duplicate-snippet collapse. Document-level fusion has no test because it does not exist |
 | YAML frontmatter: stripping, metadata promotion, malformed and undecodable blocks, scalar and flow tag lists | Covered — `internal/parser/markdown_test.go` |
 | Orphaned content pruned and space reclaimed after reindex churn | Covered — `internal/indexer/compact_test.go` |
-| Collection rename into a name already held by different files | Covered — `internal/db/db_test.go` (`TestRenameCollectionDataKeepsDifferentFilesSharingAPath`) |
+| Collection rename into a name already held by different files | Covered — `internal/db/db_test.go` (`TestRenameCollectionDataKeepsDifferentFilesSharingAPath`, `TestRenameCollectionsHandlesChainedNames`, `TestRenameCollectionsRefusesUnresolvableChain`) |
 | Collection names stay distinct across colliding and deep paths | Covered — `internal/config/config_test.go` |
 | Date filters and `--sort date` against undated documents | Partly — `internal/search/postprocess_test.go` covers the sort and the SQL builder; no test indexes a dated corpus end to end |
 | Ask prompt receives full clean chunk text | Moot — `ask` removed |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,7 +47,7 @@ collections:
 | `extensions` | no | File extensions to index; omit to use built-in defaults (`.md .markdown .txt .text`) |
 | `ignore` | no | Directory/file names to skip during indexing |
 
-Collection names are derived from paths, for example `/Users/alice/Projects/tools/qi` becomes `Projects-tools-qi`. Duplicate generated names or duplicate canonical paths are rejected at startup.
+Collection names are the directory's own name, so `/Users/alice/Projects/tools/qi` becomes `qi`. When two collections would share a name, both take on as many leading path segments as it takes to tell them apart: `~/work/notes` and `~/personal/notes` become `work-notes` and `personal-notes`, while unaffected collections keep their short names. Names that still collide, and duplicate canonical paths, are rejected at startup.
 
 ---
 
@@ -149,7 +149,7 @@ embedding:
 
 ### `providers.rerank`
 
-Enables deep search mode (`--mode deep`). Must expose `POST /v1/rerank`.
+Parsed but currently unused: `--mode deep` runs the same path as `--mode hybrid` and no reranker is invoked. The schema is documented here because the config is accepted; the provider must expose `POST /v1/rerank` once reranking lands.
 
 ```yaml
 providers:
@@ -191,7 +191,7 @@ search:
 | `default_mode` | `hybrid` | Search mode used when `--mode` is not passed. `lexical` = BM25 only; `hybrid` = BM25 + vector with RRF fusion; `deep` = hybrid then rerank |
 | `bm25_top_k` | `50` | Candidate count retrieved from BM25 before fusion |
 | `vector_top_k` | `50` | Candidate count retrieved from vector KNN before fusion |
-| `rerank_top_k` | `10` | Top N candidates passed to the reranker in `deep` mode |
+| `rerank_top_k` | `10` | Unused: no reranker is implemented |
 | `rrf_k` | `60` | Reciprocal Rank Fusion constant; higher values reduce the influence of rank position |
 | `chunk_size` | `512` | Target chunk size in characters during indexing |
 | `chunk_overlap` | `64` | Reserved; not used by the current break-point chunker |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,7 +34,7 @@ func New(ctx context.Context, cfgPath string) (*App, error) {
 		return nil, fmt.Errorf("opening db: %w", err)
 	}
 	for _, col := range normalizableLegacyCollections(cfg.Collections) {
-		if err := database.RenameCollectionData(ctx, col.OriginalName, col.Name, col.Path); err != nil {
+		if err := database.RenameCollectionData(ctx, col.OriginalName, col.Name); err != nil {
 			_ = database.Close()
 			return nil, fmt.Errorf("normalizing collection %q: %w", col.Name, err)
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,13 +13,13 @@ import (
 
 // App wires config, db, and services together.
 type App struct {
-	Config    *config.Config
-	DB        *db.DB
-	Indexer   *indexer.Indexer
-	Embedder  *indexer.Embedder // nil if no embedding provider configured
-	BM25      *search.BM25
-	Vector    *search.VectorSearch
-	Hybrid    *search.Hybrid
+	Config   *config.Config
+	DB       *db.DB
+	Indexer  *indexer.Indexer
+	Embedder *indexer.Embedder // nil if no embedding provider configured
+	BM25     *search.BM25
+	Vector   *search.VectorSearch
+	Hybrid   *search.Hybrid
 }
 
 // New opens the database and wires all services.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/itsmostafa/qi/internal/config"
 	"github.com/itsmostafa/qi/internal/db"
@@ -33,9 +34,11 @@ func New(ctx context.Context, cfgPath string) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening db: %w", err)
 	}
+	// Best-effort: the rename is a migration, not a precondition. A set that
+	// cannot be applied rolls back whole, and warning here keeps every other
+	// command — including the `qi delete` that resolves the conflict — usable.
 	if err := database.RenameCollections(ctx, legacyRenames(cfg.Collections)); err != nil {
-		_ = database.Close()
-		return nil, fmt.Errorf("normalizing collection names: %w", err)
+		slog.Warn("collection names left unnormalized", "error", err)
 	}
 
 	// The embedding fingerprint identifies which provider endpoint and

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -33,11 +33,9 @@ func New(ctx context.Context, cfgPath string) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening db: %w", err)
 	}
-	for _, col := range normalizableLegacyCollections(cfg.Collections) {
-		if err := database.RenameCollectionData(ctx, col.OriginalName, col.Name); err != nil {
-			_ = database.Close()
-			return nil, fmt.Errorf("normalizing collection %q: %w", col.Name, err)
-		}
+	if err := database.RenameCollections(ctx, legacyRenames(cfg.Collections)); err != nil {
+		_ = database.Close()
+		return nil, fmt.Errorf("normalizing collection names: %w", err)
 	}
 
 	// The embedding fingerprint identifies which provider endpoint and
@@ -72,28 +70,30 @@ func (a *App) Close() error {
 	return a.DB.Close()
 }
 
-func normalizableLegacyCollections(collections []config.Collection) []config.Collection {
-	currentNames := map[string]bool{}
+func legacyRenames(collections []config.Collection) [][2]string {
+	stableNames := map[string]bool{}
 	legacyNameCounts := map[string]int{}
 	for _, col := range collections {
-		currentNames[col.Name] = true
-		if col.OriginalName != "" && col.OriginalName != col.Name {
-			legacyNameCounts[col.OriginalName]++
+		if col.OriginalName == "" || col.OriginalName == col.Name {
+			// Nothing moves out of this name, so its rows stay its own.
+			stableNames[col.Name] = true
+			continue
 		}
+		legacyNameCounts[col.OriginalName]++
 	}
 
-	normalizable := make([]config.Collection, 0, len(collections))
+	renames := make([][2]string, 0, len(collections))
 	for _, col := range collections {
 		if col.OriginalName == "" || col.OriginalName == col.Name {
 			continue
 		}
-		if legacyNameCounts[col.OriginalName] > 1 {
+		// Two collections claiming one legacy name, or a legacy name that is
+		// also a collection's settled name: the rows under it are ambiguous, so
+		// leave them where they are.
+		if legacyNameCounts[col.OriginalName] > 1 || stableNames[col.OriginalName] {
 			continue
 		}
-		if currentNames[col.OriginalName] {
-			continue
-		}
-		normalizable = append(normalizable, col)
+		renames = append(renames, [2]string{col.OriginalName, col.Name})
 	}
-	return normalizable
+	return renames
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,32 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/itsmostafa/qi/internal/config"
+)
+
+// The collection whose legacy name another collection is vacating must still be
+// migrated; skipping it stranded its rows and let the other one land on top.
+func TestLegacyRenamesCoverChainedNames(t *testing.T) {
+	got := legacyRenames([]config.Collection{
+		{Path: "/y/x-foo", Name: "x-foo", OriginalName: "y-x-foo"},
+		{Path: "/x/foo", Name: "foo", OriginalName: "x-foo"},
+	})
+	want := [][2]string{{"y-x-foo", "x-foo"}, {"x-foo", "foo"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("legacyRenames = %v, want %v", got, want)
+	}
+}
+
+// A legacy name that is some other collection's settled name is ambiguous.
+func TestLegacyRenamesSkipsSettledName(t *testing.T) {
+	got := legacyRenames([]config.Collection{
+		{Path: "/a/notes", Name: "notes", OriginalName: ""},
+		{Path: "/b/docs", Name: "docs", OriginalName: "notes"},
+	})
+	if len(got) != 0 {
+		t.Errorf("legacyRenames = %v, want none", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,7 +209,6 @@ func AddCollection(configPath string, col Collection) error {
 	}
 	root := doc.Content[0]
 	configDir := configFileDir(configPath)
-	col.Name = SlugFromPath(col.Path)
 
 	// Find the collections sequence node in the root mapping.
 	for i := 0; i+1 < len(root.Content); i += 2 {
@@ -217,16 +216,27 @@ func AddCollection(configPath string, col Collection) error {
 			continue
 		}
 		seq := root.Content[i+1]
+
+		// Name the whole set at once. Uniqueness is a property of the set, so
+		// naming this collection alone would hand a colliding basename to the
+		// check below and reject an addition the loader would have accepted.
+		resolved := make([]string, len(seq.Content))
+		for j, item := range seq.Content {
+			resolved[j] = resolveConfigFilePath(configDir, mappingValue(item, "path"))
+		}
+		assigned := AssignCollectionNames(append(append([]string{}, resolved...), col.Path))
+		col.Name = assigned[len(assigned)-1]
+
 		// Update an existing entry only when its canonical path matches. This
 		// lets old configs with custom names be normalized without allowing a
 		// generated-name collision to rewrite another collection's path.
-		for _, item := range seq.Content {
+		for idx, item := range seq.Content {
 			itemName := mappingValue(item, "name")
 			itemPath := mappingValue(item, "path")
-			resolvedItemPath := resolveConfigFilePath(configDir, itemPath)
+			resolvedItemPath := resolved[idx]
 			generatedName := ""
 			if itemPath != "" {
-				generatedName = SlugFromPath(resolvedItemPath)
+				generatedName = assigned[idx]
 			}
 			if !sameCanonicalPath(resolvedItemPath, col.Path) {
 				if itemName == col.Name || generatedName == col.Name {
@@ -261,7 +271,9 @@ func AddCollection(configPath string, col Collection) error {
 		return writeConfigNode(configPath, &doc)
 	}
 
-	// No collections key at all — append one.
+	// No collections key at all — this is the only collection, so its own
+	// directory name is unambiguous.
+	col.Name = SlugFromPath(col.Path)
 	seq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
 	seq.Content = append(seq.Content, collectionToNode(col))
 	root.Content = append(root.Content,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,13 +114,20 @@ func Load(path string) (*Config, error) {
 	return cfg, nil
 }
 
+// normalizeCollectionNames replaces configured names with generated ones,
+// remembering the old name so indexed rows can be migrated. Names are assigned
+// together because uniqueness is a property of the set, not of one path.
 func (c *Config) normalizeCollectionNames() {
+	paths := make([]string, len(c.Collections))
 	for i := range c.Collections {
-		generated := SlugFromPath(c.Collections[i].Path)
-		if c.Collections[i].Name != "" && c.Collections[i].Name != generated {
+		paths[i] = c.Collections[i].Path
+	}
+	generated := AssignCollectionNames(paths)
+	for i := range c.Collections {
+		if c.Collections[i].Name != "" && c.Collections[i].Name != generated[i] {
 			c.Collections[i].OriginalName = c.Collections[i].Name
 		}
-		c.Collections[i].Name = generated
+		c.Collections[i].Name = generated[i]
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -311,6 +311,16 @@ func RemoveCollection(configPath string, name string) error {
 			continue
 		}
 		seq := root.Content[i+1]
+
+		// Name the whole set, the way Load does. A per-path basename would miss
+		// the lengthened name a collision produced ("work-notes"), and deleting
+		// data under a name the config cannot then find loses the entry.
+		resolved := make([]string, len(seq.Content))
+		for j, item := range seq.Content {
+			resolved[j] = resolveConfigFilePath(configDir, mappingValue(item, "path"))
+		}
+		assigned := AssignCollectionNames(resolved)
+
 		exactIndex := -1
 		exactMatches := 0
 		legacyIndex := -1
@@ -320,7 +330,7 @@ func RemoveCollection(configPath string, name string) error {
 			itemPath := mappingValue(item, "path")
 			generatedName := ""
 			if itemPath != "" {
-				generatedName = SlugFromPath(resolveConfigFilePath(configDir, itemPath))
+				generatedName = assigned[j]
 			}
 			if generatedName == name {
 				exactIndex = j

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -438,17 +438,17 @@ func TestSlugFromPath(t *testing.T) {
 		{
 			name: "mac user project path",
 			path: "/Users/alice/Projects/tools/qi",
-			want: "Projects-tools-qi",
+			want: "qi",
 		},
 		{
 			name: "linux user project path",
 			path: "/home/alice/Projects/tools/qi",
-			want: "Projects-tools-qi",
+			want: "qi",
 		},
 		{
 			name: "spaces and punctuation",
 			path: "/tmp/My Notes/docs.v1",
-			want: "tmp-My-Notes-docs-v1",
+			want: "docs-v1",
 		},
 		{
 			name: "root fallback",
@@ -460,6 +460,40 @@ func TestSlugFromPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := SlugFromPath(tt.path); got != tt.want {
 				t.Fatalf("SlugFromPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssignCollectionNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		want  []string
+	}{
+		{
+			name:  "distinct basenames stay short",
+			paths: []string{"/Users/alice/Projects/tools/qi", "/Users/alice/Documents/health"},
+			want:  []string{"qi", "health"},
+		},
+		{
+			name:  "collision lengthens only the collided",
+			paths: []string{"/Users/alice/work/notes", "/Users/alice/personal/notes", "/Users/alice/qi"},
+			want:  []string{"work-notes", "personal-notes", "qi"},
+		},
+		{
+			name:  "lengthens until distinct",
+			paths: []string{"/Users/alice/a/x/notes", "/Users/alice/b/x/notes"},
+			want:  []string{"a-x-notes", "b-x-notes"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AssignCollectionNames(tt.paths)
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("names[%d] = %q, want %q (all: %v)", i, got[i], tt.want[i], got)
+				}
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -498,3 +498,24 @@ func TestAssignCollectionNames(t *testing.T) {
 		})
 	}
 }
+
+// A fixed depth cap used to stop lengthening before deep paths diverged,
+// collapsing two distinct collections onto one name.
+func TestAssignCollectionNamesDisambiguatesDeepPaths(t *testing.T) {
+	got := AssignCollectionNames([]string{
+		"/Users/alice/a/b/c/d/e/f/g/h/notes",
+		"/Users/alice/z/b/c/d/e/f/g/h/notes",
+	})
+	if got[0] == got[1] {
+		t.Fatalf("distinct paths collapsed to %q", got[0])
+	}
+}
+
+// Termination must not depend on a round cap: the same path twice shares every
+// segment and can never be disambiguated.
+func TestAssignCollectionNamesTerminatesOnIdenticalPaths(t *testing.T) {
+	got := AssignCollectionNames([]string{"/Users/alice/notes", "/Users/alice/notes"})
+	if got[0] != got[1] {
+		t.Errorf("identical paths got different names: %v", got)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -519,3 +519,26 @@ func TestAssignCollectionNamesTerminatesOnIdenticalPaths(t *testing.T) {
 		t.Errorf("identical paths got different names: %v", got)
 	}
 }
+
+// A collision-lengthened name must still resolve on removal: the config stores
+// the short legacy name, but every command refers to the assigned one.
+func TestRemoveCollectionResolvesCollisionLengthenedName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("collections:\n  - name: notes\n    path: /work/notes\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddCollection(path, Collection{Path: "/personal/notes"}); err != nil {
+		t.Fatalf("AddCollection: %v", err)
+	}
+	if err := RemoveCollection(path, "work-notes"); err != nil {
+		t.Fatalf("RemoveCollection(work-notes): %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Collections) != 1 || cfg.Collections[0].Path != "/personal/notes" {
+		t.Fatalf("collections = %+v, want only /personal/notes", cfg.Collections)
+	}
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -44,6 +45,11 @@ func AssignCollectionNames(paths []string) []string {
 			if len(idxs) < 2 {
 				continue
 			}
+			// The same directory listed twice cannot be told apart, and
+			// lengthening it only makes both names longer for nothing.
+			if identicalPaths(parts, idxs) {
+				continue
+			}
 			for _, i := range idxs {
 				if depth[i] < len(parts[i]) {
 					depth[i]++
@@ -61,6 +67,16 @@ func AssignCollectionNames(paths []string) []string {
 	// worse, since it depends on config order and could silently move one
 	// collection's name onto another's indexed rows.
 	return names
+}
+
+// identicalPaths reports whether every indexed path has the same segments.
+func identicalPaths(parts [][]string, idxs []int) bool {
+	for _, i := range idxs[1:] {
+		if !slices.Equal(parts[i], parts[idxs[0]]) {
+			return false
+		}
+	}
+	return true
 }
 
 // joinTail slugs the last n segments of a split path.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -9,14 +9,71 @@ import (
 
 var nonAlphanumRe = regexp.MustCompile(`[^A-Za-z0-9]+`)
 
-// SlugFromPath returns a stable collection name derived from a filesystem path.
+// SlugFromPath returns a collection name derived from a filesystem path. It is
+// the directory's own name: a full-path slug produced names too long to type
+// after -c, such as Library-Mobile-Documents-iCloud-md-obsidian-Documents-health.
+// Use AssignCollectionNames when several paths must stay distinguishable.
 func SlugFromPath(path string) string {
-	parts := collectionPathParts(path)
-	slug := strings.Join(parts, "-")
-	slug = nonAlphanumRe.ReplaceAllString(slug, "-")
-	slug = strings.Trim(slug, "-")
+	return joinTail(collectionPathParts(path), 1)
+}
+
+// maxNameDepth bounds how many trailing path segments a name may absorb while
+// resolving a collision.
+const maxNameDepth = 8
+
+// AssignCollectionNames names every path, lengthening only those that would
+// otherwise collide. Two "notes" directories become "work-notes" and
+// "personal-notes"; everything else keeps its short name.
+func AssignCollectionNames(paths []string) []string {
+	parts := make([][]string, len(paths))
+	depth := make([]int, len(paths))
+	names := make([]string, len(paths))
+	for i, p := range paths {
+		parts[i] = collectionPathParts(p)
+		depth[i] = 1
+	}
+
+	for round := 0; round < maxNameDepth; round++ {
+		for i := range paths {
+			names[i] = joinTail(parts[i], depth[i])
+		}
+		groups := map[string][]int{}
+		for i, n := range names {
+			groups[n] = append(groups[n], i)
+		}
+		deepened := false
+		for _, idxs := range groups {
+			if len(idxs) < 2 {
+				continue
+			}
+			for _, i := range idxs {
+				if depth[i] < len(parts[i]) {
+					depth[i]++
+					deepened = true
+				}
+			}
+		}
+		if !deepened {
+			break
+		}
+	}
+
+	// Paths that still collide after maxNameDepth are left identical on purpose:
+	// validate() reports them. A generated numeric suffix would be worse, since
+	// it depends on config order and could silently move one collection's name
+	// onto another's indexed rows.
+	return names
+}
+
+// joinTail slugs the last n segments of a split path.
+func joinTail(parts []string, n int) string {
+	if n > len(parts) {
+		n = len(parts)
+	}
+	slug := strings.Join(parts[len(parts)-n:], "-")
+	slug = strings.Trim(nonAlphanumRe.ReplaceAllString(slug, "-"), "-")
 	if slug == "" {
-		slug = "collection"
+		return "collection"
 	}
 	return slug
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -17,10 +17,6 @@ func SlugFromPath(path string) string {
 	return joinTail(collectionPathParts(path), 1)
 }
 
-// maxNameDepth bounds how many trailing path segments a name may absorb while
-// resolving a collision.
-const maxNameDepth = 8
-
 // AssignCollectionNames names every path, lengthening only those that would
 // otherwise collide. Two "notes" directories become "work-notes" and
 // "personal-notes"; everything else keeps its short name.
@@ -33,7 +29,9 @@ func AssignCollectionNames(paths []string) []string {
 		depth[i] = 1
 	}
 
-	for round := 0; round < maxNameDepth; round++ {
+	// Terminates on its own: depth only ever grows, and only while it is below
+	// the path's own segment count.
+	for {
 		for i := range paths {
 			names[i] = joinTail(parts[i], depth[i])
 		}
@@ -58,10 +56,10 @@ func AssignCollectionNames(paths []string) []string {
 		}
 	}
 
-	// Paths that still collide after maxNameDepth are left identical on purpose:
-	// validate() reports them. A generated numeric suffix would be worse, since
-	// it depends on config order and could silently move one collection's name
-	// onto another's indexed rows.
+	// Paths sharing every segment (the same directory twice) stay identical on
+	// purpose: validate() reports them. A generated numeric suffix would be
+	// worse, since it depends on config order and could silently move one
+	// collection's name onto another's indexed rows.
 	return names
 }
 

--- a/internal/db/concurrent_open_test.go
+++ b/internal/db/concurrent_open_test.go
@@ -30,8 +30,8 @@ func TestConcurrentFreshDatabaseOpens(t *testing.T) {
 						return
 					}
 					if _, err := database.ExecContext(ctx,
-						`INSERT INTO collections(name, path) VALUES (?, ?)`,
-						fmt.Sprintf("collection-%d", i), fmt.Sprintf("/tmp/%d", i)); err != nil {
+						`INSERT INTO index_runs(collection) VALUES (?)`,
+						fmt.Sprintf("collection-%d", i)); err != nil {
 						errs <- fmt.Errorf("write %d: %w", i, err)
 					}
 					if err := database.Close(); err != nil {
@@ -55,7 +55,7 @@ func TestConcurrentFreshDatabaseOpens(t *testing.T) {
 			}
 			defer database.Close()
 			assertDBCount(t, database, `PRAGMA busy_timeout`, int(busyTimeout.Milliseconds()))
-			assertDBCount(t, database, `SELECT COUNT(*) FROM collections`, 8)
+			assertDBCount(t, database, `SELECT COUNT(*) FROM index_runs`, 8)
 			assertDBCount(t, database, `SELECT COUNT(*) FROM schema_version WHERE version BETWEEN 1 AND 4`, 4)
 			assertDBCount(t, database, `SELECT COUNT(*) FROM schema_version WHERE version = 0`, 0)
 			assertDBCount(t, database, `SELECT COUNT(*) FROM pragma_table_info('embeddings') WHERE name = 'fingerprint'`, 1)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -167,7 +167,22 @@ func (db *DB) DeleteCollection(ctx context.Context, name string) error {
 // Documents that cannot move without overwriting a different file are left
 // under oldName, where they stay searchable and can be removed deliberately.
 func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName string) error {
-	if oldName == "" || oldName == newName {
+	return db.RenameCollections(ctx, [][2]string{{oldName, newName}})
+}
+
+// RenameCollections applies a whole set of {old, new} renames in one
+// transaction. Renames are staged through temporary names first, because one
+// collection's old name can be another's new name ("x-foo" -> "foo" alongside
+// "y-x-foo" -> "x-foo"); renaming those in place would merge unrelated
+// documents into whichever name happened to still be occupied.
+func (db *DB) RenameCollections(ctx context.Context, renames [][2]string) error {
+	var pending [][2]string
+	for _, r := range renames {
+		if r[0] != "" && r[0] != r[1] {
+			pending = append(pending, r)
+		}
+	}
+	if len(pending) == 0 {
 		return nil
 	}
 
@@ -177,6 +192,47 @@ func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName string)
 	}
 	defer tx.Rollback()
 
+	// A generated collection name never contains "/", so a staged name cannot
+	// collide with a real one.
+	staged := make([]string, len(pending))
+	for i, r := range pending {
+		staged[i] = fmt.Sprintf("/staging/%d", i)
+		if _, err := renameCollectionTx(ctx, tx, r[0], staged[i]); err != nil {
+			return err
+		}
+	}
+	for i, r := range pending {
+		stranded, err := renameCollectionTx(ctx, tx, staged[i], r[1])
+		if err != nil {
+			return err
+		}
+		if stranded == 0 {
+			continue
+		}
+		// Documents that could not move without overwriting a different file
+		// go back under their original name, where they stay searchable and
+		// can be removed deliberately. That name is free: staging emptied it.
+		slog.Warn("collection rename left documents behind: the new name is already used by different files",
+			"old", r[0], "new", r[1], "documents", stranded)
+		if _, err := renameCollectionTx(ctx, tx, staged[i], r[0]); err != nil {
+			return err
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM content WHERE hash NOT IN (
+			SELECT DISTINCT content_hash FROM documents
+		)`); err != nil {
+		return fmt.Errorf("pruning orphaned content: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// renameCollectionTx moves one collection's rows and reports how many
+// documents stayed behind because newName already holds a different file at
+// the same path.
+func renameCollectionTx(ctx context.Context, tx *sql.Tx, oldName, newName string) (int, error) {
 	for _, table := range []string{"chunk_vectors", "embeddings"} {
 		if _, err := tx.ExecContext(ctx, `
 			DELETE FROM `+table+` WHERE chunk_id IN (
@@ -186,7 +242,7 @@ func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName string)
 				                  AND new.content_hash = old.content_hash
 				WHERE old.collection = ?
 			)`, newName, oldName); err != nil {
-			return fmt.Errorf("deleting duplicate %s: %w", table, err)
+			return 0, fmt.Errorf("deleting duplicate %s: %w", table, err)
 		}
 	}
 
@@ -197,7 +253,7 @@ func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName string)
 			                  AND new.content_hash = old.content_hash
 			WHERE old.collection = ?
 		)`, newName, oldName); err != nil {
-		return fmt.Errorf("deleting duplicate chunks: %w", err)
+		return 0, fmt.Errorf("deleting duplicate chunks: %w", err)
 	}
 
 	if _, err := tx.ExecContext(ctx, `
@@ -209,7 +265,7 @@ func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName string)
 			  AND new.content_hash = old.content_hash
 		  )
 	`, oldName, newName); err != nil {
-		return fmt.Errorf("deleting duplicate documents: %w", err)
+		return 0, fmt.Errorf("deleting duplicate documents: %w", err)
 	}
 
 	// Anything still sharing a path with the destination is a different file.
@@ -221,28 +277,21 @@ func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName string)
 			SELECT 1 FROM documents new
 			WHERE new.collection = ? AND new.path = old.path
 		  )`, newName, oldName, newName); err != nil {
-		return fmt.Errorf("renaming documents: %w", err)
+		return 0, fmt.Errorf("renaming documents: %w", err)
 	}
 
 	var stranded int
 	if err := tx.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM documents WHERE collection = ?`, oldName).Scan(&stranded); err != nil {
-		return fmt.Errorf("counting unmoved documents: %w", err)
+		return 0, fmt.Errorf("counting unmoved documents: %w", err)
 	}
-	if stranded > 0 {
-		slog.Warn("collection rename left documents behind: the new name is already used by different files",
-			"old", oldName, "new", newName, "documents", stranded)
-	} else if _, err := tx.ExecContext(ctx,
-		`UPDATE index_runs SET collection = ? WHERE collection = ?`, newName, oldName); err != nil {
-		return fmt.Errorf("renaming index_runs: %w", err)
-	}
-
-	if _, err := tx.ExecContext(ctx, `
-		DELETE FROM content WHERE hash NOT IN (
-			SELECT DISTINCT content_hash FROM documents
-		)`); err != nil {
-		return fmt.Errorf("pruning orphaned content: %w", err)
+	// Run history follows the documents, so it only moves when they all did.
+	if stranded == 0 {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE index_runs SET collection = ? WHERE collection = ?`, newName, oldName); err != nil {
+			return 0, fmt.Errorf("renaming index_runs: %w", err)
+		}
 	}
 
-	return tx.Commit()
+	return stranded, nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -103,8 +103,8 @@ func (db *DB) Ping(ctx context.Context) error {
 
 // DeleteCollection removes all data associated with the given collection name:
 // chunk vectors, embeddings, chunks (FTS triggers keep chunks_fts in sync),
-// documents, index runs, and the collections table row. Orphaned content blobs
-// (not referenced by any remaining document) are also pruned.
+// documents, and index runs. Orphaned content blobs (not referenced by any
+// remaining document) are also pruned.
 func (db *DB) DeleteCollection(ctx context.Context, name string) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
@@ -145,12 +145,6 @@ func (db *DB) DeleteCollection(ctx context.Context, name string) error {
 		return fmt.Errorf("deleting index_runs: %w", err)
 	}
 
-	// collections table row
-	if _, err := tx.ExecContext(ctx,
-		`DELETE FROM collections WHERE name = ?`, name); err != nil {
-		return fmt.Errorf("deleting collection row: %w", err)
-	}
-
 	// orphaned content blobs (not referenced by any document)
 	if _, err := tx.ExecContext(ctx, `
 		DELETE FROM content WHERE hash NOT IN (
@@ -163,7 +157,7 @@ func (db *DB) DeleteCollection(ctx context.Context, name string) error {
 }
 
 // RenameCollectionData merges indexed data from oldName into newName.
-func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName, path string) error {
+func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName string) error {
 	if oldName == "" || oldName == newName {
 		return nil
 	}
@@ -210,18 +204,6 @@ func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName, path s
 	if _, err := tx.ExecContext(ctx,
 		`UPDATE index_runs SET collection = ? WHERE collection = ?`, newName, oldName); err != nil {
 		return fmt.Errorf("renaming index_runs: %w", err)
-	}
-
-	if _, err := tx.ExecContext(ctx,
-		`DELETE FROM collections WHERE name = ?`, oldName); err != nil {
-		return fmt.Errorf("deleting old collection row: %w", err)
-	}
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO collections(name, path, updated_at)
-		VALUES (?, ?, datetime('now'))
-		ON CONFLICT(name) DO UPDATE SET path = excluded.path, updated_at = datetime('now')
-	`, newName, path); err != nil {
-		return fmt.Errorf("upserting collection row: %w", err)
 	}
 
 	if _, err := tx.ExecContext(ctx, `

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -157,6 +158,14 @@ func (db *DB) DeleteCollection(ctx context.Context, name string) error {
 }
 
 // RenameCollectionData merges indexed data from oldName into newName.
+//
+// A document is a duplicate only when the destination holds the same relative
+// path AND the same content hash — that is, genuinely the same file indexed
+// under both names. Matching on path alone would delete real documents whenever
+// the destination name happened to be occupied by a different directory that
+// shares a filename, which basename-derived collection names make easy to hit.
+// Documents that cannot move without overwriting a different file are left
+// under oldName, where they stay searchable and can be removed deliberately.
 func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName string) error {
 	if oldName == "" || oldName == newName {
 		return nil
@@ -174,6 +183,7 @@ func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName string)
 				SELECT c.id FROM chunks c
 				JOIN documents old ON old.id = c.doc_id
 				JOIN documents new ON new.collection = ? AND new.path = old.path
+				                  AND new.content_hash = old.content_hash
 				WHERE old.collection = ?
 			)`, newName, oldName); err != nil {
 			return fmt.Errorf("deleting duplicate %s: %w", table, err)
@@ -184,24 +194,45 @@ func (db *DB) RenameCollectionData(ctx context.Context, oldName, newName string)
 		DELETE FROM chunks WHERE doc_id IN (
 			SELECT old.id FROM documents old
 			JOIN documents new ON new.collection = ? AND new.path = old.path
+			                  AND new.content_hash = old.content_hash
 			WHERE old.collection = ?
 		)`, newName, oldName); err != nil {
 		return fmt.Errorf("deleting duplicate chunks: %w", err)
 	}
 
 	if _, err := tx.ExecContext(ctx, `
-		DELETE FROM documents
-		WHERE collection = ?
-		  AND path IN (SELECT path FROM documents WHERE collection = ?)
+		DELETE FROM documents AS old
+		WHERE old.collection = ?
+		  AND EXISTS (
+			SELECT 1 FROM documents new
+			WHERE new.collection = ? AND new.path = old.path
+			  AND new.content_hash = old.content_hash
+		  )
 	`, oldName, newName); err != nil {
 		return fmt.Errorf("deleting duplicate documents: %w", err)
 	}
 
-	if _, err := tx.ExecContext(ctx,
-		`UPDATE documents SET collection = ? WHERE collection = ?`, newName, oldName); err != nil {
+	// Anything still sharing a path with the destination is a different file.
+	// Leaving it under oldName loses nothing and keeps UNIQUE(collection, path).
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE documents AS old SET collection = ?
+		WHERE old.collection = ?
+		  AND NOT EXISTS (
+			SELECT 1 FROM documents new
+			WHERE new.collection = ? AND new.path = old.path
+		  )`, newName, oldName, newName); err != nil {
 		return fmt.Errorf("renaming documents: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx,
+
+	var stranded int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM documents WHERE collection = ?`, oldName).Scan(&stranded); err != nil {
+		return fmt.Errorf("counting unmoved documents: %w", err)
+	}
+	if stranded > 0 {
+		slog.Warn("collection rename left documents behind: the new name is already used by different files",
+			"old", oldName, "new", newName, "documents", stranded)
+	} else if _, err := tx.ExecContext(ctx,
 		`UPDATE index_runs SET collection = ? WHERE collection = ?`, newName, oldName); err != nil {
 		return fmt.Errorf("renaming index_runs: %w", err)
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -192,8 +192,12 @@ func (db *DB) RenameCollections(ctx context.Context, renames [][2]string) error 
 	}
 	defer tx.Rollback()
 
-	// A generated collection name never contains "/", so a staged name cannot
-	// collide with a real one.
+	// Generated collection names are alphanumeric and "-", so a staged name
+	// cannot collide with one.
+	targets := make(map[string]bool, len(pending))
+	for _, r := range pending {
+		targets[r[1]] = true
+	}
 	staged := make([]string, len(pending))
 	for i, r := range pending {
 		staged[i] = fmt.Sprintf("/staging/%d", i)
@@ -209,9 +213,17 @@ func (db *DB) RenameCollections(ctx context.Context, renames [][2]string) error 
 		if stranded == 0 {
 			continue
 		}
-		// Documents that could not move without overwriting a different file
-		// go back under their original name, where they stay searchable and
-		// can be removed deliberately. That name is free: staging emptied it.
+		// Documents that could not move without overwriting a different file go
+		// back under their original name, where they stay searchable and can be
+		// removed deliberately. Staging emptied that name — unless another
+		// rename in this set has since landed on it, in which case there is no
+		// name left that means what these documents mean. Fail the whole set
+		// rather than merge them into a collection they do not belong to.
+		if targets[r[0]] {
+			return fmt.Errorf("cannot rename collection %q to %q: %d documents collide with %q, "+
+				"and %q is now another collection's name; rename one of them by hand",
+				r[0], r[1], stranded, r[1], r[0])
+		}
 		slog.Warn("collection rename left documents behind: the new name is already used by different files",
 			"old", r[0], "new", r[1], "documents", stranded)
 		if _, err := renameCollectionTx(ctx, tx, staged[i], r[0]); err != nil {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -23,7 +23,7 @@ func TestRenameCollectionDataMergesDuplicateDocuments(t *testing.T) {
 		t.Fatalf("inserting index run: %v", err)
 	}
 
-	if err := database.RenameCollectionData(ctx, "old", "new", "/tmp/new"); err != nil {
+	if err := database.RenameCollectionData(ctx, "old", "new"); err != nil {
 		t.Fatalf("renaming collection data: %v", err)
 	}
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -147,3 +147,31 @@ func TestRenameCollectionsHandlesChainedNames(t *testing.T) {
 	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'foo'`, 1)
 	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'y-x-foo'`, 0)
 }
+
+// A chained rename whose second hop strands documents has nowhere safe to put
+// them: the first hop has already taken the name they came from.
+func TestRenameCollectionsRefusesUnresolvableChain(t *testing.T) {
+	ctx := context.Background()
+	database, err := Open(ctx, filepath.Join(t.TempDir(), "qi.db"))
+	if err != nil {
+		t.Fatalf("opening db: %v", err)
+	}
+	defer database.Close()
+
+	insertRenameTestDocument(t, database, "y-x-foo", "a.md", "from y")
+	insertRenameTestDocument(t, database, "x-foo", "b.md", "from x")
+	insertRenameTestDocument(t, database, "foo", "b.md", "a different b")
+
+	if err := database.RenameCollections(ctx, [][2]string{
+		{"y-x-foo", "x-foo"},
+		{"x-foo", "foo"},
+	}); err == nil {
+		t.Fatal("RenameCollections succeeded, want an error")
+	}
+
+	// Nothing moved: the whole set rolls back rather than mixing collections.
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'y-x-foo'`, 1)
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'x-foo'`, 1)
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'foo'`, 1)
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection LIKE '/staging/%'`, 0)
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -120,3 +120,30 @@ func TestRenameCollectionDataKeepsDifferentFilesSharingAPath(t *testing.T) {
 	// rather than being deleted.
 	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'old'`, 1)
 }
+
+// One collection's old name is another's new name. Renaming in place would
+// merge the chain's documents into whichever name was still occupied.
+func TestRenameCollectionsHandlesChainedNames(t *testing.T) {
+	ctx := context.Background()
+	database, err := Open(ctx, filepath.Join(t.TempDir(), "qi.db"))
+	if err != nil {
+		t.Fatalf("opening db: %v", err)
+	}
+	defer database.Close()
+
+	insertRenameTestDocument(t, database, "y-x-foo", "a.md", "from y")
+	insertRenameTestDocument(t, database, "x-foo", "b.md", "from x")
+
+	if err := database.RenameCollections(ctx, [][2]string{
+		{"y-x-foo", "x-foo"},
+		{"x-foo", "foo"},
+	}); err != nil {
+		t.Fatalf("renaming collections: %v", err)
+	}
+
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'x-foo' AND path = 'a.md'`, 1)
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'x-foo'`, 1)
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'foo' AND path = 'b.md'`, 1)
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'foo'`, 1)
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'y-x-foo'`, 0)
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -16,9 +16,10 @@ func TestRenameCollectionDataMergesDuplicateDocuments(t *testing.T) {
 	}
 	defer database.Close()
 
-	insertRenameTestDocument(t, database, "old", "same.md", "old same")
+	// The same file indexed under both names: identical bytes, identical hash.
+	insertRenameTestDocument(t, database, "old", "same.md", "shared body")
 	insertRenameTestDocument(t, database, "old", "old.md", "old only")
-	insertRenameTestDocument(t, database, "new", "same.md", "new same")
+	insertRenameTestDocument(t, database, "new", "same.md", "shared body")
 	if _, err := database.ExecContext(ctx, `INSERT INTO index_runs(collection) VALUES ('old')`); err != nil {
 		t.Fatalf("inserting index run: %v", err)
 	}
@@ -41,7 +42,7 @@ func TestRenameCollectionDataMergesDuplicateDocuments(t *testing.T) {
 func insertRenameTestDocument(t *testing.T, database *DB, collection, path, body string) {
 	t.Helper()
 	ctx := context.Background()
-	sum := sha256.Sum256([]byte(collection + "\x00" + path + "\x00" + body))
+	sum := sha256.Sum256([]byte(body))
 	hash := hex.EncodeToString(sum[:])
 	if _, err := database.ExecContext(ctx,
 		`INSERT OR IGNORE INTO content(hash, body) VALUES (?, ?)`,
@@ -92,4 +93,30 @@ func assertDBCount(t *testing.T, database *DB, query string, want int) {
 	if got != want {
 		t.Fatalf("unexpected count for %q: got %d, want %d", query, got, want)
 	}
+}
+
+// Basename-derived collection names make it easy for a rename target to be
+// occupied by a different directory. Matching duplicates on path alone deleted
+// the user's real documents; only genuinely identical files may be dropped.
+func TestRenameCollectionDataKeepsDifferentFilesSharingAPath(t *testing.T) {
+	ctx := context.Background()
+	database, err := Open(ctx, filepath.Join(t.TempDir(), "qi.db"))
+	if err != nil {
+		t.Fatalf("opening db: %v", err)
+	}
+	defer database.Close()
+
+	insertRenameTestDocument(t, database, "old", "shared.md", "the real document")
+	insertRenameTestDocument(t, database, "new", "shared.md", "an unrelated file")
+
+	if err := database.RenameCollectionData(ctx, "old", "new"); err != nil {
+		t.Fatalf("renaming collection data: %v", err)
+	}
+
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents`, 2)
+	assertDBCount(t, database,
+		`SELECT COUNT(*) FROM content WHERE CAST(body AS TEXT) = 'the real document'`, 1)
+	// It could not move without overwriting a different file, so it stays put
+	// rather than being deleted.
+	assertDBCount(t, database, `SELECT COUNT(*) FROM documents WHERE collection = 'old'`, 1)
 }

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -73,12 +73,13 @@ func runMigrations(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("reading migration %s: %w", name, err)
 		}
 
-		// Early builds of migration 004 could commit the ALTER TABLE before
-		// recording schema_version. Treat that exact state as already applied;
-		// all new applications execute the DDL and version marker atomically.
+		// SQLite has no ALTER TABLE ADD COLUMN IF NOT EXISTS, so a migration
+		// whose DDL committed without its schema_version marker (early builds
+		// of 004 did this) would fail forever on re-run. Treat the column
+		// already being present as "applied" and just record the marker.
 		alreadyApplied := false
-		if ver == 4 {
-			alreadyApplied, err = columnExists(ctx, tx, "embeddings", "fingerprint")
+		if c, ok := addedColumns[ver]; ok {
+			alreadyApplied, err = columnExists(ctx, tx, c.table, c.column)
 		}
 		if err == nil && !alreadyApplied {
 			_, err = tx.ExecContext(ctx, string(data))
@@ -122,6 +123,13 @@ func appliedVersions(ctx context.Context, tx *sql.Tx) (map[int]bool, error) {
 		return nil, fmt.Errorf("reading schema version: %w", err)
 	}
 	return applied, nil
+}
+
+// addedColumns names one column added by each ALTER TABLE migration, used to
+// detect a DDL-committed-but-unversioned state.
+var addedColumns = map[int]struct{ table, column string }{
+	4: {"embeddings", "fingerprint"},
+	6: {"documents", "doc_timestamp"},
 }
 
 func columnExists(ctx context.Context, tx *sql.Tx, table, column string) (bool, error) {

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -125,11 +125,13 @@ func appliedVersions(ctx context.Context, tx *sql.Tx) (map[int]bool, error) {
 	return applied, nil
 }
 
-// addedColumns names one column added by each ALTER TABLE migration, used to
-// detect a DDL-committed-but-unversioned state.
+// addedColumns names the LAST column each ALTER TABLE migration adds, used to
+// detect a DDL-committed-but-unversioned state. It must be the last one: an
+// earlier column proves only that the migration started, and treating a torn
+// half as applied would leave the rest of its DDL permanently unrun.
 var addedColumns = map[int]struct{ table, column string }{
 	4: {"embeddings", "fingerprint"},
-	6: {"documents", "doc_timestamp"},
+	6: {"documents", "tags"},
 }
 
 func columnExists(ctx context.Context, tx *sql.Tx, table, column string) (bool, error) {

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -37,3 +37,37 @@ func TestMigration004RecoversAfterColumnAddedWithoutVersion(t *testing.T) {
 		t.Fatalf("recovery left version=%d columns=%d, want 1/1", versions, columns)
 	}
 }
+
+// Migration 006's DDL can be present without its schema_version marker on any
+// database opened by a build that shipped the file before it recorded its own
+// version. Re-running the ALTER TABLE would fail, so the guard must recognise
+// the completed state and record the marker instead.
+func TestMigration006RecoversAfterColumnsAddedWithoutVersion(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "qi.db")
+	database, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, `DELETE FROM schema_version WHERE version = 6`); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err = Open(ctx, path)
+	if err != nil {
+		t.Fatalf("reopening partially applied migration: %v", err)
+	}
+	defer database.Close()
+
+	var versions int
+	if err := database.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM schema_version WHERE version = 6`).Scan(&versions); err != nil {
+		t.Fatal(err)
+	}
+	if versions != 1 {
+		t.Errorf("recovery left version 6 unrecorded")
+	}
+}

--- a/internal/db/migrations/006_document_metadata.sql
+++ b/internal/db/migrations/006_document_metadata.sql
@@ -1,0 +1,14 @@
+-- Promote YAML frontmatter to document-level fields so recency filters and tag
+-- lookups have something to query. Both are NULL for documents indexed before
+-- this migration; the next `qi index` of a changed file backfills them.
+ALTER TABLE documents ADD COLUMN doc_timestamp TEXT;
+ALTER TABLE documents ADD COLUMN tags TEXT;  -- JSON array
+
+CREATE INDEX IF NOT EXISTS idx_documents_timestamp ON documents(doc_timestamp);
+
+-- The collections table was never populated by indexing: `qi index` writes the
+-- config file instead, so the table held rows only after a collection rename.
+-- `qi list` and `qi stats` therefore disagreed. Config is the single source of
+-- truth for which collections exist; the documents table is the source of truth
+-- for which are indexed.
+DROP TABLE IF EXISTS collections;

--- a/internal/db/migrations/006_document_metadata.sql
+++ b/internal/db/migrations/006_document_metadata.sql
@@ -12,3 +12,5 @@ CREATE INDEX IF NOT EXISTS idx_documents_timestamp ON documents(doc_timestamp);
 -- truth for which collections exist; the documents table is the source of truth
 -- for which are indexed.
 DROP TABLE IF EXISTS collections;
+
+INSERT OR IGNORE INTO schema_version(version) VALUES (6);

--- a/internal/indexer/compact_test.go
+++ b/internal/indexer/compact_test.go
@@ -1,0 +1,127 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/itsmostafa/qi/internal/config"
+)
+
+// Reindexing churn used to grow the file without bound: FTS5 never merged its
+// segments and freed pages were never returned. 188 MB held 200 KB of notes.
+func TestIndexReclaimsSpaceAfterChurn(t *testing.T) {
+	database := openTestDB(t)
+	dir := t.TempDir()
+	col := config.Collection{Name: "test", Path: dir, Extensions: []string{".md"}}
+	idx := New(database, 512)
+	ctx := context.Background()
+
+	write := func(round int) {
+		for i := 0; i < 40; i++ {
+			body := strings.Repeat(fmt.Sprintf("round%d document%d searchable prose. ", round, i), 60)
+			path := filepath.Join(dir, fmt.Sprintf("note%02d.md", i))
+			if err := os.WriteFile(path, []byte("# Note\n\n"+body), 0o640); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	for round := 0; round < 6; round++ {
+		write(round)
+		if _, err := idx.Index(ctx, col); err != nil {
+			t.Fatalf("round %d: %v", round, err)
+		}
+	}
+
+	var pages, freelist int64
+	if err := database.QueryRowContext(ctx,
+		`SELECT * FROM pragma_page_count(), pragma_freelist_count()`).Scan(&pages, &freelist); err != nil {
+		t.Fatal(err)
+	}
+	if freelist > pages/4 && freelist >= 1000 {
+		t.Errorf("dead space left unreclaimed: %d of %d pages free", freelist, pages)
+	}
+
+	// Every rewrite supersedes a body; none of them may survive unreferenced.
+	var orphans int
+	if err := database.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM content
+		WHERE hash NOT IN (SELECT DISTINCT content_hash FROM documents)`).Scan(&orphans); err != nil {
+		t.Fatal(err)
+	}
+	if orphans != 0 {
+		t.Errorf("%d superseded content bodies retained", orphans)
+	}
+
+	// Merged segments, not one per write.
+	var segments int
+	if err := database.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks_fts_data`).Scan(&segments); err != nil {
+		t.Fatal(err)
+	}
+	if segments > 100 {
+		t.Errorf("chunks_fts_data holds %d rows; segments were not merged", segments)
+	}
+}
+
+func TestCompactKeepsSearchWorking(t *testing.T) {
+	database := openTestDB(t)
+	col := makeTestCollection(t, map[string]string{
+		"a.md": "# Alpha\n\nfindmeplease unique text\n",
+	})
+	if _, err := New(database, 512).Index(context.Background(), col); err != nil {
+		t.Fatal(err)
+	}
+	var n int
+	if err := database.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM chunks_fts WHERE chunks_fts MATCH 'findmeplease'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n == 0 {
+		t.Error("optimize left the FTS index unsearchable")
+	}
+}
+
+// Change detection is by content hash, so a parser fix would never reach files
+// already indexed. --force is the only way to rebuild them.
+func TestForceReindexesUnchangedFiles(t *testing.T) {
+	database := openTestDB(t)
+	col := makeTestCollection(t, map[string]string{"a.md": "# A\n\nbody\n"})
+	ctx := context.Background()
+	idx := New(database, 512)
+
+	if _, err := idx.Index(ctx, col); err != nil {
+		t.Fatal(err)
+	}
+	var before int64
+	if err := database.QueryRowContext(ctx, `SELECT MAX(id) FROM chunks`).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := idx.Index(ctx, col)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUpdated != 0 {
+		t.Errorf("unchanged file was reindexed without --force: %+v", stats)
+	}
+
+	idx.Force = true
+	stats, err = idx.Index(ctx, col)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUpdated != 1 {
+		t.Errorf("--force did not reindex: %+v", stats)
+	}
+	var after int64
+	if err := database.QueryRowContext(ctx, `SELECT MAX(id) FROM chunks`).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if after <= before {
+		t.Error("--force did not rebuild chunks")
+	}
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -51,8 +52,12 @@ type Stats struct {
 
 // Indexer walks a collection and upserts documents into the DB.
 type Indexer struct {
-	db         *db.DB
-	chunker    chunker.Chunker
+	db      *db.DB
+	chunker chunker.Chunker
+	// Force reparses files whose content is unchanged. Change detection is by
+	// content hash, so a parser or chunker fix is otherwise invisible to
+	// everything already indexed.
+	Force      bool
 	beforeRead func(string) // test hook; called after discovery, before secure open
 }
 
@@ -187,7 +192,52 @@ func (idx *Indexer) Index(ctx context.Context, col config.Collection) (Stats, er
 	if finishErr := idx.finishRun(ctx, runID, stats, runErr); finishErr != nil {
 		runErr = errors.Join(runErr, fmt.Errorf("finishing index run: %w", finishErr))
 	}
+
+	// Housekeeping is best-effort: a full index run should not fail because the
+	// database could not be compacted afterwards.
+	if err := idx.compact(ctx); err != nil {
+		slog.Warn("compacting database after index run", "error", err)
+	}
 	return stats, runErr
+}
+
+// compact reclaims the space an index run leaves behind. Without it the file
+// only ever grows: FTS5 keeps every segment it has ever written, superseded
+// document bodies are never referenced again, and SQLite hands freed pages to a
+// freelist it never returns to the filesystem.
+func (idx *Indexer) compact(ctx context.Context) error {
+	// A document that changed content leaves its previous body behind, holding
+	// superseded text — including anything since redacted — in the database.
+	if _, err := idx.db.ExecContext(ctx, `
+		DELETE FROM content WHERE hash NOT IN (
+			SELECT DISTINCT content_hash FROM documents
+		)`); err != nil {
+		return fmt.Errorf("pruning orphaned content: %w", err)
+	}
+
+	// FTS5 merges segments only when asked. Reindex cycles otherwise leave
+	// thousands of unmerged segments — 27 MiB of index for 241 chunks, in the
+	// case that prompted this.
+	if _, err := idx.db.ExecContext(ctx,
+		`INSERT INTO chunks_fts(chunks_fts) VALUES('optimize')`); err != nil {
+		return fmt.Errorf("optimizing fts index: %w", err)
+	}
+
+	var pageCount, freelist int64
+	if err := idx.db.QueryRowContext(ctx,
+		`SELECT * FROM pragma_page_count(), pragma_freelist_count()`).Scan(&pageCount, &freelist); err != nil {
+		return fmt.Errorf("reading page counts: %w", err)
+	}
+	// VACUUM rewrites the whole file, so only pay for it once the dead space is
+	// worth reclaiming.
+	if freelist < 1000 || freelist < pageCount/4 {
+		return nil
+	}
+	slog.Info("vacuuming database", "free_pages", freelist, "total_pages", pageCount)
+	if _, err := idx.db.ExecContext(ctx, `VACUUM`); err != nil {
+		return fmt.Errorf("vacuuming: %w", err)
+	}
+	return nil
 }
 
 func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPath string, data []byte, stats *Stats) error {
@@ -204,14 +254,14 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 		return fmt.Errorf("looking up existing document: %w", err)
 	}
 
-	if existingActive == 1 && existingHash == hash {
+	if existingActive == 1 && existingHash == hash && !idx.Force {
 		return nil // unchanged
 	}
 
 	// Fast-path: previously deactivated document restored with byte-identical content.
 	// Reactivate the row without touching chunks or embeddings — deleting chunks would
 	// cascade into chunk_vectors/embeddings (migration 003) and force pointless re-embedding.
-	if docID != 0 && existingActive == 0 && existingHash == hash {
+	if docID != 0 && existingActive == 0 && existingHash == hash && !idx.Force {
 		if _, err := idx.db.ExecContext(ctx,
 			`UPDATE documents SET active=1, updated_at=datetime('now') WHERE id=?`, docID); err != nil {
 			return fmt.Errorf("reactivating document: %w", err)
@@ -241,6 +291,13 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 	if title == "" {
 		title = filepath.Base(relPath)
 	}
+	docTime := normalizeDate(doc.Meta.When())
+	var tagsJSON any
+	if len(doc.Meta.Tags) > 0 {
+		if b, err := json.Marshal([]string(doc.Meta.Tags)); err == nil {
+			tagsJSON = string(b)
+		}
+	}
 
 	tx, err := idx.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -252,9 +309,9 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 	if docID == 0 {
 		// Insert
 		res, err := tx.ExecContext(ctx,
-			`INSERT INTO documents(collection, path, title, content_hash, active, indexed_at, updated_at)
-			 VALUES (?, ?, ?, ?, 1, datetime('now'), datetime('now'))`,
-			col.Name, relPath, title, hash)
+			`INSERT INTO documents(collection, path, title, content_hash, doc_timestamp, tags, active, indexed_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, 1, datetime('now'), datetime('now'))`,
+			col.Name, relPath, title, hash, docTime, tagsJSON)
 		if err != nil {
 			return fmt.Errorf("inserting document: %w", err)
 		}
@@ -263,8 +320,8 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 	} else {
 		// Update (or reactivate a previously deactivated document)
 		_, err = tx.ExecContext(ctx,
-			`UPDATE documents SET title=?, content_hash=?, active=1, updated_at=datetime('now') WHERE id=?`,
-			title, hash, docID)
+			`UPDATE documents SET title=?, content_hash=?, doc_timestamp=?, tags=?, active=1, updated_at=datetime('now') WHERE id=?`,
+			title, hash, docTime, tagsJSON, docID)
 		if err != nil {
 			return fmt.Errorf("updating document: %w", err)
 		}
@@ -363,6 +420,26 @@ func (idx *Indexer) finishRun(ctx context.Context, runID int64, stats Stats, run
 		`UPDATE index_runs SET finished_at=datetime('now'), files_scanned=?, files_added=?, files_updated=?, files_removed=?, error=? WHERE id=?`,
 		stats.FilesScanned, stats.FilesAdded, stats.FilesUpdated, stats.FilesRemoved, errStr, runID)
 	return err
+}
+
+// normalizeDate reduces a frontmatter date to YYYY-MM-DD. Anything else is
+// dropped rather than stored in a shape date filters cannot compare.
+func normalizeDate(s string) any {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	for _, layout := range []string{"2006-01-02", time.RFC3339, "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.Format("2006-01-02")
+		}
+	}
+	if len(s) >= 10 {
+		if t, err := time.Parse("2006-01-02", s[:10]); err == nil {
+			return t.Format("2006-01-02")
+		}
+	}
+	return nil
 }
 
 func sha256sum(data []byte) string {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -291,7 +291,7 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 	if title == "" {
 		title = filepath.Base(relPath)
 	}
-	docTime := normalizeDate(doc.Meta.When())
+	docTime := normalizeDate(doc.Meta.Timestamp)
 	var tagsJSON any
 	if len(doc.Meta.Tags) > 0 {
 		if b, err := json.Marshal([]string(doc.Meta.Tags)); err == nil {

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -39,13 +39,6 @@ func isTerminal(w io.Writer) bool {
 	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
-func renderSnippet(s string, ansi bool) string {
-	if ansi {
-		return highlightANSI.Replace(s)
-	}
-	return highlightStripper.Replace(s)
-}
-
 // stripHighlights returns a copy of results with highlight markers removed, for
 // formats that carry no styling.
 func stripHighlights(results []search.Result) []search.Result {
@@ -82,7 +75,10 @@ func (f *TextFormatter) WriteResults(w io.Writer, results []search.Result) error
 		fmt.Fprintln(w, "No results found.")
 		return nil
 	}
-	ansi := isTerminal(w)
+	highlight := highlightStripper
+	if isTerminal(w) {
+		highlight = highlightANSI
+	}
 	for i, r := range results {
 		location := fmt.Sprintf("qi://%s/%s", r.Collection, r.Path)
 		if r.HeadingPath != "" {
@@ -99,7 +95,7 @@ func (f *TextFormatter) WriteResults(w io.Writer, results []search.Result) error
 		fmt.Fprintln(w)
 		fmt.Fprintf(w, "   %s\n", location)
 		if r.Snippet != "" {
-			fmt.Fprintf(w, "   %s\n", renderSnippet(r.Snippet, ansi))
+			fmt.Fprintf(w, "   %s\n", highlight.Replace(r.Snippet))
 		}
 		if r.Explain != nil {
 			ex := r.Explain

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -4,10 +4,58 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/itsmostafa/qi/internal/search"
 )
+
+// FTS5 wraps matched terms in sentinel bytes. Render them as ANSI bold on a
+// terminal and drop them everywhere else — they are markers, not content, and
+// as <b> tags they used to leak into JSON and into piped output.
+const (
+	ansiBold  = "\x1b[1m"
+	ansiReset = "\x1b[0m"
+)
+
+var highlightStripper = strings.NewReplacer(
+	search.HighlightOpen, "",
+	search.HighlightClose, "",
+)
+
+var highlightANSI = strings.NewReplacer(
+	search.HighlightOpen, ansiBold,
+	search.HighlightClose, ansiReset,
+)
+
+// isTerminal reports whether w is a character device, so escape codes are only
+// emitted where something will interpret them.
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+func renderSnippet(s string, ansi bool) string {
+	if ansi {
+		return highlightANSI.Replace(s)
+	}
+	return highlightStripper.Replace(s)
+}
+
+// stripHighlights returns a copy of results with highlight markers removed, for
+// formats that carry no styling.
+func stripHighlights(results []search.Result) []search.Result {
+	out := make([]search.Result, len(results))
+	for i, r := range results {
+		r.Snippet = highlightStripper.Replace(r.Snippet)
+		out[i] = r
+	}
+	return out
+}
 
 // Formatter writes search results to a writer.
 type Formatter interface {
@@ -34,15 +82,24 @@ func (f *TextFormatter) WriteResults(w io.Writer, results []search.Result) error
 		fmt.Fprintln(w, "No results found.")
 		return nil
 	}
+	ansi := isTerminal(w)
 	for i, r := range results {
 		location := fmt.Sprintf("qi://%s/%s", r.Collection, r.Path)
 		if r.HeadingPath != "" {
 			location += " [" + r.HeadingPath + "]"
 		}
-		fmt.Fprintf(w, "%d. %s (score: %.4f)\n", i+1, r.Title, r.Score)
+		scale := r.Scale
+		if scale == "" {
+			scale = "score"
+		}
+		fmt.Fprintf(w, "%d. %s (%s: %.4f)", i+1, r.Title, scale, r.Score)
+		if r.Timestamp != "" {
+			fmt.Fprintf(w, " [%s]", r.Timestamp)
+		}
+		fmt.Fprintln(w)
 		fmt.Fprintf(w, "   %s\n", location)
 		if r.Snippet != "" {
-			fmt.Fprintf(w, "   %s\n", r.Snippet)
+			fmt.Fprintf(w, "   %s\n", renderSnippet(r.Snippet, ansi))
 		}
 		if r.Explain != nil {
 			ex := r.Explain
@@ -66,7 +123,12 @@ type JSONFormatter struct{}
 func (f *JSONFormatter) WriteResults(w io.Writer, results []search.Result) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(results)
+	// Always an array: a nil slice would encode as null and break callers that
+	// iterate the response unconditionally.
+	if results == nil {
+		results = []search.Result{}
+	}
+	return enc.Encode(stripHighlights(results))
 }
 
 // MarkdownFormatter writes results as a Markdown list.
@@ -86,7 +148,7 @@ func (f *MarkdownFormatter) WriteResults(w io.Writer, results []search.Result) e
 		}
 		fmt.Fprintln(w)
 		if r.Snippet != "" {
-			fmt.Fprintf(w, "> %s\n", r.Snippet)
+			fmt.Fprintf(w, "> %s\n", highlightStripper.Replace(r.Snippet))
 		}
 		fmt.Fprintln(w)
 	}

--- a/internal/parser/frontmatter.go
+++ b/internal/parser/frontmatter.go
@@ -12,16 +12,7 @@ type Meta struct {
 	Title       string     `yaml:"title"`
 	Description string     `yaml:"description"`
 	Timestamp   string     `yaml:"timestamp"`
-	Date        string     `yaml:"date"`
 	Tags        stringList `yaml:"tags"`
-}
-
-// When returns the document's own date, preferring "timestamp" over "date".
-func (m Meta) When() string {
-	if m.Timestamp != "" {
-		return m.Timestamp
-	}
-	return m.Date
 }
 
 // Summary renders the retrieval-worthy frontmatter as plain prose. It is empty
@@ -79,8 +70,11 @@ func splitFrontmatter(data []byte) (Meta, []byte, int) {
 		}
 		switch strings.TrimRight(string(line), "\r") {
 		case "---", "...":
+			// A closed block is frontmatter whether or not it decodes. YAML we
+			// cannot read yields no metadata, but indexing it as prose would
+			// put the raw block — keys, secrets and all — back into the chunk.
 			if err := yaml.Unmarshal(rest[:off], &meta); err != nil {
-				return Meta{}, data, 0 // malformed: index it as content
+				meta = Meta{}
 			}
 			return meta, rest[next:], open + next
 		}

--- a/internal/parser/frontmatter.go
+++ b/internal/parser/frontmatter.go
@@ -9,10 +9,12 @@ import (
 
 // Meta holds YAML frontmatter fields promoted to document level.
 type Meta struct {
-	Title       string     `yaml:"title"`
-	Description string     `yaml:"description"`
-	Timestamp   string     `yaml:"timestamp"`
-	Tags        stringList `yaml:"tags"`
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
+	Timestamp   string `yaml:"timestamp"`
+	// Date is the documented alias for Timestamp; read it via Timestamp.
+	Date string     `yaml:"date"`
+	Tags stringList `yaml:"tags"`
 }
 
 // Summary renders the retrieval-worthy frontmatter as plain prose. It is empty
@@ -75,6 +77,9 @@ func splitFrontmatter(data []byte) (Meta, []byte, int) {
 			// put the raw block — keys, secrets and all — back into the chunk.
 			if err := yaml.Unmarshal(rest[:off], &meta); err != nil {
 				meta = Meta{}
+			}
+			if meta.Timestamp == "" {
+				meta.Timestamp = meta.Date
 			}
 			return meta, rest[next:], open + next
 		}

--- a/internal/parser/frontmatter.go
+++ b/internal/parser/frontmatter.go
@@ -1,0 +1,93 @@
+package parser
+
+import (
+	"bytes"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Meta holds YAML frontmatter fields promoted to document level.
+type Meta struct {
+	Title       string     `yaml:"title"`
+	Description string     `yaml:"description"`
+	Timestamp   string     `yaml:"timestamp"`
+	Date        string     `yaml:"date"`
+	Tags        stringList `yaml:"tags"`
+}
+
+// When returns the document's own date, preferring "timestamp" over "date".
+func (m Meta) When() string {
+	if m.Timestamp != "" {
+		return m.Timestamp
+	}
+	return m.Date
+}
+
+// Summary renders the retrieval-worthy frontmatter as plain prose. It is empty
+// when there is nothing worth indexing.
+func (m Meta) Summary() string {
+	var parts []string
+	for _, s := range []string{m.Title, m.Description, strings.Join(m.Tags, ", ")} {
+		if s = strings.TrimSpace(s); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// stringList accepts either a YAML sequence or a comma-separated scalar, both of
+// which appear in the wild for "tags".
+type stringList []string
+
+func (s *stringList) UnmarshalYAML(n *yaml.Node) error {
+	switch n.Kind {
+	case yaml.SequenceNode:
+		var out []string
+		if err := n.Decode(&out); err != nil {
+			return err
+		}
+		*s = out
+	case yaml.ScalarNode:
+		for _, p := range strings.Split(n.Value, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				*s = append(*s, p)
+			}
+		}
+	}
+	return nil
+}
+
+// splitFrontmatter separates a leading YAML frontmatter block from the body.
+// The third return is the byte length of the stripped prefix, so section
+// ordinals still refer to positions in the original file. A missing, malformed
+// or unterminated block is treated as ordinary content.
+func splitFrontmatter(data []byte) (Meta, []byte, int) {
+	var meta Meta
+	if !bytes.HasPrefix(data, []byte("---\n")) && !bytes.HasPrefix(data, []byte("---\r\n")) {
+		return meta, data, 0
+	}
+
+	open := bytes.IndexByte(data, '\n') + 1
+	rest := data[open:]
+
+	for off := 0; off <= len(rest); {
+		next := len(rest)
+		line := rest[off:]
+		if i := bytes.IndexByte(rest[off:], '\n'); i >= 0 {
+			line, next = rest[off:off+i], off+i+1
+		}
+		switch strings.TrimRight(string(line), "\r") {
+		case "---", "...":
+			if err := yaml.Unmarshal(rest[:off], &meta); err != nil {
+				return Meta{}, data, 0 // malformed: index it as content
+			}
+			return meta, rest[next:], open + next
+		}
+		if next == len(rest) && off == next {
+			break
+		}
+		off = next
+	}
+	return Meta{}, data, 0 // unterminated
+}

--- a/internal/parser/markdown.go
+++ b/internal/parser/markdown.go
@@ -17,15 +17,23 @@ func init() {
 type markdownParser struct{}
 
 func (p *markdownParser) Parse(path string, data []byte) (*Document, error) {
+	meta, body, offset := splitFrontmatter(data)
+
 	md := goldmark.New()
-	reader := text.NewReader(data)
+	reader := text.NewReader(body)
 	node := md.Parser().Parse(reader)
 
-	doc := &Document{}
+	doc := &Document{Meta: meta, Title: meta.Title}
 	var sections []Section
 	var currentHeadings []string
 	var currentBuf strings.Builder
 	var currentOrdinal int
+
+	// Frontmatter is worth retrieving but not worth indexing as YAML: promote it
+	// to a leading section of plain prose instead of leaking syntax into chunks.
+	if summary := meta.Summary(); summary != "" {
+		sections = append(sections, Section{Text: summary, Ordinal: 0})
+	}
 
 	flush := func() {
 		text := strings.TrimSpace(currentBuf.String())
@@ -33,7 +41,7 @@ func (p *markdownParser) Parse(path string, data []byte) (*Document, error) {
 			sections = append(sections, Section{
 				HeadingPath: strings.Join(currentHeadings, " > "),
 				Text:        text,
-				Ordinal:     currentOrdinal,
+				Ordinal:     currentOrdinal + offset,
 			})
 		}
 		currentBuf.Reset()
@@ -44,7 +52,7 @@ func (p *markdownParser) Parse(path string, data []byte) (*Document, error) {
 		case *ast.Heading:
 			if entering {
 				flush()
-				headingText := extractText(v, data)
+				headingText := nodeText(v, body)
 				level := v.Level
 				if level == 1 && doc.Title == "" {
 					doc.Title = headingText
@@ -59,18 +67,20 @@ func (p *markdownParser) Parse(path string, data []byte) (*Document, error) {
 					currentOrdinal = seg.Start
 				}
 			}
-		case *ast.Paragraph, *ast.FencedCodeBlock, *ast.CodeBlock, *ast.Blockquote:
+		case *ast.Paragraph, *ast.FencedCodeBlock, *ast.CodeBlock:
 			if entering {
-				t := extractText(v, data)
-				currentBuf.WriteString(t)
+				currentBuf.WriteString(nodeText(v, body))
 				currentBuf.WriteByte('\n')
 			}
 		case *ast.ListItem:
 			if entering {
-				t := extractText(v, data)
+				// Take the whole item — including any nested list — in one pass
+				// and skip children, or the *ast.Paragraph case above would
+				// emit a loose item's text a second time.
 				currentBuf.WriteString("- ")
-				currentBuf.WriteString(t)
+				currentBuf.WriteString(nodeText(v, body))
 				currentBuf.WriteByte('\n')
+				return ast.WalkSkipChildren, nil
 			}
 		}
 		return ast.WalkContinue, nil
@@ -81,23 +91,38 @@ func (p *markdownParser) Parse(path string, data []byte) (*Document, error) {
 	return doc, nil
 }
 
-func extractText(n ast.Node, src []byte) string {
+// nodeText returns the text of n and every descendant. Container nodes such as
+// ListItem and Blockquote hold their words several levels down, so scanning
+// direct children alone silently drops them.
+func nodeText(n ast.Node, src []byte) string {
 	var buf bytes.Buffer
-	if n.Lines() != nil {
-		for i := 0; i < n.Lines().Len(); i++ {
-			seg := n.Lines().At(i)
-			buf.Write(seg.Value(src))
+	_ = ast.Walk(n, func(c ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			// Keep block structure readable when several blocks flatten into
+			// one string, as a nested list inside a list item does.
+			if c != n && c.Type() == ast.TypeBlock {
+				buf.WriteByte('\n')
+			}
+			return ast.WalkContinue, nil
 		}
-		return strings.TrimSpace(buf.String())
-	}
-	// Walk children for inline content
-	for child := n.FirstChild(); child != nil; child = child.NextSibling() {
-		if t, ok := child.(*ast.Text); ok {
+		switch t := c.(type) {
+		case *ast.Text:
 			buf.Write(t.Segment.Value(src))
 			if t.SoftLineBreak() || t.HardLineBreak() {
 				buf.WriteByte(' ')
 			}
+		case *ast.String:
+			buf.Write(t.Value)
+		case *ast.AutoLink:
+			buf.Write(t.URL(src))
+		case *ast.FencedCodeBlock, *ast.CodeBlock:
+			lines := c.Lines()
+			for i := 0; i < lines.Len(); i++ {
+				seg := lines.At(i)
+				buf.Write(seg.Value(src))
+			}
 		}
-	}
+		return ast.WalkContinue, nil
+	})
 	return strings.TrimSpace(buf.String())
 }

--- a/internal/parser/markdown_test.go
+++ b/internal/parser/markdown_test.go
@@ -89,6 +89,23 @@ func TestFrontmatterTitleBeatsHeading(t *testing.T) {
 	}
 }
 
+// "date" is the documented alias for "timestamp"; without it these documents
+// index as undated and drop out of --since/--until and date sorting.
+func TestFrontmatterDateAliasesTimestamp(t *testing.T) {
+	doc := parseMD(t, "---\ntitle: T\ndate: 2026-07-17\n---\n\nBody.\n")
+	if doc.Meta.Timestamp != "2026-07-17" {
+		t.Errorf("Timestamp = %q, want 2026-07-17", doc.Meta.Timestamp)
+	}
+}
+
+// An explicit "timestamp" wins over "date".
+func TestFrontmatterTimestampBeatsDate(t *testing.T) {
+	doc := parseMD(t, "---\ntimestamp: 2026-01-02\ndate: 2026-07-17\n---\n\nBody.\n")
+	if doc.Meta.Timestamp != "2026-01-02" {
+		t.Errorf("Timestamp = %q, want 2026-01-02", doc.Meta.Timestamp)
+	}
+}
+
 func TestFrontmatterNeverReachesChunkBody(t *testing.T) {
 	got := bodyText(parseMD(t, withFrontmatter))
 	for _, leak := range []string{"resource:", "type:", "timestamp:", "tags:"} {

--- a/internal/parser/markdown_test.go
+++ b/internal/parser/markdown_test.go
@@ -81,8 +81,8 @@ func TestFrontmatterTitleBeatsHeading(t *testing.T) {
 	if doc.Title != "Thyroid Panel" {
 		t.Errorf("Title = %q, want %q", doc.Title, "Thyroid Panel")
 	}
-	if doc.Meta.When() != "2026-07-17" {
-		t.Errorf("When() = %q, want 2026-07-17", doc.Meta.When())
+	if doc.Meta.Timestamp != "2026-07-17" {
+		t.Errorf("Timestamp = %q, want 2026-07-17", doc.Meta.Timestamp)
 	}
 	if len(doc.Meta.Tags) != 2 || doc.Meta.Tags[0] != "biomarker" {
 		t.Errorf("Tags = %v", doc.Meta.Tags)
@@ -141,5 +141,40 @@ func TestMalformedFrontmatterIsTreatedAsContent(t *testing.T) {
 		if !strings.Contains(bodyText(doc), "text") {
 			t.Errorf("%s: body lost:\n%s", name, bodyText(doc))
 		}
+	}
+}
+
+// A plain []string cannot decode `tags: personal`, and an unmarshal error used
+// to un-strip the block, putting the raw YAML back into the chunk.
+func TestScalarTagsDoNotLeakFrontmatter(t *testing.T) {
+	doc := parseMD(t, "---\ntitle: T\ntags: personal\n---\n\n# H\n\nbody\n")
+	if len(doc.Meta.Tags) != 1 || doc.Meta.Tags[0] != "personal" {
+		t.Errorf("Tags = %v, want [personal]", doc.Meta.Tags)
+	}
+	if got := bodyText(doc); strings.Contains(got, "tags:") {
+		t.Errorf("scalar tags leaked frontmatter into the body:\n%s", got)
+	}
+}
+
+func TestFlowSequenceTags(t *testing.T) {
+	doc := parseMD(t, "---\ntags: [book, summary]\n---\n\n# H\n\nbody\n")
+	if len(doc.Meta.Tags) != 2 {
+		t.Errorf("flow sequence tags = %v, want 2 entries", doc.Meta.Tags)
+	}
+}
+
+// Delimiters, not decodability, decide what is frontmatter. YAML that does not
+// fit Meta yields no metadata but must still be stripped, or the raw block —
+// keys, secrets and all — reaches the index. A tag list keeps the closing ---
+// from being read as a setext underline, so the leak lands in chunk text.
+func TestUndecodableFrontmatterIsStillStripped(t *testing.T) {
+	doc := parseMD(t, "---\ntitle: [bad]\nsecret: hunter2\ntags:\n- a\n---\n\n# Heading\n\nreal body\n")
+	for _, s := range doc.Sections {
+		if strings.Contains(s.Text, "hunter2") || strings.Contains(s.HeadingPath, "hunter2") {
+			t.Fatalf("undecodable frontmatter leaked into the index: %q / %q", s.HeadingPath, s.Text)
+		}
+	}
+	if !strings.Contains(bodyText(doc), "real body") {
+		t.Error("body lost")
 	}
 }

--- a/internal/parser/markdown_test.go
+++ b/internal/parser/markdown_test.go
@@ -1,0 +1,145 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func parseMD(t *testing.T, src string) *Document {
+	t.Helper()
+	doc, err := (&markdownParser{}).Parse("note.md", []byte(src))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	return doc
+}
+
+func bodyText(doc *Document) string {
+	var b strings.Builder
+	for _, s := range doc.Sections {
+		b.WriteString(s.Text)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// The repro from docs/audit-2026-09-03.md:380 — list text was dropped entirely,
+// leaving bare "-" markers.
+func TestListItemTextIsIndexed(t *testing.T) {
+	doc := parseMD(t, "# List\n\n- alpha uniqueitem\n- beta seconditem\n")
+	got := bodyText(doc)
+	for _, want := range []string{"alpha uniqueitem", "beta seconditem"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("list text %q missing from sections:\n%s", want, got)
+		}
+	}
+}
+
+func TestLooseListItemNotDoubleCounted(t *testing.T) {
+	doc := parseMD(t, "# L\n\n- alpha\n\n- beta\n")
+	if n := strings.Count(bodyText(doc), "alpha"); n != 1 {
+		t.Errorf("loose list item emitted %d times, want 1:\n%s", n, bodyText(doc))
+	}
+}
+
+func TestNestedListTextIsIndexed(t *testing.T) {
+	doc := parseMD(t, "# L\n\n- outer\n    - innermost deepvalue\n")
+	got := bodyText(doc)
+	if !strings.Contains(got, "innermost deepvalue") {
+		t.Errorf("nested list text missing:\n%s", got)
+	}
+	if n := strings.Count(got, "outer"); n != 1 {
+		t.Errorf("nested parent emitted %d times, want 1:\n%s", n, got)
+	}
+}
+
+func TestBlockquoteTextIsIndexed(t *testing.T) {
+	doc := parseMD(t, "# Q\n\n> quoted uniqueword\n")
+	if got := bodyText(doc); !strings.Contains(got, "quoted uniqueword") {
+		t.Errorf("blockquote text missing:\n%s", got)
+	}
+}
+
+const withFrontmatter = `---
+type: Biomarker Panel
+title: Thyroid Panel
+description: TSH and thyroid antibodies.
+resource: raw/biomarkers-export.csv
+tags:
+- biomarker
+- thyroid
+timestamp: 2026-07-17
+---
+
+# Overview
+
+Body text here.
+`
+
+func TestFrontmatterTitleBeatsHeading(t *testing.T) {
+	doc := parseMD(t, withFrontmatter)
+	if doc.Title != "Thyroid Panel" {
+		t.Errorf("Title = %q, want %q", doc.Title, "Thyroid Panel")
+	}
+	if doc.Meta.When() != "2026-07-17" {
+		t.Errorf("When() = %q, want 2026-07-17", doc.Meta.When())
+	}
+	if len(doc.Meta.Tags) != 2 || doc.Meta.Tags[0] != "biomarker" {
+		t.Errorf("Tags = %v", doc.Meta.Tags)
+	}
+}
+
+func TestFrontmatterNeverReachesChunkBody(t *testing.T) {
+	got := bodyText(parseMD(t, withFrontmatter))
+	for _, leak := range []string{"resource:", "type:", "timestamp:", "tags:"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("frontmatter key %q leaked into sections:\n%s", leak, got)
+		}
+	}
+	if strings.Contains(got, "\n- \n") || strings.HasPrefix(got, "- \n") {
+		t.Errorf("bare list markers left behind:\n%q", got)
+	}
+	// The useful fields survive as prose so they stay searchable.
+	for _, want := range []string{"Thyroid Panel", "thyroid antibodies", "biomarker"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("frontmatter value %q not indexed:\n%s", want, got)
+		}
+	}
+}
+
+func TestHeadingFallbackWithoutFrontmatterTitle(t *testing.T) {
+	doc := parseMD(t, "---\ntags: a, b\n---\n\n# Real Heading\n\ntext\n")
+	if doc.Title != "Real Heading" {
+		t.Errorf("Title = %q, want fallback to H1", doc.Title)
+	}
+	if len(doc.Meta.Tags) != 2 {
+		t.Errorf("scalar tags = %v, want 2 entries", doc.Meta.Tags)
+	}
+}
+
+func TestOrdinalsReferToOriginalFile(t *testing.T) {
+	doc := parseMD(t, withFrontmatter)
+	want := strings.Index(withFrontmatter, "# Overview")
+	for _, s := range doc.Sections {
+		if s.HeadingPath == "Overview" {
+			if s.Ordinal < want {
+				t.Errorf("Ordinal = %d, want >= %d (offset not restored)", s.Ordinal, want)
+			}
+			return
+		}
+	}
+	t.Fatal("no Overview section")
+}
+
+func TestMalformedFrontmatterIsTreatedAsContent(t *testing.T) {
+	for name, src := range map[string]string{
+		"unterminated": "---\ntitle: X\n\n# Heading\n\ntext\n",
+		"notYAML":      "---\n\tthis: [is: broken\n---\n\n# Heading\n\ntext\n",
+		"none":         "# Heading\n\ntext\n",
+	} {
+		doc := parseMD(t, src)
+		if !strings.Contains(bodyText(doc), "text") {
+			t.Errorf("%s: body lost:\n%s", name, bodyText(doc))
+		}
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -9,6 +9,7 @@ type Section struct {
 
 // Document is the parsed output of a file.
 type Document struct {
+	Meta     Meta
 	Title    string
 	Sections []Section
 }

--- a/internal/search/bm25.go
+++ b/internal/search/bm25.go
@@ -60,11 +60,14 @@ func (b *BM25) Search(ctx context.Context, opts SearchOpts) ([]Result, error) {
 
 func (b *BM25) searchFTS(ctx context.Context, opts SearchOpts, ftsQuery string) ([]Result, error) {
 	var args []any
-	var collectionFilter string
+	var filters string
 	if opts.Collection != "" {
-		collectionFilter = "AND d.collection = ?"
+		filters = "AND d.collection = ?"
 		args = append(args, opts.Collection)
 	}
+	dateFilter, dateArgs := dateFilterSQL("d", opts)
+	filters += dateFilter
+	args = append(args, dateArgs...)
 
 	query := fmt.Sprintf(`
 		SELECT
@@ -74,7 +77,8 @@ func (b *BM25) searchFTS(ctx context.Context, opts SearchOpts, ftsQuery string) 
 			d.path,
 			COALESCE(d.title, d.path),
 			COALESCE(c.heading_path, ''),
-			snippet(chunks_fts, 0, '<b>', '</b>', '...', 32),
+			COALESCE(d.doc_timestamp, ''),
+			snippet(chunks_fts, 0, ?, ?, '...', 32),
 			-bm25(chunks_fts)
 		FROM chunks_fts
 		JOIN chunks c ON c.id = chunks_fts.rowid
@@ -84,11 +88,11 @@ func (b *BM25) searchFTS(ctx context.Context, opts SearchOpts, ftsQuery string) 
 		  %s
 		ORDER BY bm25(chunks_fts)
 		LIMIT ?
-	`, collectionFilter)
+	`, filters)
 
-	queryArgs := []any{ftsQuery}
+	queryArgs := []any{HighlightOpen, HighlightClose, ftsQuery}
 	queryArgs = append(queryArgs, args...)
-	queryArgs = append(queryArgs, opts.TopK)
+	queryArgs = append(queryArgs, poolSize(opts))
 
 	rows, err := b.db.QueryContext(ctx, query, queryArgs...)
 	if err != nil {
@@ -103,11 +107,12 @@ func (b *BM25) searchFTS(ctx context.Context, opts SearchOpts, ftsQuery string) 
 		var score float64
 		if err := rows.Scan(
 			&r.DocID, &r.ChunkID, &r.Collection, &r.Path,
-			&r.Title, &r.HeadingPath, &r.Snippet, &score,
+			&r.Title, &r.HeadingPath, &r.Timestamp, &r.Snippet, &score,
 		); err != nil {
 			return nil, err
 		}
 		r.Score = score
+		r.Scale = ScaleBM25
 		if opts.Explain {
 			r.Explain = &ScoreExplain{BM25Score: score, BM25Rank: rank}
 		}

--- a/internal/search/fusion.go
+++ b/internal/search/fusion.go
@@ -79,6 +79,7 @@ func ReciprocalRankFusion(bm25 []Result, vec []Result, k int) []Result {
 	for _, s := range byChunk {
 		r := s.result
 		r.Score = s.rrfScore
+		r.Scale = ScaleRRF
 		if r.Explain != nil || s.bm25Rank > 0 || s.vecRank > 0 {
 			r.Explain = &ScoreExplain{
 				BM25Score:  s.bm25Sc,

--- a/internal/search/hybrid.go
+++ b/internal/search/hybrid.go
@@ -76,6 +76,11 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 	if vecTopK <= 0 {
 		vecTopK = 50
 	}
+	// Finalize can only return what it is given: a pool smaller than the
+	// caller's limit caps the result count when BM25 contributes little.
+	if opts.TopK > vecTopK {
+		vecTopK = opts.TopK
+	}
 
 	vecResults, err := h.vector.Search(ctx, queryVec, vecTopK, opts)
 	if err != nil {

--- a/internal/search/hybrid.go
+++ b/internal/search/hybrid.go
@@ -30,9 +30,9 @@ func NewHybrid(bm25 *BM25, vector *VectorSearch, embedding providers.EmbeddingPr
 func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) {
 	// BM25 is always run
 	bm25Opts := opts
-	bm25Opts.TopK = h.cfg.BM25TopK
-	if bm25Opts.TopK <= 0 {
-		bm25Opts.TopK = 50
+	bm25Opts.Pool = h.cfg.BM25TopK
+	if bm25Opts.Pool <= 0 {
+		bm25Opts.Pool = 50
 	}
 
 	bm25Results, err := h.bm25.Search(ctx, bm25Opts)
@@ -50,9 +50,6 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 		if topScore > 0 && secondScore > 0 && topScore/secondScore > 3.0 {
 			slog.Debug("strong BM25 signal, skipping vector search",
 				"top", topScore, "second", secondScore)
-			if opts.TopK > 0 && len(bm25Results) > opts.TopK {
-				bm25Results = bm25Results[:opts.TopK]
-			}
 			return applyExtensionBoost(bm25Results, preferExts, extBoost), nil
 		}
 	}
@@ -60,9 +57,6 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 	// No embedding provider — fall back to BM25 only
 	if h.embedding == nil {
 		slog.Debug("no embedding provider configured, using BM25 only")
-		if opts.TopK > 0 && len(bm25Results) > opts.TopK {
-			bm25Results = bm25Results[:opts.TopK]
-		}
 		return applyExtensionBoost(bm25Results, preferExts, extBoost), nil
 	}
 
@@ -74,9 +68,6 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 		} else {
 			slog.Warn("embedding query failed, falling back to BM25", "error", err)
 		}
-		if opts.TopK > 0 && len(bm25Results) > opts.TopK {
-			bm25Results = bm25Results[:opts.TopK]
-		}
 		return applyExtensionBoost(bm25Results, preferExts, extBoost), nil
 	}
 	queryVec := embeddings[0]
@@ -86,12 +77,9 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 		vecTopK = 50
 	}
 
-	vecResults, err := h.vector.Search(ctx, queryVec, vecTopK, opts.Collection)
+	vecResults, err := h.vector.Search(ctx, queryVec, vecTopK, opts)
 	if err != nil {
 		slog.Warn("vector search failed, falling back to BM25", "error", err)
-		if opts.TopK > 0 && len(bm25Results) > opts.TopK {
-			bm25Results = bm25Results[:opts.TopK]
-		}
 		return applyExtensionBoost(bm25Results, preferExts, extBoost), nil
 	}
 
@@ -108,13 +96,7 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 		}
 	}
 
-	topK := opts.TopK
-	if topK <= 0 {
-		topK = 10
-	}
-	if len(fused) > topK {
-		fused = fused[:topK]
-	}
-
+	// Truncation happens in Finalize, after dedupe and the per-document cap:
+	// cutting to TopK here would spend slots on duplicates.
 	return applyExtensionBoost(fused, preferExts, extBoost), nil
 }

--- a/internal/search/postprocess.go
+++ b/internal/search/postprocess.go
@@ -101,13 +101,12 @@ func Finalize(results []Result, opts SearchOpts) []Result {
 }
 
 // poolSize is how many candidates a retriever should fetch before dedupe and
-// capping trim the list down to TopK.
+// capping trim the list down to TopK. Never fewer than TopK: a configured pool
+// smaller than the caller's limit would silently cap the result count.
 func poolSize(opts SearchOpts) int {
-	if opts.Pool > 0 {
-		return opts.Pool
+	n := max(opts.Pool, opts.TopK)
+	if n <= 0 {
+		return 10
 	}
-	if opts.TopK > 0 {
-		return opts.TopK
-	}
-	return 10
+	return n
 }

--- a/internal/search/postprocess.go
+++ b/internal/search/postprocess.go
@@ -1,6 +1,10 @@
 package search
 
-import "strings"
+import (
+	"cmp"
+	"slices"
+	"strings"
+)
 
 // Score scales. BM25 magnitudes are raw and corpus-dependent; RRF scores are
 // bounded near 1/rrf_k. They share a JSON key, so each result names its own.
@@ -24,17 +28,17 @@ const maxPerDoc = 2
 // dateFilterSQL builds the doc_timestamp predicates for Since/Until. alias is
 // the documents table alias in the caller's query.
 func dateFilterSQL(alias string, opts SearchOpts) (string, []any) {
-	var sql strings.Builder
+	var sql string
 	var args []any
 	if opts.Since != "" {
-		sql.WriteString(" AND " + alias + ".doc_timestamp >= ?")
+		sql += " AND " + alias + ".doc_timestamp >= ?"
 		args = append(args, opts.Since)
 	}
 	if opts.Until != "" {
-		sql.WriteString(" AND " + alias + ".doc_timestamp <= ?")
+		sql += " AND " + alias + ".doc_timestamp <= ?"
 		args = append(args, opts.Until)
 	}
-	return sql.String(), args
+	return sql, args
 }
 
 // capResults collapses duplicate chunks and stops any one document from
@@ -64,25 +68,16 @@ func capResults(results []Result) []Result {
 	return out
 }
 
-// sortByDate orders results newest first, falling back to score. Documents with
-// no timestamp sort last so a date query never leads with undated notes.
+// sortByDate orders results newest first, falling back to score. An empty
+// timestamp sorts lowest, so undated documents land last rather than leading a
+// date query.
 func sortByDate(results []Result) {
-	for i := 1; i < len(results); i++ {
-		r := results[i]
-		j := i - 1
-		for j >= 0 && dateLess(results[j], r) {
-			results[j+1] = results[j]
-			j--
+	slices.SortStableFunc(results, func(a, b Result) int {
+		if c := cmp.Compare(b.Timestamp, a.Timestamp); c != 0 {
+			return c
 		}
-		results[j+1] = r
-	}
-}
-
-func dateLess(a, b Result) bool {
-	if a.Timestamp != b.Timestamp {
-		return a.Timestamp < b.Timestamp // "" sorts lowest, so undated goes last
-	}
-	return a.Score < b.Score
+		return cmp.Compare(b.Score, a.Score)
+	})
 }
 
 // Finalize applies the ordering and trimming every command needs after

--- a/internal/search/postprocess.go
+++ b/internal/search/postprocess.go
@@ -1,0 +1,113 @@
+package search
+
+import "strings"
+
+// Score scales. BM25 magnitudes are raw and corpus-dependent; RRF scores are
+// bounded near 1/rrf_k. They share a JSON key, so each result names its own.
+const (
+	ScaleBM25 = "bm25"
+	ScaleRRF  = "rrf"
+)
+
+// Highlight markers wrap matched terms in FTS5 snippets. They are sentinels,
+// not markup: the output layer turns them into ANSI or strips them. Using <b>
+// here leaked HTML into JSON and into the terminal.
+const (
+	HighlightOpen  = "\x02"
+	HighlightClose = "\x03"
+)
+
+// maxPerDoc caps how many chunks of one document may occupy the result list.
+// ponytail: a fixed 2 rather than a config key — nothing has asked to tune it.
+const maxPerDoc = 2
+
+// dateFilterSQL builds the doc_timestamp predicates for Since/Until. alias is
+// the documents table alias in the caller's query.
+func dateFilterSQL(alias string, opts SearchOpts) (string, []any) {
+	var sql strings.Builder
+	var args []any
+	if opts.Since != "" {
+		sql.WriteString(" AND " + alias + ".doc_timestamp >= ?")
+		args = append(args, opts.Since)
+	}
+	if opts.Until != "" {
+		sql.WriteString(" AND " + alias + ".doc_timestamp <= ?")
+		args = append(args, opts.Until)
+	}
+	return sql.String(), args
+}
+
+// capResults collapses duplicate chunks and stops any one document from
+// monopolising the list. Boilerplate repeated verbatim across files produces
+// byte-identical snippets, which is what the first pass removes.
+//
+// ponytail: identity is the snippet string. The same chunk reached through BM25
+// (a 32-token window) and through vector search (the whole chunk) will not
+// match; collapsing those needs the chunk text in Result, which nothing else
+// wants yet.
+func capResults(results []Result) []Result {
+	seen := make(map[string]bool, len(results))
+	perDoc := make(map[int64]int, len(results))
+	out := results[:0:0]
+	for _, r := range results {
+		key := strings.TrimSpace(r.Snippet)
+		if key != "" && seen[key] {
+			continue
+		}
+		if perDoc[r.DocID] >= maxPerDoc {
+			continue
+		}
+		seen[key] = true
+		perDoc[r.DocID]++
+		out = append(out, r)
+	}
+	return out
+}
+
+// sortByDate orders results newest first, falling back to score. Documents with
+// no timestamp sort last so a date query never leads with undated notes.
+func sortByDate(results []Result) {
+	for i := 1; i < len(results); i++ {
+		r := results[i]
+		j := i - 1
+		for j >= 0 && dateLess(results[j], r) {
+			results[j+1] = results[j]
+			j--
+		}
+		results[j+1] = r
+	}
+}
+
+func dateLess(a, b Result) bool {
+	if a.Timestamp != b.Timestamp {
+		return a.Timestamp < b.Timestamp // "" sorts lowest, so undated goes last
+	}
+	return a.Score < b.Score
+}
+
+// Finalize applies the ordering and trimming every command needs after
+// retrieval: date sort over the whole candidate pool (never after truncation,
+// or "newest" would only mean "newest of the most relevant"), duplicate and
+// per-document capping, then the caller's limit.
+func Finalize(results []Result, opts SearchOpts) []Result {
+	if opts.Sort == "date" {
+		sortByDate(results)
+	}
+	results = capResults(results)
+	if opts.TopK > 0 && len(results) > opts.TopK {
+		results = results[:opts.TopK]
+	}
+	return results
+}
+
+// poolSize is how many candidates a retriever should fetch before dedupe and
+// capping trim the list down to TopK.
+func poolSize(opts SearchOpts) int {
+	if opts.Pool > 0 {
+		return opts.Pool
+	}
+	if opts.TopK > 0 {
+		return opts.TopK
+	}
+	return 10
+}

--- a/internal/search/postprocess_test.go
+++ b/internal/search/postprocess_test.go
@@ -90,3 +90,17 @@ func TestDateFilterSQL(t *testing.T) {
 		t.Errorf("empty opts produced %q %v", sql, args)
 	}
 }
+
+// -n above the configured bm25_top_k must still return -n results, not the
+// pool size.
+func TestPoolSizeNeverBelowTopK(t *testing.T) {
+	if got := poolSize(SearchOpts{Pool: 50, TopK: 100}); got != 100 {
+		t.Errorf("poolSize = %d, want 100", got)
+	}
+	if got := poolSize(SearchOpts{Pool: 50, TopK: 10}); got != 50 {
+		t.Errorf("poolSize = %d, want 50", got)
+	}
+	if got := poolSize(SearchOpts{}); got != 10 {
+		t.Errorf("poolSize = %d, want the default 10", got)
+	}
+}

--- a/internal/search/postprocess_test.go
+++ b/internal/search/postprocess_test.go
@@ -1,0 +1,92 @@
+package search
+
+import "testing"
+
+func res(doc int64, chunk int64, snippet string, score float64, ts string) Result {
+	return Result{DocID: doc, ChunkID: chunk, Snippet: snippet, Score: score, Timestamp: ts}
+}
+
+// A boilerplate banner repeated verbatim across files took four consecutive
+// slots at an identical BM25 score.
+func TestCapResultsCollapsesIdenticalSnippets(t *testing.T) {
+	in := []Result{
+		res(1, 1, "unique one", 9, ""),
+		res(2, 2, "same banner", 5, ""),
+		res(3, 3, "same banner", 5, ""),
+		res(4, 4, "same banner", 5, ""),
+		res(5, 5, "unique two", 4, ""),
+	}
+	got := capResults(in)
+	if len(got) != 3 {
+		t.Fatalf("got %d results, want 3: %+v", len(got), got)
+	}
+	if got[1].DocID != 2 || got[2].DocID != 5 {
+		t.Errorf("wrong survivors: %+v", got)
+	}
+}
+
+func TestCapResultsLimitsChunksPerDocument(t *testing.T) {
+	in := []Result{
+		res(1, 1, "a", 9, ""), res(1, 2, "b", 8, ""),
+		res(1, 3, "c", 7, ""), res(2, 4, "d", 6, ""),
+	}
+	got := capResults(in)
+	if len(got) != 3 {
+		t.Fatalf("got %d results, want 3: %+v", len(got), got)
+	}
+	if got[2].DocID != 2 {
+		t.Errorf("document 1 exceeded the cap: %+v", got)
+	}
+}
+
+// Empty snippets are not evidence of duplication; collapsing them would drop
+// every undescribed hit but one.
+func TestCapResultsKeepsMultipleEmptySnippets(t *testing.T) {
+	in := []Result{res(1, 1, "", 9, ""), res(2, 2, "", 8, ""), res(3, 3, "  ", 7, "")}
+	if got := capResults(in); len(got) != 3 {
+		t.Fatalf("got %d results, want 3: %+v", len(got), got)
+	}
+}
+
+// The point of --sort date is "the newest", which means sorting the whole
+// candidate pool before the limit is applied — not reordering the top N.
+func TestFinalizeSortsPoolBeforeTruncating(t *testing.T) {
+	in := []Result{
+		res(1, 1, "a", 9, "2026-01-01"),
+		res(2, 2, "b", 8, "2026-02-01"),
+		res(3, 3, "c", 7, "2026-09-01"),
+	}
+	got := Finalize(in, SearchOpts{TopK: 1, Sort: "date"})
+	if len(got) != 1 || got[0].DocID != 3 {
+		t.Fatalf("got %+v, want only the 2026-09-01 document", got)
+	}
+}
+
+func TestSortByDatePutsUndatedLast(t *testing.T) {
+	in := []Result{res(1, 1, "a", 9, ""), res(2, 2, "b", 1, "2026-01-01")}
+	sortByDate(in)
+	if in[0].DocID != 2 {
+		t.Errorf("undated document sorted first: %+v", in)
+	}
+}
+
+func TestFinalizeRelevanceOrderIsUntouched(t *testing.T) {
+	in := []Result{res(1, 1, "a", 9, "2020-01-01"), res(2, 2, "b", 8, "2026-01-01")}
+	got := Finalize(in, SearchOpts{TopK: 5})
+	if got[0].DocID != 1 {
+		t.Errorf("relevance order changed without --sort date: %+v", got)
+	}
+}
+
+func TestDateFilterSQL(t *testing.T) {
+	sql, args := dateFilterSQL("d", SearchOpts{Since: "2026-01-01", Until: "2026-12-31"})
+	if sql != " AND d.doc_timestamp >= ? AND d.doc_timestamp <= ?" {
+		t.Errorf("sql = %q", sql)
+	}
+	if len(args) != 2 {
+		t.Errorf("args = %v", args)
+	}
+	if sql, args := dateFilterSQL("d", SearchOpts{}); sql != "" || args != nil {
+		t.Errorf("empty opts produced %q %v", sql, args)
+	}
+}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -32,7 +32,7 @@ type SearchOpts struct {
 	Query      string
 	Collection string // empty = all collections
 	TopK       int
-	Pool       int // candidates to retrieve before dedupe/cap; defaults to TopK
+	Pool       int    // candidates to retrieve before dedupe/cap; defaults to TopK
 	Mode       string // lexical | hybrid | deep
 	Explain    bool
 	Since      string // YYYY-MM-DD, inclusive lower bound on document timestamp

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -6,21 +6,25 @@ type Result struct {
 	ChunkID     int64   `json:"chunk_id"`
 	Collection  string  `json:"collection"`
 	Path        string  `json:"path"`
-	Title       string  `json:"title,omitempty"`
-	HeadingPath string  `json:"heading_path,omitempty"`
+	Title       string  `json:"title"`
+	HeadingPath string  `json:"heading_path"`
 	Snippet     string  `json:"snippet"`
+	Timestamp   string  `json:"timestamp"`
 	Score       float64 `json:"score"`
-	Explain     *ScoreExplain `json:"explain,omitempty"`
+	// Scale names the unit of Score. BM25 magnitudes and RRF scores differ by
+	// two orders of magnitude and are not comparable across commands.
+	Scale   string        `json:"scale"`
+	Explain *ScoreExplain `json:"explain,omitempty"`
 }
 
 // ScoreExplain breaks down how a score was computed.
 type ScoreExplain struct {
-	BM25Score    float64 `json:"bm25_score,omitempty"`
-	BM25Rank     int     `json:"bm25_rank,omitempty"`
-	VectorDist   float64 `json:"vector_distance,omitempty"`
-	VectorRank   int     `json:"vector_rank,omitempty"`
-	RRFScore     float64 `json:"rrf_score,omitempty"`
-	RerankScore  float64 `json:"rerank_score,omitempty"`
+	BM25Score   float64 `json:"bm25_score,omitempty"`
+	BM25Rank    int     `json:"bm25_rank,omitempty"`
+	VectorDist  float64 `json:"vector_distance,omitempty"`
+	VectorRank  int     `json:"vector_rank,omitempty"`
+	RRFScore    float64 `json:"rrf_score,omitempty"`
+	RerankScore float64 `json:"rerank_score,omitempty"`
 }
 
 // SearchOpts configures a search operation.
@@ -28,6 +32,10 @@ type SearchOpts struct {
 	Query      string
 	Collection string // empty = all collections
 	TopK       int
+	Pool       int // candidates to retrieve before dedupe/cap; defaults to TopK
 	Mode       string // lexical | hybrid | deep
 	Explain    bool
+	Since      string // YYYY-MM-DD, inclusive lower bound on document timestamp
+	Until      string // YYYY-MM-DD, inclusive upper bound
+	Sort       string // "" = relevance, "date" = newest first
 }

--- a/internal/search/vector.go
+++ b/internal/search/vector.go
@@ -29,7 +29,7 @@ type vecCandidate struct {
 }
 
 // Search returns up to topK results nearest to the query embedding.
-func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, topK int, collection string) ([]Result, error) {
+func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, topK int, opts SearchOpts) ([]Result, error) {
 	if err := validateVector(queryEmbedding); err != nil {
 		return nil, fmt.Errorf("invalid query embedding: %w", err)
 	}
@@ -45,10 +45,13 @@ func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, top
 
 	var collectionFilter string
 	args := []any{v.fingerprint}
-	if collection != "" {
+	if opts.Collection != "" {
 		collectionFilter = "AND d.collection = ?"
-		args = append(args, collection)
+		args = append(args, opts.Collection)
 	}
+	dateFilter, dateArgs := dateFilterSQL("d", opts)
+	collectionFilter += dateFilter
+	args = append(args, dateArgs...)
 
 	query := fmt.Sprintf(`
 		SELECT
@@ -58,6 +61,7 @@ func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, top
 			d.path,
 			COALESCE(d.title, d.path),
 			COALESCE(c.heading_path, ''),
+			COALESCE(d.doc_timestamp, ''),
 			c.text,
 			cv.vector
 		FROM chunk_vectors cv
@@ -81,7 +85,7 @@ func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, top
 		var blob []byte
 		if err := rows.Scan(
 			&r.DocID, &r.ChunkID, &r.Collection, &r.Path,
-			&r.Title, &r.HeadingPath, &r.Snippet, &blob,
+			&r.Title, &r.HeadingPath, &r.Timestamp, &r.Snippet, &blob,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/search/vector_test.go
+++ b/internal/search/vector_test.go
@@ -40,7 +40,7 @@ func TestVectorSearch_FiltersByFingerprint(t *testing.T) {
 	}
 
 	vs := NewVectorSearch(database, "fp-current")
-	results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 10, "")
+	results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 10, SearchOpts{})
 	if err != nil {
 		t.Fatalf("Search failed: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestVectorSearch_EmptyFingerprintReturnsNoResults(t *testing.T) {
 	}
 
 	vs := NewVectorSearch(database, "")
-	results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 10, "")
+	results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 10, SearchOpts{})
 	if err != nil {
 		t.Fatalf("Search failed: %v", err)
 	}
@@ -85,10 +85,10 @@ func TestVectorSearch_EmptyFingerprintReturnsNoResults(t *testing.T) {
 
 func TestVectorSearchRejectsZeroNormAndNonFiniteQueries(t *testing.T) {
 	vs := NewVectorSearch(openTestDB(t), "fp")
-	if _, err := vs.Search(context.Background(), []float32{0, 0}, 10, ""); err == nil {
+	if _, err := vs.Search(context.Background(), []float32{0, 0}, 10, SearchOpts{}); err == nil {
 		t.Fatal("expected zero-norm query rejection")
 	}
-	if _, err := vs.Search(context.Background(), []float32{1, math.Float32frombits(0x7fc00000)}, 10, ""); err == nil {
+	if _, err := vs.Search(context.Background(), []float32{1, math.Float32frombits(0x7fc00000)}, 10, SearchOpts{}); err == nil {
 		t.Fatal("expected non-finite query rejection")
 	}
 }
@@ -116,7 +116,7 @@ func TestVectorSearch_SkipsMismatchedDimensionDefensively(t *testing.T) {
 	}
 
 	vs := NewVectorSearch(database, "fp-x")
-	results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 10, "")
+	results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 10, SearchOpts{})
 	if err != nil {
 		t.Fatalf("Search must not error on a dimension mismatch: %v", err)
 	}

--- a/skills/qi-cli/SKILL.md
+++ b/skills/qi-cli/SKILL.md
@@ -119,7 +119,7 @@ These are per-command, not global.
 | `--until YYYY-MM-DD` | Only documents dated on or before this day |
 | `--sort date` | Newest first instead of by relevance |
 
-Dates come from the document's YAML frontmatter `timestamp:` (or `date:`). Documents without one are excluded by `--since`/`--until` and sort last under `--sort date`.
+Dates come from the document's YAML frontmatter `timestamp:`. Documents without one are excluded by `--since`/`--until` and sort last under `--sort date`.
 
 ---
 

--- a/skills/qi-cli/SKILL.md
+++ b/skills/qi-cli/SKILL.md
@@ -58,14 +58,14 @@ Semantic/hybrid search. Falls back gracefully to BM25 if the embedding provider 
 qi query "how does auth work"
 qi query "deploy pipeline" --mode lexical   # BM25 only
 qi query "deployment steps" --mode hybrid   # BM25 + vector (default)
-qi query "critical path" --mode deep        # hybrid + reranking
+qi query "critical path" --mode deep        # currently an alias for hybrid; reranking is not implemented
 qi query "question" --explain               # show BM25/vector/RRF score breakdown
 ```
 
 **Modes:**
 - `lexical` — BM25 only
 - `hybrid` (default) — BM25 + vector fused with RRF; skips vector if BM25 has a clear winner
-- `deep` — hybrid + optional reranking pass
+- `deep` — currently identical to `hybrid`. The reranking pass it is meant to add is not implemented, and `providers.rerank` / `rerank_top_k` are read by nothing.
 
 ### `qi get <id>`
 Retrieve a document by its 6-character hash prefix (shown in search results).
@@ -92,7 +92,7 @@ qi delete notes
 Show document counts, chunk counts, embedding counts, and database size per collection. If `Embeddings` count is much lower than `Chunks` count, vector search has no data to work with — re-run `qi index`.
 
 ### `qi doctor`
-Health-check config, database, collection paths, and provider connectivity. If the embedding provider shows `SKIP` instead of `OK`, `qi query` will silently fall back to BM25 regardless of your config.
+Health-check config, database, collection paths, and embedding coverage. It does **not** contact the provider: a `SKIP` line means no embedding provider is configured, not that one is unreachable. When none is configured, `qi query` silently falls back to BM25.
 
 ### `qi update`
 Update the binary in place from the latest GitHub release.
@@ -103,11 +103,23 @@ Update the binary in place from the latest GitHub release.
 
 | Flag | Description |
 |---|---|
-| `-v, --verbose` | Verbose/debug output |
+| `--verbose` | Log debug detail to stderr (no `-v` shorthand; `-v` is `--version` on `qi` itself) |
 | `-f, --format text\|json\|markdown` | Output format (default: text) |
 | `--config <path>` | Override config path |
+
+## `search` and `query` Flags
+
+These are per-command, not global.
+
+| Flag | Description |
+|---|---|
 | `-c, --collection <name>` | Limit to a specific collection |
 | `-n, --limit <N>` | Number of results (default: 10) |
+| `--since YYYY-MM-DD` | Only documents dated on or after this day |
+| `--until YYYY-MM-DD` | Only documents dated on or before this day |
+| `--sort date` | Newest first instead of by relevance |
+
+Dates come from the document's YAML frontmatter `timestamp:` (or `date:`). Documents without one are excluded by `--since`/`--until` and sort last under `--sort date`.
 
 ---
 
@@ -134,7 +146,7 @@ providers:
     dimension: 768
     max_input_chars: 0                    # optional — truncate long texts before embedding (0 = no limit)
 
-  rerank:                                 # optional — enables deep mode
+  rerank:                                 # parsed but unused: reranking is not implemented
     base_url: http://localhost:8080
     model: bge-reranker-v2-m3
 
@@ -179,7 +191,7 @@ providers:
 - **BM25** — SQLite FTS5. Always available, very fast, good for keyword queries.
 - **Vector KNN** — Cosine similarity over embedding BLOBs in SQLite. Requires an embedding provider. Captures semantic intent.
 - **Hybrid (RRF)** — Runs both, fuses rankings with Reciprocal Rank Fusion (`score = Σ 1/(k + rank)`). Skips vector if BM25 has a dominant winner (top score > 3× second place).
-- **Deep** — Hybrid + a second-pass reranker for best accuracy.
+- **Deep** — Accepted, but identical to Hybrid today. No reranker runs.
 
 ---
 
@@ -215,7 +227,7 @@ qi query "how does X work" --explain
 
 **Debug / inspect:**
 ```bash
-qi doctor                         # check all providers are reachable
+qi doctor                         # check config, database, and embedding coverage
 qi stats                          # see document/chunk/embedding counts
 qi query "question" --explain     # see score breakdown
 qi get abc123                     # read the full source document


### PR DESCRIPTION
## Summary

A session using qi against a 26-file Obsidian vault had to abandon it and fall back to `find` + `cat`. The investigation found one upstream bug causing most of the damage: `internal/parser/markdown.go` dropped the text of every markdown list item and parsed YAML frontmatter as body prose. **78 of 241 chunks (32%) were the literal string `- \n- \n-`** — each one embedded, all identical, so they occupied the top of every vector result list.

The same corpus had grown a **188 MB database from 200 KB of notes**, 85% of it dead space that nothing ever reclaimed.

## Commits

- `08caed1` feat(config)!: name collections after their directory
- `8900b66` fix(parser): index list text and keep YAML frontmatter out of chunks
- `afce383` fix(index): store frontmatter metadata, reclaim space, add --force
- `da1045e` feat(search): filter by date, collapse duplicates, and label score scales
- `6a323ae` fix(cli): print local time in stats and make --verbose work
- `00873ea` docs: reconcile the bundled skill and docs with the binary
- `0e126e9` fix(search): keep -n above bm25_top_k from capping the result count
- `b69cd64` fix(parser): strip frontmatter even when its YAML does not decode
- `01916de` fix(config): stop a depth cap from collapsing deep colliding names
- `da03c2e` refactor(search): use the stdlib sort and drop a one-call wrapper
- `fd8539c` fix(db): stop a collection rename from deleting real documents
- `3fd0a51` fix(config): assign collection names over the whole set when adding one

The last six came out of adversarial review of the first six.

## Changes

**Parsing.** `extractText` read only a node's direct `ast.Text` children; a list item's words sit in a `TextBlock` one level down, so every list was indexed as a bare `-`. `nodeText` now walks the whole subtree, and list items are taken in one pass with `WalkSkipChildren` so a loose item is not emitted twice. Frontmatter is split off before goldmark sees the file — `title`, `timestamp` and `tags` become document fields, and the retrieval-worthy ones are re-emitted as one leading section of plain prose. Delimiters decide what is frontmatter; YAML that fails to decode is still stripped rather than indexed as text.

**Recency.** `--since`, `--until` and `--sort date` on both `search` and `query`, filtering on the frontmatter date (migration `006` adds `documents.doc_timestamp` and `tags`). The sort runs over the full candidate pool before the limit is applied — sorting after truncation would return the newest of the most relevant, which is not what "latest" means.

**Result quality.** Nothing deduplicated or capped, so a warning banner repeated across nine files took four consecutive slots at an identical BM25 score. `search.Finalize` collapses byte-identical snippets and allows at most two chunks per document. Retrievers no longer truncate; the same clamp appeared five times in `Hybrid.Search`.

**Output.** FTS5 was asked for `<b>`/`</b>`, which reached the terminal, JSON and markdown as literal tags; it now returns sentinel bytes rendered as ANSI bold only on a character device. `score` carried raw BM25 magnitudes on one path and RRF values on the other under one unlabelled key — each result now names its `scale`. `title` and `heading_path` lost `omitempty`, and an empty result set encodes as `[]` rather than `null`.

**Storage.** Every index run prunes orphaned content bodies, runs FTS5 `optimize`, and vacuums once the freelist is worth the rewrite. FTS5 merges segments only when asked, and superseded document bodies — including anything since redacted — were never pruned. `--force` reindexes unchanged files, which any parser change needs.

**Naming.** Collections were named from every path segment below home, producing `Library-Mobile-Documents-iCloud-md-obsidian-Documents-health`. A collection is now named after its own directory, and only colliding names absorb leading segments (`work-notes`, `personal-notes`).

## Breaking Changes

**Generated collection names change.** `~/Library/.../Documents/health` was `Library-Mobile-Documents-iCloud-md-obsidian-Documents-health` and is now `health`.

Indexed data migrates automatically on the next run through the existing `OriginalName` → `RenameCollectionData` path. **Scripts passing the old long name to `-c` must be updated.**

Migration `006` also drops the vestigial `collections` table. Indexing never populated it — `qi index` writes the config file — so `qi list` and `qi stats` disagreed. Config is now the single source of truth for which collections exist, `documents` for which are indexed.

**Upgrade note:** change detection is by content hash, so already-indexed files are not reparsed by an upgrade alone. Run `qi index <collection> --force` once to pick up the parser fix and backfill `doc_timestamp`.

## Test Plan

- [ ] `task check` (build + `go test ./...` + `go vet ./...`)
- [ ] Index a vault with YAML frontmatter, then confirm no junk chunks remain:
  ```sh
  sqlite3 qi.db "select count(*) from chunks
    where trim(replace(replace(text,'-',''),char(10),''))=''"   # expect 0
  ```
- [ ] `qi query "<topic>" -n 2 -f json` — real titles from frontmatter, no `<b>`, every row the same key set, a `scale` field
- [ ] `qi query "<topic>" --sort date -n 5` returns newest first; `--since 2026-07-01` excludes older notes; `--since july` errors
- [ ] `qi search "<repeated boilerplate>" -n 8` — the banner appears once, no document holds more than two slots
- [ ] `qi index <collection>` on a churned database drops `pragma freelist_count` and shrinks the file
- [ ] `qi index ~/work/notes && qi index ~/personal/notes` — both accepted, named `work-notes` and `personal-notes`
- [ ] `qi list` and `qi stats` agree on names; `qi stats` prints a zone-suffixed local time matching `date`

## Verification performed

Against the 26-file vault that prompted the work:

| | before | after |
|---|---|---|
| junk chunks | 78 / 241 | **0 / 247** |
| chunks with leaked frontmatter | 16 | **0** |
| documents titled "Overview" | 10 | **0** |
| documents with a usable date | 0 | **16** |
| database size | 188.2 MB | **1.3 MB** |

`qi query "recent health status labs symptoms"` returned nothing but a boilerplate banner in slots 2–5 at four identical scores; it now returns the relevant panels. `qi query "<topic>" --sort date` answers "what's the latest", which was previously unanswerable.

## Notes for review

`--mode deep` is accepted but identical to `hybrid`, and `providers.rerank` / `rerank_top_k` are read by nothing. Not implemented here — the docs now say so instead of describing a third mode that does not exist. `qi doctor` likewise never contacted a provider despite promising "provider health"; the wording is corrected rather than the check added.

Finding #4 from the investigation — long natural-language queries failing in both modes — was **misdiagnosed as a fusion bug**. `--explain` shows the 3× vector-skip heuristic never fires; no term in the corpus exceeds a 1.4× top/second BM25 ratio. The failure was the identical junk vectors from the parser bug. `fusion.go` is deliberately unchanged.

## Release Notes

qi now indexes the contents of markdown lists, which were previously dropped entirely, and reads YAML frontmatter as document metadata instead of body text — so results carry real titles and searching finds text that lives in bullet points. New `--since`, `--until` and `--sort date` options answer "what changed recently". Repeated boilerplate no longer crowds out real results, and no single document can monopolise the list. Indexing now reclaims disk space it used to leak; one vault went from 188 MB to 1.3 MB. Collection names are short again: `health` rather than `Library-Mobile-Documents-iCloud-md-obsidian-Documents-health`.

After upgrading, run `qi index <collection> --force` once so existing documents are reparsed.

## Checklist

- [x] Tests pass locally (`task test`)
- [x] Linting passes (`task lint`)
- [x] Documentation updated (`CLAUDE.md`, `docs/configuration.md`, `skills/qi-cli/SKILL.md`)
- [x] Breaking changes documented (`BREAKING CHANGE:` footer on `08caed1`)
- [x] Conventional commit format followed
