### PR TITLE
fix(ci): honor draft release tag creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,9 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Run Release Please
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        # Requires release-please >=17.2.0 to honor force-tag-creation for drafts.
+        # Without the tag, PR generation replays already-released commits.
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
 
   build-binaries:


### PR DESCRIPTION
The pinned Release Please action v4.4.0 bundles release-please 17.1.3, which ignores `force-tag-creation`. After creating a draft release, the same run cannot find its tag and replays previously released commits into another release PR. Run 33924975743 demonstrated this by opening #71 while v0.14.0 was still a draft.

Upgrade the action to SHA-pinned v5.0.0, which bundles release-please 17.6.0 and honors forced tag creation for draft releases. This preserves publication after asset verification while making the release boundary available during PR generation.

Validation: `task check`, `go build .`, actionlint v1.7.7, and `git diff --check` passed.

After this fix lands, close the redundant release PR #71 rather than merging it.
