### PR TITLE
feat(search): make every hit citable with source line ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ qi doctor
 | `qi index [path\|collection]` | Index directory (current dir by default) or collection |
 | `qi search <query>` | BM25 full-text search |
 | `qi query <query>` | Hybrid search (BM25 + vector) |
-| `qi get <id>` | Retrieve document by 6-char hash ID (`--lines A:B`, `--max-bytes N`) |
+| `qi get <hash>` | Retrieve indexed source by full content hash or unambiguous prefix (`--lines A:B`, `--max-bytes N`) |
 | `qi list` | List all collections |
 | `qi delete <collection>` | Delete a collection and all its indexed data |
 | `qi stats` | Show index statistics |
@@ -159,17 +159,43 @@ providers:
   #   batch_size: 32
 ```
 
-## Document IDs
+## Retrieving and citing search hits
 
-Each document gets a short ID from the first 6 hex characters of its SHA-256 content hash:
+Every `search` and `query` hit includes a full SHA-256 `hash`, a `source_uri`
+identifying its collection/path, and 1-indexed, inclusive `start_line` and
+`end_line` ranges in the original indexed source. The hash identifies the source
+version; cite the URI, hash, and line range together. Integer `doc_id`/`chunk_id`
+fields are internal IDs, not arguments to `get`. If you override `--config`,
+use the same config for search and retrieval.
 
 ```sh
-qi get abc123
-qi get abc123 --lines 40:80      # 1-indexed, inclusive
-qi get abc123 --max-bytes 4096   # truncate long documents
+qi search "deployment" --format json
+# Copy hash, start_line and end_line from a hit:
+qi get <hash> --lines <start_line>:<end_line>
+qi get <hash> --max-bytes 4096
+
+# Include up to two additional matching passages per document:
+qi query "deployment" --passages 2 --format json
 ```
 
-A prefix matching more than one document is an error listing the candidates.
+`--passages` accepts 0–5 (default 0), without giving a document extra result slots
+or ranking votes. Supporting passages inherit the parent hit's hash and source
+URI. Ranges cover the source behind each chunk, not just highlighted words;
+Markdown syntax and frontmatter remain present when retrieved.
+
+`get` reads the **indexed snapshot**, not the live file. Editing a file does not
+change that snapshot until reindexing. Old hashes are not retained as revision
+history after replacement/deletion and index compaction. A hash alone does not
+prove the current file is unchanged.
+
+Unambiguous hash prefixes (such as `abc123`) also work. Identical content at
+multiple paths is returned once, with other locations in `also_at`; use the
+search hit's `source_uri` to retain the intended citation identity. Prefixes
+matching different content hashes are errors.
+
+Search skips chunks with missing or invalid source ranges. After upgrading an
+older index, run `qi index <collection>` to repair them. If the collection is no
+longer in config, index its source directory with `qi index /path/to/directory`.
 
 ## License
 

--- a/cmd/citations_test.go
+++ b/cmd/citations_test.go
@@ -1,0 +1,239 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type citationJSONResult struct {
+	Hash      string            `json:"hash"`
+	SourceURI string            `json:"source_uri"`
+	StartLine int               `json:"start_line"`
+	EndLine   int               `json:"end_line"`
+	Passages  []json.RawMessage `json:"passages"`
+}
+
+func TestSearchJSONCitationRoundTripThroughGet(t *testing.T) {
+	root := t.TempDir()
+	collectionPath := filepath.Join(root, "docs")
+	if err := os.Mkdir(collectionPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw := "---\r\ntitle: Citation notes\r\ntags: [unicode]\r\n---\r\n# Intro\r\nIgnored context.\r\n\r\n## Evidence 🧭\r\nThe citation-anchor appears inside a Unicode section.\r\n\r\n## More evidence\r\nA second citation-anchor supports the same document.\r\n\r\n```go\r\nfmt.Println(\"fence\")\r\n```\r\n"
+	nested := filepath.Join(collectionPath, "nested")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(nested, "space ü.md")
+	if err := os.WriteFile(path, []byte(raw), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeIndexTestConfig(t, fmt.Sprintf(`database_path: %s
+search:
+  default_mode: lexical
+  chunk_size: 32
+collections:
+  - name: docs
+    path: %s
+    extensions: [.md]
+`, filepath.Join(root, "qi.db"), collectionPath))
+	withIndexTestConfig(t, cfgPath)
+
+	oldForce := indexForce
+	indexForce = false
+	t.Cleanup(func() { indexForce = oldForce })
+	if out := captureIndexTestOutput(t, func() {
+		if err := indexCmd.RunE(indexCmd, []string{"docs"}); err != nil {
+			t.Fatalf("index failed: %v", err)
+		}
+	}); out == "" {
+		t.Fatal("index produced no status output")
+	}
+
+	oldFormat, oldCollection, oldTopK, oldPassages := format, searchCollection, searchTopK, searchPassages
+	oldSince, oldUntil, oldSort := searchSince, searchUntil, searchSort
+	format, searchCollection, searchTopK, searchPassages = "json", "", 10, 5
+	searchSince, searchUntil, searchSort = "", "", ""
+	t.Cleanup(func() {
+		format, searchCollection, searchTopK, searchPassages = oldFormat, oldCollection, oldTopK, oldPassages
+		searchSince, searchUntil, searchSort = oldSince, oldUntil, oldSort
+	})
+	var results []citationJSONResult
+	searchOutput := captureIndexTestOutput(t, func() {
+		if err := searchCmd.RunE(searchCmd, []string{"citation", "anchor"}); err != nil {
+			t.Fatalf("search failed: %v", err)
+		}
+	})
+	if err := json.Unmarshal([]byte(searchOutput), &results); err != nil {
+		t.Fatalf("search JSON is invalid: %v\n%s", err, searchOutput)
+	}
+	if len(results) != 1 {
+		t.Fatalf("search returned %d results, want one\n%s", len(results), searchOutput)
+	}
+	result := results[0]
+	if len(result.Hash) != sha256.Size*2 {
+		t.Fatalf("search hash = %q, want full SHA-256", result.Hash)
+	}
+	if result.SourceURI != "qi://docs/nested/space%20%C3%BC.md" {
+		t.Fatalf("source_uri = %q, want escaped path identity", result.SourceURI)
+	}
+	if result.StartLine < 1 || result.EndLine < result.StartLine {
+		t.Fatalf("invalid source range %d:%d", result.StartLine, result.EndLine)
+	}
+	if len(result.Passages) == 0 {
+		t.Fatal("search result has no supporting passages")
+	}
+
+	// Get must serve the indexed content-addressed snapshot, not bytes changed
+	// after indexing.
+	changed := strings.Replace(raw, "citation-anchor", "changed-live", 1)
+	if err := os.WriteFile(path, []byte(changed), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	oldGetLines, oldMaxBytes := getLines, getMaxBytes
+	getLines, getMaxBytes, format = fmt.Sprintf("%d:%d", result.StartLine, result.EndLine), 0, "json"
+	t.Cleanup(func() { getLines, getMaxBytes = oldGetLines, oldMaxBytes })
+	var got candidate
+	getOutput := captureIndexTestOutput(t, func() {
+		if err := getCmd.RunE(getCmd, []string{result.Hash}); err != nil {
+			t.Fatalf("get failed: %v", err)
+		}
+	})
+	if err := json.Unmarshal([]byte(getOutput), &got); err != nil {
+		t.Fatalf("get JSON is invalid: %v\n%s", err, getOutput)
+	}
+	rawLines := strings.Split(strings.TrimSuffix(raw, "\n"), "\n")
+	if result.EndLine > len(rawLines) {
+		t.Fatalf("source range ends past source: %d > %d", result.EndLine, len(rawLines))
+	}
+	expectedBody := strings.Join(rawLines[result.StartLine-1:result.EndLine], "\n")
+	if got.Hash != result.Hash || got.Path != "nested/space ü.md" || got.SourceURI != result.SourceURI || got.Body != expectedBody || !strings.Contains(got.Body, "citation-anchor") || strings.Contains(got.Body, "changed-live") {
+		t.Fatalf("get did not return indexed snapshot: hash=%q path=%q body=%q want=%q", got.Hash, got.Path, got.Body, expectedBody)
+	}
+}
+
+func TestCitationRangesNarrowLateCRLFParagraphAndFenceChunks(t *testing.T) {
+	root := t.TempDir()
+	collectionPath := filepath.Join(root, "docs")
+	if err := os.Mkdir(collectionPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lines := []string{
+		"---", "title: Range notes", "---", "# Range heading",
+		"paragraph first source line", "paragraph second source line", "paragraph third source line",
+		"paragraph fourth source line", "paragraphmarkerNE near the end", "",
+		"```text", "fence first source line", "fence second source line", "fence third source line",
+		"fence fourth source line", "fencemarkerNE near the end", "```", "",
+	}
+	raw := strings.Join(lines, "\r\n")
+	path := filepath.Join(collectionPath, "ranges.md")
+	if err := os.WriteFile(path, []byte(raw), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeIndexTestConfig(t, fmt.Sprintf(`database_path: %s
+search:
+  default_mode: lexical
+  chunk_size: 36
+collections:
+  - name: docs
+    path: %s
+    extensions: [.md]
+`, filepath.Join(root, "qi.db"), collectionPath))
+	withIndexTestConfig(t, cfgPath)
+	oldForce := indexForce
+	indexForce = false
+	t.Cleanup(func() { indexForce = oldForce })
+	captureIndexTestOutput(t, func() {
+		if err := indexCmd.RunE(indexCmd, []string{"docs"}); err != nil {
+			t.Fatalf("index failed: %v", err)
+		}
+	})
+
+	oldFormat, oldCollection, oldTopK, oldPassages := format, searchCollection, searchTopK, searchPassages
+	oldSince, oldUntil, oldSort := searchSince, searchUntil, searchSort
+	format, searchCollection, searchTopK, searchPassages = "json", "", 10, 0
+	searchSince, searchUntil, searchSort = "", "", ""
+	t.Cleanup(func() {
+		format, searchCollection, searchTopK, searchPassages = oldFormat, oldCollection, oldTopK, oldPassages
+		searchSince, searchUntil, searchSort = oldSince, oldUntil, oldSort
+	})
+	search := func(marker string) citationJSONResult {
+		var results []citationJSONResult
+		out := captureIndexTestOutput(t, func() {
+			if err := searchCmd.RunE(searchCmd, []string{marker}); err != nil {
+				t.Fatalf("search %q failed: %v", marker, err)
+			}
+		})
+		if err := json.Unmarshal([]byte(out), &results); err != nil {
+			t.Fatalf("search %q JSON is invalid: %v\n%s", marker, err, out)
+		}
+		if len(results) != 1 {
+			t.Fatalf("search %q returned %d results, want one\n%s", marker, len(results), out)
+		}
+		return results[0]
+	}
+	paragraph := search("paragraphmarkerNE")
+	if paragraph.StartLine <= 5 || paragraph.EndLine < paragraph.StartLine {
+		t.Fatalf("late paragraph marker cited its first lines: %+v", paragraph)
+	}
+	fence := search("fencemarkerNE")
+	if fence.StartLine <= 12 || fence.EndLine < fence.StartLine {
+		t.Fatalf("late fence marker cited its first lines: %+v", fence)
+	}
+}
+
+func TestIndexedDuplicateContentIsRetrievableAtAllPaths(t *testing.T) {
+	root := t.TempDir()
+	collectionPath := filepath.Join(root, "docs")
+	if err := os.Mkdir(collectionPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("same content\n")
+	for _, name := range []string{"one.md", "two.md"} {
+		if err := os.WriteFile(filepath.Join(collectionPath, name), body, 0o640); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfgPath := writeIndexTestConfig(t, fmt.Sprintf(`database_path: %s
+collections:
+  - name: docs
+    path: %s
+    extensions: [.md]
+`, filepath.Join(root, "qi.db"), collectionPath))
+	withIndexTestConfig(t, cfgPath)
+	oldForce := indexForce
+	indexForce = false
+	t.Cleanup(func() { indexForce = oldForce })
+	captureIndexTestOutput(t, func() {
+		if err := indexCmd.RunE(indexCmd, []string{"docs"}); err != nil {
+			t.Fatalf("index failed: %v", err)
+		}
+	})
+
+	hashBytes := sha256.Sum256(body)
+	hash := hex.EncodeToString(hashBytes[:])
+	oldFormat, oldLines, oldMaxBytes := format, getLines, getMaxBytes
+	format, getLines, getMaxBytes = "json", "", 0
+	t.Cleanup(func() { format, getLines, getMaxBytes = oldFormat, oldLines, oldMaxBytes })
+	var got candidate
+	out := captureIndexTestOutput(t, func() {
+		if err := getCmd.RunE(getCmd, []string{hash}); err != nil {
+			t.Fatalf("get failed: %v", err)
+		}
+	})
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("get JSON is invalid: %v\n%s", err, out)
+	}
+	if got.Hash != hash || got.Body != string(body) || len(got.AlsoAt) != 1 {
+		t.Fatalf("unexpected duplicate retrieval: %+v", got)
+	}
+	if got.Path != "one.md" || got.AlsoAt[0] != "qi://docs/two.md" {
+		t.Fatalf("duplicate paths lost identity: path=%q also_at=%q", got.Path, got.AlsoAt)
+	}
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/itsmostafa/qi/internal/app"
+	"github.com/itsmostafa/qi/internal/search"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +22,7 @@ var (
 type candidate struct {
 	Collection string `json:"collection"`
 	Path       string `json:"path"`
+	SourceURI  string `json:"source_uri"`
 	Title      string `json:"title"`
 	Hash       string `json:"hash"`
 	Body       string `json:"body"`
@@ -30,15 +32,16 @@ type candidate struct {
 	AlsoAt []string `json:"also_at,omitempty"`
 }
 
-// sharedHash reports whether every match is the same content under different
-// paths, which no longer prefix can tell apart.
-func sharedHash(matches []candidate) bool {
-	for _, m := range matches[1:] {
-		if m.Hash != matches[0].Hash {
-			return false
+func validateHashPrefix(id string) (string, error) {
+	if id == "" || len(id) > 64 {
+		return "", fmt.Errorf("ID prefix must contain 1 to 64 hexadecimal characters, got %q", id)
+	}
+	for _, r := range id {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return "", fmt.Errorf("ID prefix must contain only hexadecimal characters, got %q", id)
 		}
 	}
-	return true
+	return strings.ToLower(id), nil
 }
 
 var getCmd = &cobra.Command{
@@ -46,7 +49,13 @@ var getCmd = &cobra.Command{
 	Short: "Retrieve a document by ID (hash prefix)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id := args[0]
+		id, err := validateHashPrefix(args[0])
+		if err != nil {
+			return err
+		}
+		if getMaxBytes < 0 {
+			return fmt.Errorf("--max-bytes must not be negative, got %d", getMaxBytes)
+		}
 		ctx := context.Background()
 		a, err := app.New(ctx, cfgFile)
 		if err != nil {
@@ -54,17 +63,56 @@ var getCmd = &cobra.Command{
 		}
 		defer a.Close()
 
-		// Match by content hash prefix. LIMIT bounds an over-short prefix.
-		// ponytail: past 10 documents sharing one hash the "also at" list is
-		// truncated; page it if anyone ever hits that.
+		// First identify distinct hashes. Looking at only the first ten paths can
+		// hide a second hash when many documents share one content blob.
+		hashRows, err := a.DB.QueryContext(ctx, `
+			SELECT DISTINCT d.content_hash
+			FROM documents d
+			WHERE d.content_hash LIKE ? AND d.active = 1
+			ORDER BY d.content_hash
+			LIMIT 2
+		`, id+"%")
+		if err != nil {
+			return fmt.Errorf("querying document: %w", err)
+		}
+		var hashes []string
+		for hashRows.Next() {
+			var hash string
+			if err := hashRows.Scan(&hash); err != nil {
+				hashRows.Close()
+				return fmt.Errorf("reading document hash: %w", err)
+			}
+			hashes = append(hashes, hash)
+		}
+		if err := hashRows.Err(); err != nil {
+			hashRows.Close()
+			return fmt.Errorf("reading document hashes: %w", err)
+		}
+		hashRows.Close()
+		switch len(hashes) {
+		case 0:
+			return fmt.Errorf("no document found with ID prefix %q", id)
+		case 2:
+			var b strings.Builder
+			fmt.Fprintf(&b, "ID prefix %q is ambiguous; distinct hashes:", id)
+			for _, hash := range hashes {
+				fmt.Fprintf(&b, "\n  %s", hash)
+			}
+			b.WriteString("\n\nRetry with a longer prefix.")
+			return fmt.Errorf("%s", b.String())
+		}
+
+		// LIMIT bounds a potentially very large duplicate-content path list.
+		// ponytail: only the first ten locations are reported; page this list if
+		// a caller ever needs every duplicate path.
 		rows, err := a.DB.QueryContext(ctx, `
 			SELECT d.collection, d.path, COALESCE(d.title, ''), d.content_hash, c.body
 			FROM documents d
 			JOIN content c ON c.hash = d.content_hash
-			WHERE d.content_hash LIKE ? AND d.active = 1
+			WHERE d.content_hash = ? AND d.active = 1
 			ORDER BY d.collection, d.path
 			LIMIT 10
-		`, id+"%")
+		`, hashes[0])
 		if err != nil {
 			return fmt.Errorf("querying document: %w", err)
 		}
@@ -76,36 +124,23 @@ var getCmd = &cobra.Command{
 			if err := rows.Scan(&c.Collection, &c.Path, &c.Title, &c.Hash, &c.Body); err != nil {
 				return fmt.Errorf("reading document: %w", err)
 			}
+			c.SourceURI = search.SourceURI(c.Collection, c.Path)
 			matches = append(matches, c)
 		}
 		if err := rows.Err(); err != nil {
 			return fmt.Errorf("reading documents: %w", err)
 		}
 
-		switch {
-		case len(matches) == 0:
+		if len(matches) == 0 {
 			return fmt.Errorf("no document found with ID prefix %q", id)
-		case len(matches) > 1 && !sharedHash(matches):
-			// Printing every match silently was a correctness bug: the caller
-			// could not tell one document from a pile of them.
-			var b strings.Builder
-			fmt.Fprintf(&b, "ID prefix %q is ambiguous; matches:", id)
-			for _, c := range matches {
-				fmt.Fprintf(&b, "\n  %s  qi://%s/%s", c.Hash, c.Collection, c.Path)
-			}
-			b.WriteString("\n\nRetry with a longer prefix.")
-			return fmt.Errorf("%s", b.String())
 		}
 
-		if getMaxBytes < 0 {
-			return fmt.Errorf("--max-bytes must not be negative, got %d", getMaxBytes)
-		}
 		// Identical files dedupe to one content row, so several documents can
 		// share a hash. That is not an ambiguous prefix — no longer prefix
-		// exists — so return the content and name every path it lives at.
+		// exists — so return the content and list the locations found.
 		doc := matches[0]
 		for _, m := range matches[1:] {
-			doc.AlsoAt = append(doc.AlsoAt, fmt.Sprintf("qi://%s/%s", m.Collection, m.Path))
+			doc.AlsoAt = append(doc.AlsoAt, search.SourceURI(m.Collection, m.Path))
 		}
 		doc.Body, err = sliceLines(doc.Body, getLines)
 		if err != nil {
@@ -127,7 +162,7 @@ var getCmd = &cobra.Command{
 		fmt.Fprintf(os.Stdout, "# %s\n", doc.Title)
 		fmt.Fprintf(os.Stdout, "ID:         #%s\n", doc.Hash[:6])
 		fmt.Fprintf(os.Stdout, "Collection: %s\n", doc.Collection)
-		fmt.Fprintf(os.Stdout, "Path:       qi://%s/%s\n", doc.Collection, doc.Path)
+		fmt.Fprintf(os.Stdout, "Path:       %s\n", search.SourceURI(doc.Collection, doc.Path))
 		for _, p := range doc.AlsoAt {
 			fmt.Fprintf(os.Stdout, "Also at:    %s\n", p)
 		}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -63,7 +63,7 @@ func TestGetAmbiguousPrefixErrors(t *testing.T) {
 	if strings.Contains(out, "one") || strings.Contains(out, "two") {
 		t.Errorf("ambiguous prefix printed document bodies:\n%s", out)
 	}
-	for _, want := range []string{"ambiguous", "abc123aaaa", "abc123bbbb", "qi://test/a.md"} {
+	for _, want := range []string{"ambiguous", "abc123aaaa", "abc123bbbb"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error missing %q: %v", want, err)
 		}
@@ -103,6 +103,47 @@ func TestGetLineRangeAndMaxBytes(t *testing.T) {
 	}
 	if doc.Body != "l1" || !doc.Truncated || doc.Hash != "def456cccc" {
 		t.Errorf("unexpected JSON document: %+v", doc)
+	}
+}
+
+func TestGetRejectsInvalidHashPrefixes(t *testing.T) {
+	withIndexTestConfig(t, makeGetTestConfig(t))
+	withGetFlags(t, "", 0, "text")
+	for _, id := range []string{"", "%", "abc_", strings.Repeat("a", 65), "not-a-hash"} {
+		if err := getCmd.RunE(getCmd, []string{id}); err == nil {
+			t.Errorf("invalid ID prefix %q should be rejected", id)
+		}
+	}
+}
+
+func TestGetDetectsAmbiguityBeyondDuplicatePathLimit(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "qi.db")
+	database, err := db.Open(context.Background(), dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(`
+		INSERT INTO content(hash, body) VALUES ('abc123aaaa', 'one'), ('abc123bbbb', 'two');
+		INSERT INTO documents(collection, path, title, content_hash)
+		VALUES
+			('test', 'a-01.md', 'A', 'abc123aaaa'), ('test', 'a-02.md', 'A', 'abc123aaaa'),
+			('test', 'a-03.md', 'A', 'abc123aaaa'), ('test', 'a-04.md', 'A', 'abc123aaaa'),
+			('test', 'a-05.md', 'A', 'abc123aaaa'), ('test', 'a-06.md', 'A', 'abc123aaaa'),
+			('test', 'a-07.md', 'A', 'abc123aaaa'), ('test', 'a-08.md', 'A', 'abc123aaaa'),
+			('test', 'a-09.md', 'A', 'abc123aaaa'), ('test', 'a-10.md', 'A', 'abc123aaaa'),
+			('test', 'b.md', 'B', 'abc123bbbb');
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+	withIndexTestConfig(t, writeIndexTestConfig(t, fmt.Sprintf("database_path: %s\n", dbPath)))
+	withGetFlags(t, "", 0, "text")
+	if err := getCmd.RunE(getCmd, []string{"abc123"}); err == nil ||
+		!strings.Contains(err.Error(), "abc123bbbb") {
+		t.Fatalf("prefix hidden beyond duplicate paths: %v", err)
 	}
 }
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -17,6 +17,7 @@ var (
 	queryExplain    bool
 	queryCollection string
 	queryTopK       int
+	queryPassages   int
 	querySince      string
 	queryUntil      string
 	querySort       string
@@ -44,6 +45,7 @@ var queryCmd = &cobra.Command{
 			Query:      q,
 			Collection: queryCollection,
 			TopK:       queryTopK,
+			Passages:   queryPassages,
 			Pool:       a.Config.Search.BM25TopK,
 			Mode:       mode,
 			Explain:    queryExplain,
@@ -84,5 +86,6 @@ func init() {
 	queryCmd.Flags().BoolVar(&queryExplain, "explain", false, "show scoring breakdown")
 	queryCmd.Flags().StringVarP(&queryCollection, "collection", "c", "", "limit to a specific collection")
 	queryCmd.Flags().IntVarP(&queryTopK, "limit", "n", 10, "number of results to return")
+	queryCmd.Flags().IntVar(&queryPassages, "passages", 0, "additional supporting passages per document (0–5)")
 	addRecencyFlags(queryCmd, &querySince, &queryUntil, &querySort)
 }

--- a/cmd/recency.go
+++ b/cmd/recency.go
@@ -18,6 +18,9 @@ func addRecencyFlags(cmd *cobra.Command, since, until, sort *string) {
 }
 
 func validateSearchOpts(opts search.SearchOpts) error {
+	if opts.Passages < 0 || opts.Passages > search.MaxPassages {
+		return fmt.Errorf("--passages must be between 0 and %d", search.MaxPassages)
+	}
 	checkDate := func(name, value string) error {
 		if value == "" {
 			return nil

--- a/cmd/recency_test.go
+++ b/cmd/recency_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/itsmostafa/qi/internal/search"
+)
+
+func TestPassageLimitValidation(t *testing.T) {
+	for _, n := range []int{-1, 0, search.MaxPassages, search.MaxPassages + 1} {
+		err := validateSearchOpts(search.SearchOpts{Passages: n})
+		valid := n >= 0 && n <= search.MaxPassages
+		if (err == nil) != valid {
+			t.Errorf("passages=%d: got %v, want valid=%v", n, err, valid)
+		}
+	}
+}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -15,6 +15,7 @@ import (
 var (
 	searchCollection string
 	searchTopK       int
+	searchPassages   int
 	searchSince      string
 	searchUntil      string
 	searchSort       string
@@ -37,6 +38,7 @@ var searchCmd = &cobra.Command{
 			Query:      query,
 			Collection: searchCollection,
 			TopK:       searchTopK,
+			Passages:   searchPassages,
 			Pool:       a.Config.Search.BM25TopK,
 			Mode:       "lexical",
 			Since:      searchSince,
@@ -61,5 +63,6 @@ var searchCmd = &cobra.Command{
 func init() {
 	searchCmd.Flags().StringVarP(&searchCollection, "collection", "c", "", "limit to a specific collection")
 	searchCmd.Flags().IntVarP(&searchTopK, "limit", "n", 10, "number of results to return")
+	searchCmd.Flags().IntVar(&searchPassages, "passages", 0, "additional supporting passages per document (0–5)")
 	addRecencyFlags(searchCmd, &searchSince, &searchUntil, &searchSort)
 }

--- a/docs/zvec-grep-comparison-2026-09-04.md
+++ b/docs/zvec-grep-comparison-2026-09-04.md
@@ -1,0 +1,133 @@
+# qi vs zvec-grep: feature audit
+
+Date: 2026-09-04 (America/Los_Angeles).
+
+Reviewed zvec-grep commit `52653951b24617762f4ab0c71c34d594e5001617` and qi working tree based on `0e1830d8fb7b663a3a5b2946616abf6ff4569938`, including existing uncommitted changes. Three Luna subagents investigated retrieval, indexing, and agent UX; the primary agent checked and consolidated findings. This is source inspection, not a measured performance comparison. The original audit performed no implementation or benchmark runs; finding 1's implementation follow-up is recorded below. Existing user changes were preserved.
+
+## Recommendation
+
+Borrow zvec-grep’s evidence and operational contracts before its infrastructure. qi already has the core retrieval algorithms. Its most valuable improvements are making search results directly retrievable, making indexing recoverable, and exposing scope and freshness clearly. Keep the lightweight SQLite architecture until measurements justify changing it.
+
+Priority labels below express proposed work order, not confirmed incident severity. “Small/medium/large” are relative scope estimates.
+
+## 1. P1: Make every search hit directly retrievable and citable (medium)
+
+**What zg gets right:** hits carry source ranges, files, and multiple evidence records. See [range types](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/src/engine/types.ts#L101) and [hit evidence](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/src/engine/types.ts#L329).
+
+**qi gap:** `internal/search/types.go:4` returns integer document/chunk IDs, but `cmd/get.go:50` resolves a content-hash prefix. The search response does not supply that hash. There are no start/end line fields. `internal/chunker/breakpoint.go:135` copies the section ordinal into each chunk, so it cannot identify a later chunk’s exact location.
+
+**Implement:** expose a full content hash as a public retrieval handle; include source start/end lines and a source identity/version. Preserve raw-source offsets through Markdown/frontmatter parsing rather than deriving them from transformed text. Keep document diversity, but optionally attach a bounded list of supporting passages to each document.
+
+**Verify:** search JSON → get round trip; duplicate-content paths; several chunks under one heading; frontmatter, CRLF, Unicode, code fences, and files changed since indexing.
+
+**Implementation follow-up:** search/query now expose `hash`, `source_uri`,
+`start_line`, and `end_line`, with raw-source mappings carried through parsing
+and chunking. `qi get <hash> --lines A:B` retrieves the indexed snapshot, not the
+live file. `--passages 0–5` adds bounded supporting passages while retaining
+one result and one ranking contribution per document per retriever. Existing
+indexes require a normal `qi index <collection>` to rebuild missing ranges;
+search rejects unknown ranges instead of inventing citations. The hash is a
+source version, not proof of current filesystem freshness or a promise to
+retain historical versions. `task check` passes, including search→get snapshot
+round trips, duplicate-content paths, legacy-range repair, Markdown/CRLF/Unicode
+source mapping, and bounded supporting evidence. Other findings below remain
+proposals.
+
+## 2. P1: Persist embedding progress between batches (medium)
+
+**What zg gets right:** automatic failed-file retry and structured failure details ([index pipeline](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/src/engine/pipeline/indexing/index.ts#L248)).
+
+**qi gap:** `internal/providers/embedding.go:90` already batches HTTP requests, but returns an error if a later batch fails. `internal/indexer/embedder.go:85` waits for the entire provider call before persisting vectors. Earlier successful network work is consequently lost on a late failure, and all pending texts/vectors are materialized together.
+
+**Implement:** move the persistence boundary to bounded batches, preserve valid successes, retry transient errors with bounded backoff, and record failed chunk/path details. Reuse existing fingerprint and vector validation; qi already detects stale/missing/invalid embeddings and should retain that behavior.
+
+**Verify:** fail the second batch, restart, and assert the first batch is not sent again; cover 429/5xx, cancellation, malformed vectors, and fingerprint changes.
+
+## 3. P1: Add consistent ignore rules and query scope filters (medium)
+
+**What zg gets right:** discovery supports ignore files, ordered glob rules, hidden-file controls and size/depth limits ([scanner](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/src/engine/pipeline/indexing/scanner/index.ts#L88)); indexed queries can narrow scope too ([pipeline guide](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/docs/04-pipeline.md)).
+
+**qi gap:** `internal/indexer/indexer.go:100` builds an exact basename ignore set; lines 130–150 apply directory and extension checks. This is not gitignore/glob semantics. `internal/search/types.go:30` offers collection/date filters but no path or file-type constraints. The 10 MiB cap is fixed.
+
+**Implement:** explicit include/exclude globs, gitignore-compatible discovery, configurable size limits, and path/type filters applied before retrieval limits in both BM25 and vector search. Define how policy changes remove now-excluded indexed files. Preserve qi’s secure symlink handling.
+
+**Verify:** nested rules and negation, root dot-directories, exclude-to-include transitions, and relevant in-scope hits buried below out-of-scope candidates.
+
+## 4. P1: Report operational status and freshness (medium; watcher later)
+
+**What zg gets right:** an explicit status/readiness interface and freshness semantics, backed by a watcher with reconciliation ([watch manager](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/src/daemon/watch-manager.ts#L58), [execution modes](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/docs/06-server.md)).
+
+**qi gap:** `cmd/doctor.go` checks installation, storage, paths, permissions and embedding health, but search results do not say whether they reflect current files. Updating requires manual indexing. Existing indexing errors and run information are useful foundations, not missing wholesale.
+
+**Implement first:** `qi status --format json` with last successful indexing time, failed paths, embedding coverage and a recommended action. Distinguish “indexed at” from verified freshness; do not claim freshness from time alone. Add explicit refresh on demand. An opt-in watcher can follow once targeted incremental updates are robust.
+
+**Verify:** edited/deleted files, failed reads preserving old content, interrupted indexing, and status distinguishing lexical readiness from semantic readiness.
+
+## 5. P2: Add compact, bounded evidence output (small to medium)
+
+zg offers selectable previews and compact agent output ([output contract](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/docs/04-pipeline.md#output-for-agents-and-people)). qi supports text/Markdown/JSON, but `internal/output/formatter.go` prints available snippets without a search-response byte budget; vector results carry entire chunk text (`internal/search/vector.go:66`).
+
+Add `--preview none|short|full`, a response budget, explicit truncation, and a bounded context-expansion operation. Preserve IDs/ranges even when previews are omitted. Test multibyte truncation and many hits; measure tokens rather than assuming shorter-looking output is cheaper.
+
+## 6. P2: Add multi-query retrieval and explicit exact verification (medium)
+
+zg separates lexical/vector routes, can fuse multiple query groups, and offers managed ripgrep without an index ([route guide](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/docs/04-pipeline.md#querying)). qi joins positional arguments into one query (`cmd/query.go:29`) and always runs BM25 in hybrid mode (`internal/search/hybrid.go:31`).
+
+Allow semantic intent plus separate exact lexical anchors, and optionally vector-only retrieval. For exhaustive verification, either document a direct ripgrep handoff using resolved paths or add an optional `qi grep` adapter; do not make ripgrep required for ordinary search. Mark ranked results as non-exhaustive and bounded exact results as truncated. Test repeated evidence not inflating RRF and explicit vector-only errors versus hybrid fallback.
+
+## 7. P2: Improve candidate refill after deduplication (medium)
+
+zg expands recall depth until enough candidates are found or a cap is reached ([adaptive recall](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/src/engine/pipeline/search/index.ts#L520)). qi retrieves a fixed pool (`internal/search/postprocess.go:93`) and then collapses duplicate snippets (`:79`). Although qi correctly counts distinct documents within retrievers, many different documents with identical snippets can still consume the pool and leave fewer final results.
+
+Add bounded refill only when final deduplication leaves too few hits. Measure latency and recall; do not copy zg’s depth constants without evidence. Test duplicate-heavy corpora with unique matches beyond the first pool.
+
+## 8. P2: Make agent setup discoverable (medium)
+
+zg supports managed installation for several agent hosts and an MCP interface ([agent integrations](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/docs/01-agents.md)). qi already ships `skills/qi-cli/SKILL.md` and a Claude marketplace entry, so it does have agent integration.
+
+First make the CLI contract reliable and document/install the skill for Codex as well as Claude. Add MCP if users need structured discovery or cannot run shell commands. Keep adapters thin over existing services and test real search/get invocation after installation; configuration written successfully is not proof the agent can call it.
+
+## 9. P2: Clarify local versus remote embedding behavior (small)
+
+zg explicitly documents remote grants and revocation ([embedding authorization](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/docs/07-embedding.md)). qi’s README says “Fully local + offline” while also supporting OpenAI, and indexing automatically embeds with the configured provider (`cmd/index.go:172`).
+
+Clarify that local storage and lexical retrieval work offline, while remote providers receive embedding inputs. Show the configured destination during setup/status; consider a persisted remote-use policy for automation. Explicit provider configuration already conveys user intent: the absence of an extra prompt is not by itself a security vulnerability.
+
+## 10. P2/P3: Expand formats selectively; preserve structure (medium to large)
+
+zg extracts code symbols/signatures and uses metadata in embedding content ([vector content](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/src/engine/extraction/vector-content.ts#L68)). qi defaults to Markdown/plaintext and falls back to plaintext for unregistered extensions (`internal/parser/parser.go:32`).
+
+Add useful text formats first, then Go/code structure only if repository search is a target workflow. Raw HTML/JSON text is not equivalent to a format-aware parser. PDF/Office support should not be credited as an existing zg advantage: its current pipeline explicitly skips those binary formats. Graph retrieval, native GUI, and mobile are roadmap items, not shipped parity requirements.
+
+## 11. P2: Establish retrieval and agent-efficiency evaluations (medium)
+
+zg includes reproducible paired agent evaluations ([benchmark protocol](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/benchmarks/README.md)). qi has correctness tests but no comparable checked-in quality/performance evaluation suite identified in this audit.
+
+Create a held-out corpus with exact terms, paraphrases, dates, duplicate-heavy files, long documents, and multilingual queries. Track Recall@k, MRR, citation correctness, p50/p95 latency, indexing time, peak memory, and output tokens. Compare lexical/hybrid and each proposed change using the same corpus. Add small paired agent tasks after deterministic retrieval metrics exist. Published zg numbers do not establish that zg outperforms qi.
+
+## 12. P3: Optimize vector search only after measuring scale (large for ANN)
+
+zg uses HNSW ([storage schema](https://github.com/zvec-ai/zvec-grep/blob/52653951b24617762f4ab0c71c34d594e5001617/src/engine/storage/zvec.ts#L934)). qi loads candidate vectors and chunk text, computes cosine distances, and sorts all candidates (`internal/search/vector.go:82`). This has a clear scaling cost but is simple and exact.
+
+Benchmark representative collection sizes. First consider retaining only the best chunk per document, bounded top-k selection, and loading text after candidate selection. Adopt an ANN backend only if latency warrants the recall/storage/dependency tradeoff; retain the CGo-free fallback.
+
+## What qi should keep
+
+- Optional embeddings and lexical fallback on provider failure (`internal/search/hybrid.go`).
+- Unicode-aware lexical sanitization and AND-to-OR relaxation (`internal/search/bm25.go`).
+- Document-level RRF, result diversity, and duplicate collapse (`internal/search/fusion.go`, `postprocess.go`).
+- Date metadata and date filters; note newest-first operates over the retrieved pool, not every matching document.
+- Content-addressed storage, secure file opening, embedding fingerprints and validation.
+- A single SQLite database and lightweight CLI; a mandatory daemon would change the product’s operational cost.
+
+## Suggested implementation sequence
+
+1. Public retrieval handles, exact source ranges, and search→get tests.
+2. Batch embedding persistence/recovery and structured status.
+3. Shared discovery/query filters and bounded preview output.
+4. Evaluation corpus; use it to decide multi-query/refill/ranking changes.
+5. Broader agent setup; optional watch, code parsers, or ANN only with demonstrated demand.
+
+The original audit proposed these changes without changing code or running
+`task check`. Finding 1 now has an implementation follow-up above; the remaining
+findings are still proposals.

--- a/internal/chunker/breakpoint.go
+++ b/internal/chunker/breakpoint.go
@@ -3,12 +3,12 @@ package chunker
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/itsmostafa/qi/internal/parser"
 )
 
 // breakpointScores assigns a score to each position that could start a new chunk.
-// Higher scores = stronger break points.
 const (
 	scoreHeading   = 100
 	scoreCodeFence = 80
@@ -21,31 +21,23 @@ type BreakpointChunker struct {
 	MinSize    int // minimum chunk size before emitting
 }
 
-// defaultTargetSize is used when a non-positive target size is given. A
-// non-positive size makes the oversized-line split loop (offset += TargetSize)
-// spin forever, so it is never accepted.
 const defaultTargetSize = 512
 
 func NewBreakpointChunker(targetSize int) *BreakpointChunker {
 	if targetSize <= 0 {
 		targetSize = defaultTargetSize
 	}
-	return &BreakpointChunker{
-		TargetSize: targetSize,
-		MinSize:    targetSize / 4,
-	}
+	return &BreakpointChunker{TargetSize: targetSize, MinSize: targetSize / 4}
 }
 
 func (c *BreakpointChunker) Chunk(doc *parser.Document) []Chunk {
 	var chunks []Chunk
 	seq := 0
-
 	for _, section := range doc.Sections {
 		sectionChunks := c.chunkSection(section, seq)
 		chunks = append(chunks, sectionChunks...)
 		seq += len(sectionChunks)
 	}
-
 	return chunks
 }
 
@@ -54,13 +46,18 @@ func (c *BreakpointChunker) chunkSection(section parser.Section, startSeq int) [
 	if len(lines) == 0 {
 		return nil
 	}
-
-	type breakPoint struct {
-		lineIdx int
-		score   int
+	lineStarts := make([]int, len(lines))
+	for i := 1; i < len(lines); i++ {
+		lineStarts[i] = lineStarts[i-1] + len(lines[i-1]) + 1
+	}
+	makeChunk := func(text string, seq, byteStart int) Chunk {
+		ch := Chunk{Seq: seq, Text: text, HeadingPath: section.HeadingPath, Ordinal: section.Ordinal}
+		if span, ok := parser.SourceRange(section.SourceMap, byteStart, byteStart+len(text)); ok {
+			ch.Ordinal, ch.StartLine, ch.EndLine = span.Start, span.StartLine, span.EndLine
+		}
+		return ch
 	}
 
-	// Score each line boundary
 	scores := make([]int, len(lines))
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -78,62 +75,43 @@ func (c *BreakpointChunker) chunkSection(section parser.Section, startSeq int) [
 	seq := startSeq
 	start := 0
 	size := 0
-
 	for i, line := range lines {
 		lineLen := runeLen(line)
-
-		// Force-split lines that individually exceed target size (e.g. minified files).
 		if lineLen > c.TargetSize {
 			if i > start {
-				text := strings.Join(lines[start:i], "\n")
-				text = strings.TrimRightFunc(text, unicode.IsSpace)
+				text := strings.TrimRightFunc(strings.Join(lines[start:i], "\n"), unicode.IsSpace)
 				if text != "" {
-					chunks = append(chunks, Chunk{
-						Seq: seq, Text: text,
-						HeadingPath: section.HeadingPath, Ordinal: section.Ordinal,
-					})
+					chunks = append(chunks, makeChunk(text, seq, lineStarts[start]))
 					seq++
 				}
 			}
-			runes := []rune(line)
-			for offset := 0; offset < len(runes); offset += c.TargetSize {
-				end := offset + c.TargetSize
-				if end > len(runes) {
-					end = len(runes)
+			byteStart, count := 0, 0
+			for byteEnd := range line {
+				if count == c.TargetSize {
+					chunks = append(chunks, makeChunk(line[byteStart:byteEnd], seq, lineStarts[i]+byteStart))
+					seq++
+					byteStart, count = byteEnd, 0
 				}
-				chunks = append(chunks, Chunk{
-					Seq: seq, Text: string(runes[offset:end]),
-					HeadingPath: section.HeadingPath, Ordinal: section.Ordinal,
-				})
-				seq++
+				count++
 			}
+			chunks = append(chunks, makeChunk(line[byteStart:], seq, lineStarts[i]+byteStart))
+			seq++
 			start = i + 1
 			size = 0
 			continue
 		}
 
-		size += lineLen + 1 // +1 for newline
-
+		size += lineLen + 1
 		if size < c.MinSize {
 			continue
 		}
-
-		// Apply distance decay: score decreases as we move away from target
 		if size >= c.TargetSize || (scores[i] > 0 && size >= c.MinSize) {
 			decay := distanceDecay(size, c.TargetSize)
 			effectiveScore := float64(scores[i]) * decay
-
-			// Emit chunk when we hit target size OR have a strong breakpoint
 			if size >= c.TargetSize || effectiveScore >= float64(scoreBlankLine) {
-				text := strings.Join(lines[start:i+1], "\n")
-				text = strings.TrimRightFunc(text, unicode.IsSpace)
+				text := strings.TrimRightFunc(strings.Join(lines[start:i+1], "\n"), unicode.IsSpace)
 				if text != "" {
-					chunks = append(chunks, Chunk{
-						Seq:         seq,
-						Text:        text,
-						HeadingPath: section.HeadingPath,
-						Ordinal:     section.Ordinal,
-					})
+					chunks = append(chunks, makeChunk(text, seq, lineStarts[start]))
 					seq++
 				}
 				start = i + 1
@@ -142,29 +120,17 @@ func (c *BreakpointChunker) chunkSection(section parser.Section, startSeq int) [
 		}
 	}
 
-	// Remaining text
 	if start < len(lines) {
-		text := strings.Join(lines[start:], "\n")
-		text = strings.TrimRightFunc(text, unicode.IsSpace)
+		text := strings.TrimRightFunc(strings.Join(lines[start:], "\n"), unicode.IsSpace)
 		if text != "" {
-			chunks = append(chunks, Chunk{
-				Seq:         seq,
-				Text:        text,
-				HeadingPath: section.HeadingPath,
-				Ordinal:     section.Ordinal,
-			})
+			chunks = append(chunks, makeChunk(text, seq, lineStarts[start]))
 		}
 	}
-
 	return chunks
 }
 
-func runeLen(s string) int {
-	return len([]rune(s))
-}
+func runeLen(s string) int { return utf8.RuneCountInString(s) }
 
-// distanceDecay returns a multiplier [0, 1] based on how far size is from target.
-// At target: 1.0. Decays linearly.
 func distanceDecay(size, target int) float64 {
 	if target <= 0 {
 		return 1.0

--- a/internal/chunker/breakpoint_test.go
+++ b/internal/chunker/breakpoint_test.go
@@ -127,3 +127,104 @@ func TestBreakpointChunker_NonPositiveTargetSize(t *testing.T) {
 		t.Fatal("Chunk hung with targetSize 0")
 	}
 }
+
+func TestBreakpointChunkerCitesEachMappedChunk(t *testing.T) {
+	src := "# Heading\n\nfirst café\n\nsecond passage\n\n## Later\n\nthird text\n"
+	doc, err := parser.For(".md").Parse("note.md", []byte(src))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	chunks := NewBreakpointChunker(10).Chunk(doc)
+	if len(chunks) < 2 {
+		t.Fatalf("got %d chunks, want several", len(chunks))
+	}
+	for _, ch := range chunks {
+		if ch.StartLine < 1 || ch.EndLine < ch.StartLine {
+			t.Errorf("invalid citation range %+v", ch)
+		}
+		if ch.Ordinal < 0 || ch.Ordinal >= len(src) {
+			t.Errorf("invalid raw ordinal %+v", ch)
+		}
+	}
+	if chunks[0].Ordinal == chunks[len(chunks)-1].Ordinal {
+		t.Errorf("all chunks point at one source location: %+v", chunks)
+	}
+}
+
+func TestBreakpointChunkerNarrowsFlattenedMarkdownLines(t *testing.T) {
+	src := "# Heading\n\nαααααααα\nββββββββ\n"
+	doc, err := parser.For(".md").Parse("note.md", []byte(src))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	chunks := NewBreakpointChunker(8).Chunk(doc)
+	if len(chunks) < 2 {
+		t.Fatalf("got %d chunks, want flattened paragraph split", len(chunks))
+	}
+	if chunks[0].StartLine != 3 || chunks[len(chunks)-1].EndLine != 4 {
+		t.Errorf("flattened paragraph citations = %+v, want lines 3 through 4", chunks)
+	}
+	if chunks[0].Ordinal >= chunks[len(chunks)-1].Ordinal {
+		t.Errorf("flattened chunks did not narrow raw ordinal: %+v", chunks)
+	}
+	// A split after the synthetic soft-break space must not cite the next line.
+	chunks = NewBreakpointChunker(9).Chunk(doc)
+	if len(chunks) != 2 || chunks[0].EndLine != 3 || chunks[1].StartLine != 4 {
+		t.Errorf("soft-break boundary widened source ranges: %+v", chunks)
+	}
+}
+
+func TestBreakpointChunkerCitesLaterCodeChunksPrecisely(t *testing.T) {
+	src := "# Code\n\n```\nline-one\nline-two\nline-333\n```\n"
+	doc, err := parser.For(".md").Parse("note.md", []byte(src))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	chunks := NewBreakpointChunker(8).Chunk(doc)
+	if len(chunks) != 3 {
+		t.Fatalf("got %d code chunks, want 3: %+v", len(chunks), chunks)
+	}
+	for i, wantLine := range []int{4, 5, 6} {
+		if chunks[i].StartLine != wantLine || chunks[i].EndLine != wantLine {
+			t.Errorf("chunk %d range = %d-%d, want %d-%d", i, chunks[i].StartLine, chunks[i].EndLine, wantLine, wantLine)
+		}
+	}
+	if chunks[1].Ordinal <= chunks[0].Ordinal || chunks[2].Ordinal <= chunks[1].Ordinal {
+		t.Errorf("code chunk ordinals are not source ordered: %+v", chunks)
+	}
+}
+
+func TestTrimmedCodeChunksKeepExactRawOrdinals(t *testing.T) {
+	src := "# Code\n\n```\n  ééééé  \n```\n"
+	doc, err := parser.For(".md").Parse("note.md", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunks := NewBreakpointChunker(2).Chunk(doc)
+	if len(chunks) != 3 {
+		t.Fatalf("got %d chunks, want 3: %+v", len(chunks), chunks)
+	}
+	for i, ch := range chunks {
+		want := strings.Index(src, "é") + i*4
+		if ch.Ordinal != want || ch.StartLine != 4 || ch.EndLine != 4 {
+			t.Errorf("chunk %d = %+v, want byte %d on line 4", i, ch, want)
+		}
+	}
+}
+
+func TestBreakpointChunkerUnicodeOrdinalUsesRawBytes(t *testing.T) {
+	src := "ééééé\n"
+	doc, err := parser.For(".txt").Parse("note.txt", []byte(src))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	chunks := NewBreakpointChunker(2).Chunk(doc)
+	if len(chunks) != 3 {
+		t.Fatalf("got %d chunks, want 3", len(chunks))
+	}
+	for i, want := range []int{0, 4, 8} {
+		if chunks[i].Ordinal != want || chunks[i].StartLine != 1 || chunks[i].EndLine != 1 {
+			t.Errorf("chunk %d citation = %+v, want ordinal %d on line 1", i, chunks[i], want)
+		}
+	}
+}

--- a/internal/chunker/chunker.go
+++ b/internal/chunker/chunker.go
@@ -7,7 +7,11 @@ type Chunk struct {
 	Seq         int
 	Text        string
 	HeadingPath string
-	Ordinal     int // byte offset of the section heading this chunk came from
+	// Ordinal is the raw byte offset where this chunk starts. StartLine and
+	// EndLine are 1-indexed inclusive raw-source lines.
+	Ordinal   int
+	StartLine int
+	EndLine   int
 }
 
 // Chunker splits a parsed document into indexable chunks.

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -132,6 +132,7 @@ func appliedVersions(ctx context.Context, tx *sql.Tx) (map[int]bool, error) {
 var addedColumns = map[int]struct{ table, column string }{
 	4: {"embeddings", "fingerprint"},
 	6: {"documents", "tags"},
+	7: {"chunks", "end_line"},
 }
 
 func columnExists(ctx context.Context, tx *sql.Tx, table, column string) (bool, error) {

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -38,6 +38,44 @@ func TestMigration004RecoversAfterColumnAddedWithoutVersion(t *testing.T) {
 	}
 }
 
+// Migration 007's DDL can be present without its schema_version marker on any
+// database opened by a build that shipped the file before it recorded its own
+// version. Re-running the ALTER TABLE would fail, so the guard must recognise
+// the completed state and record the marker instead.
+func TestMigration007RecoversAfterColumnsAddedWithoutVersion(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "qi.db")
+	database, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, `DELETE FROM schema_version WHERE version = 7`); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err = Open(ctx, path)
+	if err != nil {
+		t.Fatalf("reopening partially applied migration: %v", err)
+	}
+	defer database.Close()
+
+	var versions, columns int
+	if err := database.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM schema_version WHERE version = 7`).Scan(&versions); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pragma_table_info('chunks') WHERE name IN ('start_line', 'end_line')`).Scan(&columns); err != nil {
+		t.Fatal(err)
+	}
+	if versions != 1 || columns != 2 {
+		t.Fatalf("recovery left version=%d columns=%d, want 1/2", versions, columns)
+	}
+}
+
 // Migration 006's DDL can be present without its schema_version marker on any
 // database opened by a build that shipped the file before it recorded its own
 // version. Re-running the ALTER TABLE would fail, so the guard must recognise

--- a/internal/db/migrations/007_chunk_line_ranges.sql
+++ b/internal/db/migrations/007_chunk_line_ranges.sql
@@ -1,0 +1,7 @@
+-- Record each chunk's inclusive 1-based line range in the raw source.
+-- NULL is intentional for chunks created before this migration: line
+-- precision is unknown until the owning document is indexed again.
+ALTER TABLE chunks ADD COLUMN start_line INTEGER;
+ALTER TABLE chunks ADD COLUMN end_line INTEGER;
+
+INSERT OR IGNORE INTO schema_version(version) VALUES (7);

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -83,6 +83,11 @@ func (idx *Indexer) Index(ctx context.Context, col config.Collection) (Stats, er
 	start := time.Now()
 	stats := Stats{}
 
+	// Detect legacy ranges once per collection, not once per unchanged file.
+	rangeRepairs, err := idx.chunkRangeRepairs(ctx, col.Name)
+	if err != nil {
+		return stats, fmt.Errorf("checking chunk line ranges: %w", err)
+	}
 	runID, err := idx.startRun(ctx, col.Name)
 	if err != nil {
 		return stats, err
@@ -175,7 +180,7 @@ func (idx *Indexer) Index(ctx context.Context, col config.Collection) (Stats, er
 		if err == nil {
 			var info fs.FileInfo
 			if info, err = d.Info(); err == nil {
-				err = idx.indexFile(ctx, col, relPath, data, info.ModTime(), &stats)
+				err = idx.indexFile(ctx, col, relPath, data, info.ModTime(), rangeRepairs[relPath], &stats)
 			}
 		}
 		if err != nil {
@@ -293,7 +298,7 @@ func (idx *Indexer) compact(ctx context.Context) error {
 	return nil
 }
 
-func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPath string, data []byte, modTime time.Time, stats *Stats) error {
+func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPath string, data []byte, modTime time.Time, rangeRepairRequired bool, stats *Stats) error {
 	hash := sha256sum(data)
 
 	// Check if document exists (active or deactivated) and whether content changed
@@ -308,6 +313,9 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 		return fmt.Errorf("looking up existing document: %w", err)
 	}
 
+	var doc *parser.Document
+	var chunks []chunker.Chunk
+	var err error
 	if existingActive == 1 && existingHash == hash && !idx.Force {
 		// Unchanged bytes still need their date rechecked. Two rows land here:
 		// one indexed before dates existed, holding a NULL that no --since or
@@ -322,23 +330,35 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 		// stored.
 		// ponytail: parses every frontmatter-dated file each run; export a
 		// frontmatter-only date reader from parser if index time starts to hurt.
-		if existingTime.Valid && existingTime.String == documentDate("", modTime) {
+		if !rangeRepairRequired && existingTime.Valid && existingTime.String == documentDate("", modTime) {
 			return nil // unchanged
 		}
-		doc, err := parser.For(strings.ToLower(filepath.Ext(relPath))).Parse(relPath, data)
+		doc, err = parser.For(strings.ToLower(filepath.Ext(relPath))).Parse(relPath, data)
 		if err != nil {
 			return fmt.Errorf("parsing: %w", err)
 		}
+		if rangeRepairRequired {
+			// Keep embeddings only when the chunk layout is identical. Reuse
+			// this parse and chunking below if a rebuild is needed instead.
+			chunks = idx.chunker.Chunk(doc)
+			backfilled, err := idx.backfillChunkRanges(ctx, docID, chunks)
+			if err != nil {
+				return fmt.Errorf("backfilling chunk line ranges: %w", err)
+			}
+			rangeRepairRequired = !backfilled
+		}
 		docDate := documentDate(doc.Meta.Timestamp, modTime)
-		if docDate == existingTime.String {
-			return nil // frontmatter still supplies the date; mtime is irrelevant
+		if !rangeRepairRequired {
+			if docDate == existingTime.String {
+				return nil // frontmatter still supplies the date; mtime is irrelevant
+			}
+			if _, err := idx.db.ExecContext(ctx,
+				`UPDATE documents SET doc_timestamp=? WHERE id=?`,
+				docDate, docID); err != nil {
+				return fmt.Errorf("updating document date: %w", err)
+			}
+			return nil
 		}
-		if _, err := idx.db.ExecContext(ctx,
-			`UPDATE documents SET doc_timestamp=? WHERE id=?`,
-			docDate, docID); err != nil {
-			return fmt.Errorf("updating document date: %w", err)
-		}
-		return nil
 	}
 
 	// Fast-path: previously deactivated document restored with byte-identical content.
@@ -347,7 +367,7 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 	// A row with no date is not fully indexed: reactivating it would restore a
 	// document that no date filter can ever match. Let it fall through and be
 	// rebuilt instead.
-	if docID != 0 && existingActive == 0 && existingHash == hash && existingTime.Valid && !idx.Force {
+	if docID != 0 && existingActive == 0 && existingHash == hash && existingTime.Valid && !idx.Force && !rangeRepairRequired {
 		if _, err := idx.db.ExecContext(ctx,
 			`UPDATE documents SET active=1, updated_at=datetime('now') WHERE id=?`, docID); err != nil {
 			return fmt.Errorf("reactivating document: %w", err)
@@ -363,14 +383,19 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 		return fmt.Errorf("inserting content: %w", err)
 	}
 
-	// Parse + chunk
-	ext := strings.ToLower(filepath.Ext(relPath))
-	p := parser.For(ext)
-	doc, err := p.Parse(relPath, data)
-	if err != nil {
-		return fmt.Errorf("parsing: %w", err)
+	// Parse + chunk unless the range repair already did it.
+	if doc == nil {
+		doc, err = parser.For(strings.ToLower(filepath.Ext(relPath))).Parse(relPath, data)
+		if err != nil {
+			return fmt.Errorf("parsing: %w", err)
+		}
+		chunks = idx.chunker.Chunk(doc)
 	}
-	chunks := idx.chunker.Chunk(doc)
+	for _, ch := range chunks {
+		if ch.StartLine <= 0 || ch.EndLine < ch.StartLine {
+			return fmt.Errorf("invalid source line range for chunk %d: %d-%d", ch.Seq, ch.StartLine, ch.EndLine)
+		}
+	}
 
 	// Upsert document
 	title := doc.Title
@@ -426,15 +451,114 @@ func (idx *Indexer) indexFile(ctx context.Context, col config.Collection, relPat
 	// Insert chunks
 	for _, ch := range chunks {
 		_, err := tx.ExecContext(ctx,
-			`INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-			hash, newDocID, ch.Seq, ch.Text, ch.HeadingPath, ch.Ordinal, len(ch.Text))
+			`INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			hash, newDocID, ch.Seq, ch.Text, ch.HeadingPath, ch.Ordinal, len(ch.Text), ch.StartLine, ch.EndLine)
 		if err != nil {
 			return fmt.Errorf("inserting chunk: %w", err)
 		}
 	}
 
 	return tx.Commit()
+}
+
+// chunkRangeRepairs finds documents with unknown or invalid source ranges.
+// Empty documents have no chunks and need no repair. Include inactive rows so
+// the reactivation fast path cannot restore chunks without usable citations.
+func (idx *Indexer) chunkRangeRepairs(ctx context.Context, collection string) (map[string]bool, error) {
+	rows, err := idx.db.QueryContext(ctx, `
+		SELECT DISTINCT d.path FROM chunks c JOIN documents d ON d.id=c.doc_id
+		WHERE d.collection=? AND
+		(c.start_line IS NULL OR c.end_line IS NULL OR c.start_line < 1 OR c.end_line < c.start_line)`, collection)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	repairs := map[string]bool{}
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			return nil, err
+		}
+		repairs[path] = true
+	}
+	return repairs, rows.Err()
+}
+
+// backfillChunkRanges updates legacy chunks in place when the current parser
+// and chunker produce exactly the same chunk text and metadata. Ordinal is not
+// part of the identity: older indexers recorded a section start, while the
+// current chunker records the chunk start. Updating it here is safe because
+// embeddings are generated from chunk text (and heading/text identity is
+// unchanged). If anything else differs, callers rebuild the chunks and the
+// embedding repair pass regenerates vectors.
+func (idx *Indexer) backfillChunkRanges(ctx context.Context, docID int64, chunks []chunker.Chunk) (bool, error) {
+	type storedChunk struct {
+		id, seq, length int64
+		text, heading   string
+		headingValid    bool
+	}
+
+	rows, err := idx.db.QueryContext(ctx, `
+		SELECT id, seq, text, heading_path, content_length
+		FROM chunks WHERE doc_id=? ORDER BY seq`, docID)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	stored := make([]storedChunk, 0, len(chunks))
+	for rows.Next() {
+		var c storedChunk
+		var headingText sql.NullString
+		if err := rows.Scan(&c.id, &c.seq, &c.text, &headingText, &c.length); err != nil {
+			return false, err
+		}
+		c.headingValid, c.heading = headingText.Valid, headingText.String
+		stored = append(stored, c)
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	if err := rows.Close(); err != nil {
+		return false, err
+	}
+	if len(stored) == 0 || len(stored) != len(chunks) {
+		return false, nil
+	}
+
+	for i, old := range stored {
+		ch := chunks[i]
+		if ch.StartLine <= 0 || ch.EndLine < ch.StartLine {
+			return false, fmt.Errorf("invalid source line range for chunk %d: %d-%d", ch.Seq, ch.StartLine, ch.EndLine)
+		}
+		if old.seq != int64(ch.Seq) || old.text != ch.Text ||
+			!old.headingValid || old.heading != ch.HeadingPath ||
+			old.length != int64(len(ch.Text)) {
+			return false, nil
+		}
+	}
+
+	// Update source locations from the current chunker. This transaction leaves
+	// chunk IDs and their vector/embedding rows intact when the exact-match
+	// proof succeeds.
+	tx, err := idx.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	for i, old := range stored {
+		ch := chunks[i]
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE chunks SET ordinal=?, start_line=?, end_line=? WHERE id=?`,
+			ch.Ordinal, ch.StartLine, ch.EndLine, old.id); err != nil {
+			return false, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // staleActivePaths returns the failed paths whose previously indexed document

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/itsmostafa/qi/internal/config"
 	"github.com/itsmostafa/qi/internal/db"
+	"github.com/itsmostafa/qi/internal/parser"
 )
 
 func openTestDB(t *testing.T) *db.DB {
@@ -101,6 +102,121 @@ func TestIndexer_IncrementalUpdate(t *testing.T) {
 	}
 	if stats.FilesUpdated != 1 {
 		t.Errorf("expected 1 updated, got %d", stats.FilesUpdated)
+	}
+}
+
+type countingParser struct {
+	parser.Parser
+	calls int
+}
+
+func (p *countingParser) Parse(path string, data []byte) (*parser.Document, error) {
+	p.calls++
+	return p.Parser.Parse(path, data)
+}
+
+func TestIndexer_PersistsAndRepairsSourceLineRanges(t *testing.T) {
+	p := &countingParser{Parser: parser.For(".md")}
+	parser.Register(".md", p)
+	t.Cleanup(func() { parser.Register(".md", p.Parser) })
+	database := openTestDB(t)
+	idx := New(database, 256)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.md")
+	col := config.Collection{Name: "test", Path: dir, Extensions: []string{".md"}}
+	body := []byte("# Heading\none\ntwo")
+	if err := os.WriteFile(path, body, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := idx.Index(ctx, col); err != nil {
+		t.Fatal(err)
+	}
+
+	var chunkID int64
+	var startLine, endLine int
+	if err := database.QueryRowContext(ctx, `
+		SELECT c.id, c.start_line, c.end_line FROM chunks c
+		JOIN documents d ON d.id=c.doc_id WHERE d.path='doc.md'`).Scan(&chunkID, &startLine, &endLine); err != nil {
+		t.Fatalf("reading line range: %v", err)
+	}
+	if startLine != 2 || endLine != 3 {
+		t.Fatalf("got line range %d-%d, want 2-3", startLine, endLine)
+	}
+
+	// Simulate a pre-migration chunk. An exact layout match must repair only
+	// the nullable range and retain the chunk ID and its embedding.
+	if err := database.InsertEmbedding(ctx, chunkID, []float32{0.1, 0.2}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx,
+		`INSERT INTO embeddings(chunk_id, provider, model, dimension) VALUES (?, 'test', 'test-model', 2)`, chunkID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx,
+		`UPDATE chunks SET start_line=NULL, end_line=NULL WHERE id=?`, chunkID); err != nil {
+		t.Fatal(err)
+	}
+
+	p.calls = 0
+	stats, err := idx.Index(ctx, col)
+	if err != nil {
+		t.Fatalf("legacy range repair failed: %v", err)
+	}
+	if p.calls != 1 {
+		t.Fatalf("range repair parsed %d times, want 1", p.calls)
+	}
+	if stats.FilesUpdated != 0 || stats.FilesAdded != 0 {
+		t.Fatalf("range repair changed file stats: added=%d updated=%d", stats.FilesAdded, stats.FilesUpdated)
+	}
+	var repairedID int64
+	if err := database.QueryRowContext(ctx,
+		`SELECT c.id FROM chunks c JOIN documents d ON d.id=c.doc_id WHERE d.path='doc.md'`).Scan(&repairedID); err != nil {
+		t.Fatal(err)
+	}
+	if repairedID != chunkID {
+		t.Fatalf("range repair replaced chunk %d with %d", chunkID, repairedID)
+	}
+	if err := database.QueryRowContext(ctx,
+		`SELECT start_line, end_line FROM chunks WHERE id=?`, chunkID).Scan(&startLine, &endLine); err != nil {
+		t.Fatal(err)
+	}
+	if startLine != 2 || endLine != 3 {
+		t.Fatalf("repaired line range %d-%d, want 2-3", startLine, endLine)
+	}
+	var vectorCount int
+	if err := database.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id=?`, chunkID).Scan(&vectorCount); err != nil {
+		t.Fatal(err)
+	}
+	if vectorCount != 1 {
+		t.Fatalf("range repair dropped embedding, count=%d", vectorCount)
+	}
+
+	// If the old chunk layout cannot be proven equivalent, a matching source
+	// hash must still rebuild instead of taking the unchanged-date fast path.
+	if _, err := database.ExecContext(ctx,
+		`UPDATE chunks SET text='stale', start_line=NULL, end_line=NULL WHERE id=?`, chunkID); err != nil {
+		t.Fatal(err)
+	}
+	p.calls = 0
+	stats, err = idx.Index(ctx, col)
+	if err != nil {
+		t.Fatalf("legacy layout rebuild failed: %v", err)
+	}
+	if p.calls != 1 {
+		t.Fatalf("layout rebuild parsed %d times, want 1", p.calls)
+	}
+	if stats.FilesUpdated != 1 {
+		t.Fatalf("expected one updated file after unsafe legacy repair, got %d", stats.FilesUpdated)
+	}
+	if err := database.QueryRowContext(ctx,
+		`SELECT c.id, c.start_line, c.end_line FROM chunks c
+		 JOIN documents d ON d.id=c.doc_id WHERE d.path='doc.md'`).Scan(&repairedID, &startLine, &endLine); err != nil {
+		t.Fatal(err)
+	}
+	if repairedID == chunkID || startLine != 2 || endLine != 3 {
+		t.Fatalf("unsafe repair left chunk id/range as %d/%d-%d", repairedID, startLine, endLine)
 	}
 }
 

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -45,6 +45,10 @@ func stripHighlights(results []search.Result) []search.Result {
 	out := make([]search.Result, len(results))
 	for i, r := range results {
 		r.Snippet = highlightStripper.Replace(r.Snippet)
+		r.Passages = append([]search.Passage(nil), r.Passages...)
+		for j := range r.Passages {
+			r.Passages[j].Snippet = highlightStripper.Replace(r.Passages[j].Snippet)
+		}
 		out[i] = r
 	}
 	return out
@@ -80,7 +84,7 @@ func (f *TextFormatter) WriteResults(w io.Writer, results []search.Result) error
 		highlight = highlightANSI
 	}
 	for i, r := range results {
-		location := fmt.Sprintf("qi://%s/%s", r.Collection, r.Path)
+		location := fmt.Sprintf("%s#L%d-L%d", r.SourceURI, r.StartLine, r.EndLine)
 		if r.HeadingPath != "" {
 			location += " [" + r.HeadingPath + "]"
 		}
@@ -94,8 +98,12 @@ func (f *TextFormatter) WriteResults(w io.Writer, results []search.Result) error
 		}
 		fmt.Fprintln(w)
 		fmt.Fprintf(w, "   %s\n", location)
+		fmt.Fprintf(w, "   qi get %s --lines %d:%d\n", r.Hash, r.StartLine, r.EndLine)
 		if r.Snippet != "" {
 			fmt.Fprintf(w, "   %s\n", highlight.Replace(r.Snippet))
+		}
+		for _, p := range r.Passages {
+			fmt.Fprintf(w, "   [lines %d:%d] %s\n", p.StartLine, p.EndLine, highlight.Replace(p.Snippet))
 		}
 		if r.Explain != nil {
 			ex := r.Explain
@@ -136,15 +144,19 @@ func (f *MarkdownFormatter) WriteResults(w io.Writer, results []search.Result) e
 		return nil
 	}
 	for _, r := range results {
-		location := fmt.Sprintf("qi://%s/%s", r.Collection, r.Path)
+		location := fmt.Sprintf("%s#L%d-L%d", r.SourceURI, r.StartLine, r.EndLine)
 		fmt.Fprintf(w, "### %s\n", r.Title)
 		fmt.Fprintf(w, "**Location:** `%s`", location)
 		if r.HeadingPath != "" {
 			fmt.Fprintf(w, " › %s", r.HeadingPath)
 		}
 		fmt.Fprintln(w)
+		fmt.Fprintf(w, "**Retrieve:** `qi get %s --lines %d:%d`\n", r.Hash, r.StartLine, r.EndLine)
 		if r.Snippet != "" {
 			fmt.Fprintf(w, "> %s\n", highlightStripper.Replace(r.Snippet))
+		}
+		for _, p := range r.Passages {
+			fmt.Fprintf(w, "- **Lines %d:%d:** %s\n", p.StartLine, p.EndLine, highlightStripper.Replace(p.Snippet))
 		}
 		fmt.Fprintln(w)
 	}

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -1,0 +1,50 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/itsmostafa/qi/internal/search"
+)
+
+func TestCitationOutput(t *testing.T) {
+	hash := strings.Repeat("ab", 32)
+	marked := search.HighlightOpen + "evidence" + search.HighlightClose
+	results := []search.Result{{
+		Collection: "notes", Path: "a #1.md", Hash: hash,
+		SourceURI: search.SourceURI("notes", "a #1.md"),
+		StartLine: 4, EndLine: 6, Snippet: marked,
+		Passages: []search.Passage{{ChunkID: 2, StartLine: 10, EndLine: 12, Snippet: marked}},
+	}}
+	for _, format := range []string{"json", "text", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := New(format).WriteResults(&buf, results); err != nil {
+				t.Fatal(err)
+			}
+			if strings.ContainsAny(buf.String(), search.HighlightOpen+search.HighlightClose) {
+				t.Fatalf("highlight markers leaked: %q", buf.String())
+			}
+			if format == "json" {
+				var got []search.Result
+				if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+					t.Fatal(err)
+				}
+				if len(got) != 1 || got[0].Hash != hash || got[0].SourceURI != results[0].SourceURI || got[0].StartLine != 4 || got[0].EndLine != 6 || len(got[0].Passages) != 1 || got[0].Passages[0].Snippet != "evidence" {
+					t.Fatalf("citation metadata lost: %+v", got)
+				}
+			} else {
+				for _, want := range []string{"qi://notes/a%20%231.md#L4-L6", "qi get " + hash + " --lines 4:6", "10:12"} {
+					if !strings.Contains(buf.String(), want) {
+						t.Errorf("missing %q in %s", want, buf.String())
+					}
+				}
+			}
+		})
+	}
+	if results[0].Snippet != marked || results[0].Passages[0].Snippet != marked {
+		t.Fatal("formatting mutated input evidence")
+	}
+}

--- a/internal/parser/frontmatter.go
+++ b/internal/parser/frontmatter.go
@@ -23,13 +23,31 @@ type Meta struct {
 // Summary renders the retrieval-worthy frontmatter as plain prose. It is empty
 // when there is nothing worth indexing.
 func (m Meta) Summary() string {
-	var parts []string
-	for _, s := range []string{m.Title, m.Description, strings.Join(m.Tags, ", ")} {
-		if s = strings.TrimSpace(s); s != "" {
-			parts = append(parts, s)
+	return strings.Join(m.summaryParts(), "\n")
+}
+
+type summaryField struct {
+	key  string
+	text string
+}
+
+func (m Meta) summaryFields() []summaryField {
+	var fields []summaryField
+	for _, field := range []summaryField{{"title", m.Title}, {"description", m.Description}, {"tags", strings.Join(m.Tags, ", ")}} {
+		if field.text = strings.TrimSpace(field.text); field.text != "" {
+			fields = append(fields, field)
 		}
 	}
-	return strings.Join(parts, "\n")
+	return fields
+}
+
+func (m Meta) summaryParts() []string {
+	fields := m.summaryFields()
+	parts := make([]string, len(fields))
+	for i, field := range fields {
+		parts[i] = field.text
+	}
+	return parts
 }
 
 // stringList accepts either a YAML sequence or a comma-separated scalar, both of

--- a/internal/parser/frontmatter_map.go
+++ b/internal/parser/frontmatter_map.go
@@ -1,0 +1,101 @@
+package parser
+
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+)
+
+// frontmatterFieldSpans maps metadata values to their YAML source ranges. It
+// runs as part of frontmatter extraction, never by searching rendered prose.
+func frontmatterFieldSpans(data []byte, offset int, mapper sourceMapper) map[string]SourceSpan {
+	if offset == 0 || len(data) == 0 {
+		return nil
+	}
+	open := bytes.IndexByte(data, '\n') + 1
+	if open <= 0 || open > offset {
+		return nil
+	}
+	yamlEnd := offset
+	for lineStart := open; lineStart < offset; {
+		lineEnd := bytes.IndexByte(data[lineStart:offset], '\n')
+		if lineEnd < 0 {
+			lineEnd = offset - lineStart
+		}
+		lineEnd += lineStart
+		line := bytes.TrimSuffix(data[lineStart:lineEnd], []byte{'\r'})
+		if bytes.Equal(line, []byte("---")) || bytes.Equal(line, []byte("...")) {
+			yamlEnd = lineStart
+			break
+		}
+		if lineEnd == offset {
+			break
+		}
+		lineStart = lineEnd + 1
+	}
+	yamlData := data[open:yamlEnd]
+	var document yaml.Node
+	if err := yaml.Unmarshal(yamlData, &document); err != nil || len(document.Content) == 0 {
+		return nil
+	}
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	// Mapping values know their starting line. The next top-level key bounds a
+	// block value (including a sequence or block scalar) without guessing from
+	// generated text.
+	type field struct {
+		name      string
+		keyLine   int
+		valueLine int
+		nextLine  int
+	}
+	var fields []field
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		key, value := root.Content[i], root.Content[i+1]
+		if key.Value == "" {
+			continue
+		}
+		line := value.Line
+		if line <= 0 {
+			line = key.Line
+		}
+		fields = append(fields, field{name: key.Value, keyLine: key.Line, valueLine: line})
+	}
+	lineCount := bytes.Count(yamlData, []byte{'\n'}) + 2
+	for i := range fields {
+		fields[i].nextLine = lineCount
+		if i+1 < len(fields) && fields[i+1].keyLine > fields[i].keyLine {
+			fields[i].nextLine = fields[i+1].keyLine
+		}
+	}
+
+	lineStarts := []int{0}
+	for i, b := range yamlData {
+		if b == '\n' {
+			lineStarts = append(lineStarts, i+1)
+		}
+	}
+	lineOffset := func(line int) int {
+		if line < 1 {
+			line = 1
+		}
+		if line > len(lineStarts) {
+			return len(yamlData)
+		}
+		return lineStarts[line-1]
+	}
+
+	out := make(map[string]SourceSpan, len(fields))
+	for _, f := range fields {
+		start := lineOffset(f.valueLine)
+		end := lineOffset(f.nextLine)
+		if end < start {
+			end = start
+		}
+		out[f.name] = mapper.span(open+start, open+end)
+	}
+	return out
+}

--- a/internal/parser/markdown.go
+++ b/internal/parser/markdown.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"strings"
+	"unicode"
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
@@ -16,41 +17,115 @@ func init() {
 
 type markdownParser struct{}
 
+type mappedText struct {
+	text      string
+	intervals []SourceInterval
+}
+
+type mappedBuilder struct {
+	strings.Builder
+	intervals []SourceInterval
+}
+
+func (b *mappedBuilder) fallback(value string, span SourceSpan) {
+	start := b.Len()
+	b.WriteString(value)
+	if len(value) > 0 {
+		b.intervals = append(b.intervals, SourceInterval{TextStart: start, TextEnd: b.Len(), SourceSpan: span})
+	}
+}
+
+func (b *mappedBuilder) raw(value []byte, rawStart, rawBase int, src []byte, mapper sourceMapper, fallback SourceSpan) {
+	if rawStart < 0 || rawStart+len(value) > len(src) || !bytes.Equal(src[rawStart:rawStart+len(value)], value) {
+		b.fallback(string(value), fallback)
+		return
+	}
+	textStart := b.Len()
+	b.Write(value)
+	for from := 0; from < len(value); {
+		to := len(value)
+		if i := bytes.IndexByte(value[from:], '\n'); i >= 0 {
+			to = from + i + 1
+		}
+		b.intervals = append(b.intervals, SourceInterval{TextStart: textStart + from, TextEnd: textStart + to,
+			Literal: true, SourceSpan: mapper.span(rawBase+rawStart+from, rawBase+rawStart+to)})
+		from = to
+	}
+}
+
 func (p *markdownParser) Parse(path string, data []byte) (*Document, error) {
 	meta, body, offset := splitFrontmatter(data)
-
+	mapper := newSourceMapper(data)
 	md := goldmark.New()
-	reader := text.NewReader(body)
-	node := md.Parser().Parse(reader)
+	node := md.Parser().Parse(text.NewReader(body))
 
 	doc := &Document{Meta: meta, Title: meta.Title}
 	var sections []Section
 	var currentHeadings []string
 	var currentBuf strings.Builder
-	var currentOrdinal int
+	var currentMap []SourceInterval
 
-	// Frontmatter is worth retrieving but not worth indexing as YAML: promote it
-	// to a leading section of plain prose instead of leaking syntax into chunks.
-	if summary := meta.Summary(); summary != "" {
-		sections = append(sections, Section{Text: summary, Ordinal: 0})
+	if summaryFields := meta.summaryFields(); len(summaryFields) > 0 {
+		parts := make([]string, len(summaryFields))
+		for i, field := range summaryFields {
+			parts[i] = field.text
+		}
+		summary := strings.Join(parts, "\n")
+		whole := mapper.span(0, offset)
+		fields := frontmatterFieldSpans(data, offset, mapper)
+		var summaryMap []SourceInterval
+		textOffset := 0
+		for i, field := range summaryFields {
+			if i > 0 {
+				separator := SourceInterval{TextStart: textOffset, TextEnd: textOffset + 1, SourceSpan: sourcePointAt(summaryMap[len(summaryMap)-1].SourceSpan)}
+				summaryMap = append(summaryMap, separator)
+				textOffset++
+			}
+			span, ok := fields[field.key]
+			if !ok {
+				span = whole
+			}
+			summaryMap = append(summaryMap, SourceInterval{TextStart: textOffset, TextEnd: textOffset + len(field.text), SourceSpan: span})
+			textOffset += len(field.text)
+		}
+		sections = append(sections, Section{Text: summary, Ordinal: summaryMap[0].SourceSpan.Start,
+			SourceMap: summaryMap})
 	}
-	// The fallback below asks whether the body produced anything, so a
-	// frontmatter summary must not count as body text.
 	fromFrontmatter := len(sections)
-
 	var headings []string
-	var firstHeadingOrdinal int
+	var headingSpans []SourceSpan
 
 	flush := func() {
-		text := strings.TrimSpace(currentBuf.String())
+		text, sourceMap := trimMappedText(currentBuf.String(), currentMap)
 		if text != "" {
-			sections = append(sections, Section{
-				HeadingPath: strings.Join(currentHeadings, " > "),
-				Text:        text,
-				Ordinal:     currentOrdinal + offset,
-			})
+			ordinal := 0
+			if len(sourceMap) > 0 {
+				ordinal = sourceMap[0].SourceSpan.Start
+			}
+			sections = append(sections, Section{HeadingPath: strings.Join(currentHeadings, " > "),
+				Text: text, Ordinal: ordinal, SourceMap: sourceMap})
 		}
 		currentBuf.Reset()
+		currentMap = nil
+	}
+
+	appendMapped := func(n ast.Node, mapped mappedText) {
+		if mapped.text == "" {
+			return
+		}
+		base := currentBuf.Len()
+		if base > 0 {
+			separator := sourcePoint(n, offset, mapper)
+			currentMap = append(currentMap, SourceInterval{TextStart: base, TextEnd: base + 1, SourceSpan: separator})
+			currentBuf.WriteByte('\n')
+			base++
+		}
+		currentBuf.WriteString(mapped.text)
+		for _, interval := range mapped.intervals {
+			interval.TextStart += base
+			interval.TextEnd += base
+			currentMap = append(currentMap, interval)
+		}
 	}
 
 	ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -58,40 +133,32 @@ func (p *markdownParser) Parse(path string, data []byte) (*Document, error) {
 		case *ast.Heading:
 			if entering {
 				flush()
-				headingText := nodeText(v, body)
-				level := v.Level
-				if level == 1 && doc.Title == "" {
+				headingText := nodeMappedText(v, body, offset, mapper).text
+				if v.Level == 1 && doc.Title == "" {
 					doc.Title = headingText
 				}
-				// Truncate heading stack to this level
-				if level-1 < len(currentHeadings) {
-					currentHeadings = currentHeadings[:level-1]
+				if v.Level-1 < len(currentHeadings) {
+					currentHeadings = currentHeadings[:v.Level-1]
 				}
 				currentHeadings = append(currentHeadings, headingText)
-				if v.Lines() != nil && v.Lines().Len() > 0 {
-					seg := v.Lines().At(0)
-					currentOrdinal = seg.Start
-				}
 				if headingText != "" {
-					if len(headings) == 0 {
-						firstHeadingOrdinal = currentOrdinal
-					}
 					headings = append(headings, headingText)
+					headingSpans = append(headingSpans, nodeSourceSpan(v, offset, mapper))
 				}
 			}
 		case *ast.Paragraph, *ast.FencedCodeBlock, *ast.CodeBlock:
 			if entering {
-				currentBuf.WriteString(nodeText(v, body))
-				currentBuf.WriteByte('\n')
+				appendMapped(v, nodeMappedText(v, body, offset, mapper))
 			}
 		case *ast.ListItem:
 			if entering {
-				// Take the whole item — including any nested list — in one pass
-				// and skip children, or the *ast.Paragraph case above would
-				// emit a loose item's text a second time.
-				currentBuf.WriteString("- ")
-				currentBuf.WriteString(nodeText(v, body))
-				currentBuf.WriteByte('\n')
+				mapped := nodeMappedText(v, body, offset, mapper)
+				if mapped.text != "" {
+					span := sourcePoint(v, offset, mapper)
+					mapped.text = "- " + mapped.text
+					mapped.intervals = prependSynthetic(mapped.intervals, span, 2)
+					appendMapped(v, mapped)
+				}
 				return ast.WalkSkipChildren, nil
 			}
 		}
@@ -99,53 +166,132 @@ func (p *markdownParser) Parse(path string, data []byte) (*Document, error) {
 	})
 
 	flush()
-	// A document that is nothing but headings would otherwise be stored active
-	// with zero chunks and be unfindable. Every heading goes in, not just the
-	// first: the deeper ones carry the words worth searching for. Headings of
-	// documents that do have body text need no chunk of their own — they are
-	// already searchable through chunks_fts.heading_path.
 	if len(sections) == fromFrontmatter && len(headings) > 0 {
-		sections = append(sections, Section{
-			Text:    strings.Join(headings, "\n"),
-			Ordinal: firstHeadingOrdinal + offset,
-		})
+		var b strings.Builder
+		var sourceMap []SourceInterval
+		for i, heading := range headings {
+			if i > 0 {
+				start := b.Len()
+				b.WriteByte('\n')
+				sourceMap = append(sourceMap, SourceInterval{TextStart: start, TextEnd: start + 1, SourceSpan: sourcePointAt(headingSpans[i-1])})
+			}
+			start := b.Len()
+			b.WriteString(heading)
+			sourceMap = append(sourceMap, SourceInterval{TextStart: start, TextEnd: b.Len(), SourceSpan: headingSpans[i]})
+		}
+		text := b.String()
+		sections = append(sections, Section{Text: text, Ordinal: headingSpans[0].Start,
+			SourceMap: sourceMap})
 	}
 	doc.Sections = sections
 	return doc, nil
 }
 
-// nodeText returns the text of n and every descendant. Container nodes such as
-// ListItem and Blockquote hold their words several levels down, so scanning
-// direct children alone silently drops them.
-func nodeText(n ast.Node, src []byte) string {
-	var buf bytes.Buffer
+// nodeMappedText emits retrieval text and its raw-source map together, rather
+// than trying to locate transformed text in the source afterward.
+func nodeMappedText(n ast.Node, src []byte, offset int, mapper sourceMapper) mappedText {
+	var b mappedBuilder
+	fallback := nodeSourceSpan(n, offset, mapper)
 	_ = ast.Walk(n, func(c ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
-			// Keep block structure readable when several blocks flatten into
-			// one string, as a nested list inside a list item does.
 			if c != n && c.Type() == ast.TypeBlock {
-				buf.WriteByte('\n')
+				b.fallback("\n", sourcePoint(c, offset, mapper))
 			}
 			return ast.WalkContinue, nil
 		}
 		switch t := c.(type) {
 		case *ast.Text:
-			buf.Write(t.Segment.Value(src))
+			seg := t.Segment
+			value := seg.Value(src)
+			b.raw(value, seg.Start, offset, src, mapper, mapper.span(offset+seg.Start, offset+seg.Stop))
 			if t.SoftLineBreak() || t.HardLineBreak() {
-				buf.WriteByte(' ')
+				// The source newline belongs to this line, not the following one.
+				b.fallback(" ", mapper.span(offset+seg.Stop, offset+seg.Stop))
 			}
 		case *ast.String:
-			buf.Write(t.Value)
+			b.fallback(string(t.Value), fallback)
 		case *ast.AutoLink:
-			buf.Write(t.URL(src))
+			b.fallback(string(t.URL(src)), fallback)
 		case *ast.FencedCodeBlock, *ast.CodeBlock:
 			lines := c.Lines()
 			for i := 0; i < lines.Len(); i++ {
 				seg := lines.At(i)
-				buf.Write(seg.Value(src))
+				b.raw(seg.Value(src), seg.Start, offset, src, mapper, mapper.span(offset+seg.Start, offset+seg.Stop))
 			}
 		}
 		return ast.WalkContinue, nil
 	})
-	return strings.TrimSpace(buf.String())
+	text, intervals := trimMappedText(b.String(), b.intervals)
+	return mappedText{text: text, intervals: intervals}
+}
+
+func trimMappedText(text string, intervals []SourceInterval) (string, []SourceInterval) {
+	left := strings.TrimLeftFunc(text, unicode.IsSpace)
+	start := len(text) - len(left)
+	end := start + len(strings.TrimRightFunc(left, unicode.IsSpace))
+	out := make([]SourceInterval, 0, len(intervals))
+	for _, interval := range intervals {
+		if interval.TextEnd <= start || interval.TextStart >= end {
+			continue
+		}
+		interval = interval.Clip(start, end)
+		interval.TextStart -= start
+		interval.TextEnd -= start
+		out = append(out, interval)
+	}
+	return text[start:end], out
+}
+
+func prependSynthetic(intervals []SourceInterval, span SourceSpan, prefixBytes int) []SourceInterval {
+	out := []SourceInterval{{TextStart: 0, TextEnd: prefixBytes, SourceSpan: span}}
+	for _, interval := range intervals {
+		interval.TextStart += prefixBytes
+		interval.TextEnd += prefixBytes
+		out = append(out, interval)
+	}
+	return out
+}
+
+func sourcePoint(n ast.Node, offset int, mapper sourceMapper) SourceSpan {
+	span := nodeSourceSpan(n, offset, mapper)
+	return sourcePointAt(span)
+}
+
+func sourcePointAt(span SourceSpan) SourceSpan {
+	span.End = span.Start
+	span.EndLine = span.StartLine
+	return span
+}
+
+func nodeSourceSpan(n ast.Node, offset int, mapper sourceMapper) SourceSpan {
+	start, end := -1, -1
+	consider := func(v ast.Node) {
+		if v.Type() != ast.TypeBlock {
+			return
+		}
+		lines := v.Lines()
+		if lines == nil || lines.Len() == 0 {
+			return
+		}
+		first, last := lines.At(0), lines.At(lines.Len()-1)
+		if start < 0 || first.Start < start {
+			start = first.Start
+		}
+		if last.Stop > end {
+			end = last.Stop
+		}
+	}
+	consider(n)
+	if start < 0 {
+		_ = ast.Walk(n, func(v ast.Node, entering bool) (ast.WalkStatus, error) {
+			if entering {
+				consider(v)
+			}
+			return ast.WalkContinue, nil
+		})
+	}
+	if start < 0 {
+		return mapper.span(offset, offset)
+	}
+	return mapper.span(offset+start, offset+end)
 }

--- a/internal/parser/markdown_test.go
+++ b/internal/parser/markdown_test.go
@@ -106,6 +106,37 @@ func TestFrontmatterTimestampBeatsDate(t *testing.T) {
 	}
 }
 
+func TestFrontmatterScalarRangeStopsBeforeNextKey(t *testing.T) {
+	doc := parseMD(t, "---\ntitle: hello\ntags:\n  - foo\n---\n\nbody\n")
+	spans := sourceLineSpans(t, doc.Sections[0])
+	if len(spans) != 2 {
+		t.Fatalf("summary spans = %+v", spans)
+	}
+	if spans[0].StartLine != 2 || spans[0].EndLine != 2 {
+		t.Errorf("title span = %+v, want scalar line 2 only", spans[0])
+	}
+	if spans[1].StartLine != 4 || spans[1].EndLine != 4 {
+		t.Errorf("tags span = %+v, want value line 4", spans[1])
+	}
+}
+
+func TestFrontmatterSummaryUsesFieldRanges(t *testing.T) {
+	doc := parseMD(t, withFrontmatter)
+	spans := sourceLineSpans(t, doc.Sections[0])
+	if len(spans) != 3 {
+		t.Fatalf("summary spans = %+v", spans)
+	}
+	if spans[0].StartLine != 3 || spans[0].EndLine != 3 {
+		t.Errorf("title span = %+v, want line 3", spans[0])
+	}
+	if spans[1].StartLine != 4 || spans[1].EndLine != 4 {
+		t.Errorf("description span = %+v, want line 4", spans[1])
+	}
+	if spans[2].StartLine != 7 || spans[2].EndLine != 8 {
+		t.Errorf("tags span = %+v, want lines 7-8", spans[2])
+	}
+}
+
 func TestFrontmatterNeverReachesChunkBody(t *testing.T) {
 	got := bodyText(parseMD(t, withFrontmatter))
 	for _, leak := range []string{"resource:", "type:", "timestamp:", "tags:"} {
@@ -267,5 +298,74 @@ func TestFrontmatterDoesNotSuppressTheHeadingFallback(t *testing.T) {
 	}
 	if !strings.Contains(joined, "Project Unicorn") {
 		t.Errorf("sections = %+v, want one containing %q", doc.Sections, "Project Unicorn")
+	}
+}
+
+func TestSourceSpansRemainRawWithFrontmatterCRLFAndUnicode(t *testing.T) {
+	src := "---\r\ntitle: Café\r\n---\r\n\r\n# Héading\r\n\r\n- first café\r\n- second\r\n\r\n## Next\r\n\r\nbody\r\n"
+	doc := parseMD(t, src)
+	if len(doc.Sections) != 3 {
+		t.Fatalf("got %d sections: %+v", len(doc.Sections), doc.Sections)
+	}
+	if got := doc.Sections[0].SourceMap[0].StartLine; got != 2 {
+		t.Errorf("frontmatter title StartLine = %d, want 2", got)
+	}
+	for _, section := range doc.Sections[1:] {
+		if len(section.SourceMap) == 0 {
+			t.Fatalf("section %q has no source map", section.HeadingPath)
+		}
+		if section.Ordinal != section.SourceMap[0].Start {
+			t.Errorf("section %q Ordinal = %d, want source start %d", section.HeadingPath, section.Ordinal, section.SourceMap[0].Start)
+		}
+		for _, span := range section.SourceMap {
+			if span.StartLine < 6 || span.EndLine < span.StartLine {
+				t.Errorf("section %q has invalid raw span %+v", section.HeadingPath, span)
+			}
+		}
+	}
+	if got := doc.Sections[1].Text; !strings.Contains(got, "first café") {
+		t.Errorf("list transformation lost Unicode text: %q", got)
+	}
+	if got := sourceLineSpans(t, doc.Sections[1])[0].StartLine; got != 7 {
+		t.Errorf("first list item source line = %d, want 7", got)
+	}
+	if got := sourceLineSpans(t, doc.Sections[1])[1].StartLine; got != 8 {
+		t.Errorf("second list item source line = %d, want 8", got)
+	}
+}
+
+func TestSourceMapUsesIntervalsNotPerRuneEntries(t *testing.T) {
+	doc := parseMD(t, "# H\n\n"+strings.Repeat("x", 10000)+"\n")
+	if len(doc.Sections) != 1 || len(doc.Sections[0].SourceMap) >= len([]rune(doc.Sections[0].Text))/10 {
+		t.Fatalf("source map is not compressed: text=%d intervals=%d", len(doc.Sections[0].Text), len(doc.Sections[0].SourceMap))
+	}
+}
+
+func sourceLineSpans(t *testing.T, section Section) []SourceSpan {
+	t.Helper()
+	var spans []SourceSpan
+	start := 0
+	for _, line := range strings.Split(section.Text, "\n") {
+		span, ok := SourceRange(section.SourceMap, start, start+len(line))
+		if !ok {
+			t.Fatalf("no source range for %q", line)
+		}
+		spans = append(spans, span)
+		start += len(line) + 1
+	}
+	return spans
+}
+
+func TestCodeLinesKeepDistinctRawSpans(t *testing.T) {
+	doc := parseMD(t, "# Code\n\n```go\nα\nβ\n```\n")
+	spans := sourceLineSpans(t, doc.Sections[0])
+	if len(doc.Sections) != 1 || len(spans) != 2 {
+		t.Fatalf("sections = %+v, want two code-line spans", doc.Sections)
+	}
+	if spans[0].StartLine != 4 || spans[1].StartLine != 5 {
+		t.Errorf("code spans = %+v, want lines 4 and 5", spans)
+	}
+	if spans[0].Start >= spans[1].Start {
+		t.Errorf("code spans are not ordered: %+v", spans)
 	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,10 +1,34 @@
 package parser
 
+// SourceSpan identifies the raw source represented by a piece of parsed text.
+// Offsets are byte offsets (end exclusive); lines are 1-indexed and inclusive.
+type SourceSpan struct {
+	Start     int
+	End       int
+	StartLine int
+	EndLine   int
+}
+
+// SourceInterval maps a transformed text byte interval to a raw source span.
+// Keeping intervals rather than one entry per rune bounds map memory by AST
+// fragments and source lines while retaining exact literal byte deltas. For
+// non-1:1 generated text, the source span is a conservative envelope.
+type SourceInterval struct {
+	TextStart int
+	TextEnd   int
+	// Literal intervals preserve bytes exactly and lie within one source line.
+	Literal bool
+	SourceSpan
+}
+
 // Section is a logical division of a document (heading + content).
 type Section struct {
 	HeadingPath string // e.g. "Introduction > Background"
 	Text        string
 	Ordinal     int // byte offset where this section starts
+
+	// SourceMap maps transformed byte intervals to raw source spans.
+	SourceMap []SourceInterval
 }
 
 // Document is the parsed output of a file.

--- a/internal/parser/plaintext.go
+++ b/internal/parser/plaintext.go
@@ -16,10 +16,11 @@ type plaintextParser struct{}
 func (p *plaintextParser) Parse(path string, data []byte) (*Document, error) {
 	text := string(data)
 	title := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	mapper := newSourceMapper(data)
 	return &Document{
 		Title: title,
 		Sections: []Section{
-			{Text: text, Ordinal: 0},
+			{Text: text, Ordinal: 0, SourceMap: rawLineMap(data, mapper)},
 		},
 	}, nil
 }

--- a/internal/parser/source.go
+++ b/internal/parser/source.go
@@ -1,0 +1,93 @@
+package parser
+
+import (
+	"bytes"
+	"sort"
+)
+
+// sourceMapper converts offsets in the original input to source spans. Keeping
+// this map next to parsing is important: rendered Markdown is not reversible.
+type sourceMapper struct {
+	starts []int
+}
+
+func newSourceMapper(data []byte) sourceMapper {
+	starts := []int{0}
+	for i, b := range data {
+		if b == '\n' {
+			starts = append(starts, i+1)
+		}
+	}
+	return sourceMapper{starts: starts}
+}
+
+func (m sourceMapper) lineAt(offset int) int {
+	if offset < 0 {
+		offset = 0
+	}
+	line := sort.Search(len(m.starts), func(i int) bool { return m.starts[i] > offset })
+	if line == 0 {
+		return 1
+	}
+	return line
+}
+
+func (m sourceMapper) span(start, end int) SourceSpan {
+	if start < 0 {
+		start = 0
+	}
+	if end < start {
+		end = start
+	}
+	return SourceSpan{Start: start, End: end, StartLine: m.lineAt(start), EndLine: m.lineAt(max(start, end-1))}
+}
+
+// rawLineMap maps plaintext transformed bytes to source line intervals. It is
+// linear in the input and bounded by line count, not rune count.
+func rawLineMap(data []byte, m sourceMapper) []SourceInterval {
+	var out []SourceInterval
+	start := 0
+	for start < len(data) {
+		end := len(data)
+		if i := bytes.IndexByte(data[start:], '\n'); i >= 0 {
+			end = start + i + 1
+		}
+		out = append(out, SourceInterval{TextStart: start, TextEnd: end, Literal: true, SourceSpan: m.span(start, end)})
+		start = end
+	}
+	return out
+}
+
+// Clip restricts a mapping to an overlapping transformed byte interval.
+// Literal intervals stay on one source line, so clipping adjusts bytes only;
+// transformed intervals retain their conservative source envelope.
+func (s SourceInterval) Clip(start, end int) SourceInterval {
+	from, to := max(start, s.TextStart), min(end, s.TextEnd)
+	if s.Literal {
+		s.Start += from - s.TextStart
+		s.End -= s.TextEnd - to
+	}
+	s.TextStart, s.TextEnd = from, to
+	return s
+}
+
+// SourceRange combines the source spans overlapping transformed bytes [start,end).
+// Maps are ordered by transformed position, even when source fragments reorder.
+func SourceRange(intervals []SourceInterval, start, end int) (SourceSpan, bool) {
+	if end <= start {
+		return SourceSpan{}, false
+	}
+	i := sort.Search(len(intervals), func(i int) bool { return intervals[i].TextEnd > start })
+	var out SourceSpan
+	found := false
+	for ; i < len(intervals) && intervals[i].TextStart < end; i++ {
+		span := intervals[i].Clip(start, end).SourceSpan
+		if !found {
+			out, found = span, true
+			continue
+		}
+		out.Start, out.End = min(out.Start, span.Start), max(out.End, span.End)
+		out.StartLine, out.EndLine = min(out.StartLine, span.StartLine), max(out.EndLine, span.EndLine)
+	}
+	return out, found
+}

--- a/internal/search/bm25.go
+++ b/internal/search/bm25.go
@@ -79,8 +79,11 @@ func (b *BM25) searchFTS(ctx context.Context, opts SearchOpts, ftsQuery string) 
 			c.id,
 			d.collection,
 			d.path,
+			d.content_hash,
 			COALESCE(d.title, d.path),
 			COALESCE(c.heading_path, ''),
+			COALESCE(c.start_line, 0),
+			COALESCE(c.end_line, 0),
 			COALESCE(d.doc_timestamp, ''),
 			snippet(chunks_fts, 0, ?, ?, '...', 32),
 			-bm25(chunks_fts)
@@ -89,6 +92,7 @@ func (b *BM25) searchFTS(ctx context.Context, opts SearchOpts, ftsQuery string) 
 		JOIN documents d ON d.id = c.doc_id
 		WHERE chunks_fts MATCH ?
 		  AND d.active = 1
+		  AND c.start_line >= 1 AND c.end_line >= c.start_line
 		  %s
 		ORDER BY bm25(chunks_fts)
 	`, filters)
@@ -110,11 +114,13 @@ func (b *BM25) searchFTS(ctx context.Context, opts SearchOpts, ftsQuery string) 
 		var r Result
 		var score float64
 		if err := rows.Scan(
-			&r.DocID, &r.ChunkID, &r.Collection, &r.Path,
-			&r.Title, &r.HeadingPath, &r.Timestamp, &r.Snippet, &score,
+			&r.DocID, &r.ChunkID, &r.Collection, &r.Path, &r.Hash,
+			&r.Title, &r.HeadingPath, &r.StartLine, &r.EndLine,
+			&r.Timestamp, &r.Snippet, &score,
 		); err != nil {
 			return nil, err
 		}
+		r.SourceURI = SourceURI(r.Collection, r.Path)
 		if seenDoc[r.DocID] {
 			continue // a document is represented by its best-ranked chunk
 		}
@@ -130,8 +136,74 @@ func (b *BM25) searchFTS(ctx context.Context, opts SearchOpts, ftsQuery string) 
 			break
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if passageLimit(opts) > 0 && len(results) > 0 {
+		if err := b.addPassages(ctx, opts, ftsQuery, results); err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}
 
-	return results, rows.Err()
+func (b *BM25) addPassages(ctx context.Context, opts SearchOpts, ftsQuery string, results []Result) error {
+	limit := passageLimit(opts)
+	if limit == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(results))
+	byDoc := make(map[int64]int, len(results))
+	for i, r := range results {
+		placeholders[i] = "?"
+		byDoc[r.DocID] = i
+	}
+	query := fmt.Sprintf(`
+		SELECT c.doc_id, c.id, COALESCE(c.heading_path, ''),
+		       COALESCE(c.start_line, 0), COALESCE(c.end_line, 0),
+		       snippet(chunks_fts, 0, ?, ?, '...', 32)
+		FROM chunks_fts
+		JOIN chunks c ON c.id = chunks_fts.rowid
+		JOIN documents d ON d.id = c.doc_id
+		WHERE chunks_fts MATCH ? AND d.active = 1
+		  AND c.start_line >= 1 AND c.end_line >= c.start_line
+		  AND c.doc_id IN (%s)
+		ORDER BY bm25(chunks_fts)
+	`, strings.Join(placeholders, ","))
+	// The snippet arguments and MATCH argument come first, followed by doc IDs.
+	args := []any{HighlightOpen, HighlightClose, ftsQuery}
+	for _, r := range results {
+		args = append(args, r.DocID)
+	}
+	counts := make(map[int64]int, len(results))
+	seen := make(map[int64]map[int64]bool, len(results))
+	for _, r := range results {
+		seen[r.DocID] = map[int64]bool{r.ChunkID: true}
+	}
+	rows, err := b.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("bm25 passages query: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var docID, chunkID int64
+		var p Passage
+		if err := rows.Scan(&docID, &chunkID, &p.HeadingPath, &p.StartLine, &p.EndLine, &p.Snippet); err != nil {
+			return err
+		}
+		if counts[docID] >= limit || seen[docID][chunkID] {
+			continue
+		}
+		r := &results[byDoc[docID]]
+		p.ChunkID = chunkID
+		r.Passages = append(r.Passages, p)
+		seen[docID][chunkID] = true
+		counts[docID]++
+	}
+	return rows.Err()
 }
 
 // ftsStopWords are common English words excluded from FTS5 queries to avoid

--- a/internal/search/bm25_test.go
+++ b/internal/search/bm25_test.go
@@ -28,14 +28,14 @@ func seedTestData(t *testing.T, database *db.DB) {
 		INSERT INTO content(hash, body) VALUES ('hash1', 'body1');
 		INSERT INTO documents(collection, path, title, content_hash)
 			VALUES ('test', 'doc1.md', 'Go Programming', 'hash1');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('hash1', 1, 0, 'Go is an open source programming language.', 'Intro', 0, 41);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('hash1', 1, 0, 'Go is an open source programming language.', 'Intro', 0, 41, 1, 1);
 
 		INSERT INTO content(hash, body) VALUES ('hash2', 'body2');
 		INSERT INTO documents(collection, path, title, content_hash)
 			VALUES ('test', 'doc2.md', 'Python Tutorial', 'hash2');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('hash2', 2, 0, 'Python is a high-level programming language.', 'Intro', 0, 44);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('hash2', 2, 0, 'Python is a high-level programming language.', 'Intro', 0, 44, 1, 1);
 	`)
 	if err != nil {
 		t.Fatalf("seeding test data: %v", err)
@@ -69,6 +69,45 @@ func TestBM25_Search(t *testing.T) {
 	}
 }
 
+func TestBM25_ResultMetadataAndBoundedPassages(t *testing.T) {
+	database := openTestDB(t)
+	ctx := context.Background()
+	if _, err := database.ExecContext(ctx, `
+		INSERT INTO content(hash, body) VALUES ('full-hash', 'source');
+		INSERT INTO documents(collection, path, title, content_hash)
+			VALUES ('test', 'dir/a b.md', 'A', 'full-hash');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('full-hash', 1, 0, 'needle primary', 'Intro', 0, 14, 3, 4);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('full-hash', 1, 1, 'needle support one', 'Details', 20, 18, 8, 9);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('full-hash', 1, 2, 'needle support two', 'More', 40, 18, 12, 13);
+	`); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	results, err := NewBM25(database).Search(ctx, SearchOpts{Query: "needle", TopK: 1, Passages: 1})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if r.Hash != "full-hash" || r.SourceURI != "qi://test/dir/a%20b.md" {
+		t.Fatalf("metadata = hash %q uri %q", r.Hash, r.SourceURI)
+	}
+	if r.StartLine == 0 || r.EndLine == 0 {
+		t.Fatalf("missing primary range: %d-%d", r.StartLine, r.EndLine)
+	}
+	if len(r.Passages) != 1 || r.Passages[0].ChunkID == r.ChunkID {
+		t.Fatalf("passages = %+v, want one additional chunk", r.Passages)
+	}
+	if r.Passages[0].StartLine != 8 || r.Passages[0].EndLine != 9 {
+		t.Errorf("passage range = %d-%d, want 8-9", r.Passages[0].StartLine, r.Passages[0].EndLine)
+	}
+}
+
 func TestBM25_CollectionFilter(t *testing.T) {
 	database := openTestDB(t)
 	seedTestData(t, database)
@@ -79,8 +118,8 @@ func TestBM25_CollectionFilter(t *testing.T) {
 		INSERT INTO content(hash, body) VALUES ('hash3', 'body3');
 		INSERT INTO documents(collection, path, title, content_hash)
 			VALUES ('other', 'doc3.md', 'Rust Language', 'hash3');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('hash3', 3, 0, 'Rust is a systems programming language.', 'Intro', 0, 39);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('hash3', 3, 0, 'Rust is a systems programming language.', 'Intro', 0, 39, 1, 1);
 	`)
 	if err != nil {
 		t.Fatalf("seeding: %v", err)
@@ -162,8 +201,8 @@ func TestBM25PoolIsBoundedByDocuments(t *testing.T) {
 	}
 	for i := range 30 {
 		if _, err := database.ExecContext(ctx,
-			`INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			 VALUES ('hv', 1, ?, 'widget widget widget', 'S', 0, 20)`, i); err != nil {
+			`INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			 VALUES ('hv', 1, ?, 'widget widget widget', 'S', 0, 20, ?, ?)`, i, i+1, i+1); err != nil {
 			t.Fatalf("seeding chunk %d: %v", i, err)
 		}
 	}
@@ -179,8 +218,8 @@ func TestBM25PoolIsBoundedByDocuments(t *testing.T) {
 			t.Fatalf("seeding other document %d: %v", i, err)
 		}
 		if _, err := database.ExecContext(ctx,
-			`INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			 SELECT ?, id, 0, 'a widget lives here', 'S', 0, 19 FROM documents WHERE path = ?`,
+			`INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			 SELECT ?, id, 0, 'a widget lives here', 'S', 0, 19, 1, 1 FROM documents WHERE path = ?`,
 			hash, path); err != nil {
 			t.Fatalf("seeding chunk for other document %d: %v", i, err)
 		}

--- a/internal/search/bm25_unicode_test.go
+++ b/internal/search/bm25_unicode_test.go
@@ -16,26 +16,26 @@ func TestBM25_MultilingualAndPunctuationQueries(t *testing.T) {
 		INSERT INTO content(hash, body) VALUES ('hcjk', 'body-cjk');
 		INSERT INTO documents(collection, path, title, content_hash)
 			VALUES ('test', 'cjk.md', 'CJK Doc', 'hcjk');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('hcjk', 1, 0, '这是 中文 文档 内容', 'Intro', 0, 9);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('hcjk', 1, 0, '这是 中文 文档 内容', 'Intro', 0, 9, 1, 1);
 
 		INSERT INTO content(hash, body) VALUES ('hcyr', 'body-cyr');
 		INSERT INTO documents(collection, path, title, content_hash)
 			VALUES ('test', 'cyr.md', 'Cyrillic Doc', 'hcyr');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('hcyr', 2, 0, 'привет мир программирование', 'Intro', 0, 27);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('hcyr', 2, 0, 'привет мир программирование', 'Intro', 0, 27, 1, 1);
 
 		INSERT INTO content(hash, body) VALUES ('hara', 'body-ara');
 		INSERT INTO documents(collection, path, title, content_hash)
 			VALUES ('test', 'ara.md', 'Arabic Doc', 'hara');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('hara', 3, 0, 'مرحبا بالعالم برمجة', 'Intro', 0, 20);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('hara', 3, 0, 'مرحبا بالعالم برمجة', 'Intro', 0, 20, 1, 1);
 
 		INSERT INTO content(hash, body) VALUES ('hacc', 'body-acc');
 		INSERT INTO documents(collection, path, title, content_hash)
 			VALUES ('test', 'acc.md', 'Accented Doc', 'hacc');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('hacc', 4, 0, 'Le café et le résumé sont sur la façade naïve.', 'Intro', 0, 47);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('hacc', 4, 0, 'Le café et le résumé sont sur la façade naïve.', 'Intro', 0, 47, 1, 1);
 	`); err != nil {
 		t.Fatalf("seeding multilingual data: %v", err)
 	}

--- a/internal/search/citations_test.go
+++ b/internal/search/citations_test.go
@@ -1,0 +1,117 @@
+package search
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/itsmostafa/qi/internal/config"
+	"github.com/itsmostafa/qi/internal/providers"
+)
+
+func TestCitationSearchSkipsInvalidRanges(t *testing.T) {
+	for _, route := range []string{"bm25", "vector"} {
+		t.Run(route, func(t *testing.T) {
+			ctx := context.Background()
+			database := openTestDB(t)
+			seedTestData(t, database)
+			if _, err := database.ExecContext(ctx, `UPDATE chunks SET text=?, start_line=NULL, end_line=NULL WHERE id=2`, "programming "+strings.Repeat("filler ", 100)); err != nil {
+				t.Fatal(err)
+			}
+			for id, vector := range map[int64][]float32{1: {1, 0}, 2: {0, 1}} {
+				if err := database.UpsertEmbedding(ctx, id, vector, "test", "model", 2, "fp"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for _, tc := range []struct {
+				name     string
+				sql      string
+				limit    int
+				passages int
+				wantNone bool
+			}{
+				{name: "unknown outside pool", limit: 1},
+				{name: "unknown selected primary", limit: 2},
+				{name: "unknown unrequested sibling", sql: `UPDATE chunks SET doc_id=1, content_hash='hash1', seq=1 WHERE id=2`, limit: 1},
+				{name: "unknown requested sibling", limit: 1, passages: 1},
+				{name: "inverted requested sibling", sql: `UPDATE chunks SET start_line=5, end_line=2 WHERE id=2`, limit: 1, passages: 1},
+				{name: "unknown best primary", sql: `UPDATE chunks SET start_line=NULL, end_line=NULL WHERE id=1`, limit: 1, wantNone: true},
+				{name: "valid sibling replaces primary", sql: `UPDATE chunks SET start_line=2, end_line=3 WHERE id=2`, limit: 1},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					if tc.sql != "" {
+						if _, err := database.ExecContext(ctx, tc.sql); err != nil {
+							t.Fatal(err)
+						}
+					}
+					opts := SearchOpts{Query: "programming", TopK: tc.limit, Pool: tc.limit, Passages: tc.passages}
+					var results []Result
+					var err error
+					if route == "bm25" {
+						results, err = NewBM25(database).Search(ctx, opts)
+					} else {
+						results, err = NewVectorSearch(database, "fp").Search(ctx, []float32{1, 0}, tc.limit, opts)
+					}
+					if tc.wantNone {
+						if err != nil || len(results) != 0 {
+							t.Fatalf("expected no citable results, got results=%+v err=%v", results, err)
+						}
+					} else if err != nil || len(results) != 1 || results[0].DocID != 1 || len(results[0].Passages) != 0 {
+						t.Fatalf("unexpected results=%+v err=%v", results, err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestHybridKeepsValidVectorHitsWithUnknownRanges(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+	seedTestData(t, database)
+	if _, err := database.ExecContext(ctx, `
+		UPDATE chunks SET text='semantic evidence', start_line=NULL, end_line=NULL WHERE id=2;
+		INSERT INTO chunks(content_hash, doc_id, seq, text, content_length, start_line, end_line)
+		VALUES ('hash2', 2, 1, 'valid semantic evidence', 23, 2, 3);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	for id, vector := range map[int64][]float32{2: {1, 0}, 3: {1, 0.1}} {
+		if err := database.UpsertEmbedding(ctx, id, vector, "test", "model", 2, "fp"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"index":0,"embedding":[1,0]}]}`))
+	}))
+	defer srv.Close()
+	embedder := providers.NewEmbedding(&config.EmbeddingProviderConfig{BaseURL: srv.URL, Model: "model", Dimension: 2})
+	hybrid := NewHybrid(NewBM25(database), NewVectorSearch(database, "fp"), embedder, config.SearchConfig{VectorTopK: 1})
+	results, err := hybrid.Search(ctx, SearchOpts{Query: "programming", TopK: 1, Passages: 1})
+	if err != nil || len(results) != 2 {
+		t.Fatalf("valid vector document lost: results=%+v err=%v", results, err)
+	}
+	for _, r := range results {
+		if r.DocID == 2 && (r.ChunkID != 3 || len(r.Passages) != 0) {
+			t.Fatalf("invalid vector evidence returned: %+v", r)
+		}
+	}
+}
+
+func TestFusionEvidenceIsOptInAndKeepsOtherPrimary(t *testing.T) {
+	bm25 := []Result{{DocID: 1, ChunkID: 10, StartLine: 2, EndLine: 3}}
+	vec := []Result{{DocID: 1, ChunkID: 20, StartLine: 8, EndLine: 9}}
+	without := ReciprocalRankFusion(bm25, vec, 60, 0)
+	with := ReciprocalRankFusion(bm25, vec, 60, 1)
+	if len(without) != 1 || len(without[0].Passages) != 0 {
+		t.Fatalf("unrequested evidence: %+v", without)
+	}
+	if len(with) != 1 || with[0].ChunkID != 10 || len(with[0].Passages) != 1 || with[0].Passages[0].ChunkID != 20 || with[0].Passages[0].StartLine != 8 || with[0].Passages[0].EndLine != 9 {
+		t.Fatalf("other route's primary lost: %+v", with)
+	}
+	if with[0].Score != without[0].Score {
+		t.Fatal("supporting evidence changed document rank")
+	}
+}

--- a/internal/search/fusion.go
+++ b/internal/search/fusion.go
@@ -35,39 +35,65 @@ func applyExtensionBoost(results []Result, exts []string, boost float64) []Resul
 // document: each list contributes a document once, at its best rank, so a
 // verbose file cannot buy rank with extra matching chunks or take extra slots.
 // k is the rank constant (default 60 per the paper).
-// Returns results sorted by descending RRF score.
-//
-// ponytail: the better-ranked of the document's two chunks represents it and
-// the siblings are dropped. Keeping them as extra evidence for context
-// expansion needs a Result that can carry more than one chunk, which nothing
-// asks for yet.
-func ReciprocalRankFusion(bm25 []Result, vec []Result, k int) []Result {
+// Returns results sorted by descending RRF score. Both route primaries and
+// supporting passages become evidence candidates, but only one document
+// position per route contributes to the RRF score.
+func ReciprocalRankFusion(bm25 []Result, vec []Result, k int, maxPassages int) []Result {
+	passageCap := max(0, min(maxPassages, MaxPassages))
 	if k <= 0 {
 		k = 60
 	}
 
 	type score struct {
-		result   Result
-		rrfScore float64
-		bm25Rank int
-		vecRank  int
-		bm25Sc   float64
-		vecDist  float64
+		result      Result
+		rrfScore    float64
+		bm25Rank    int
+		vecRank     int
+		bm25Sc      float64
+		vecDist     float64
+		evidence    []Passage
+		evidenceIDs map[int64]bool
+	}
+
+	primaryPassage := func(r Result) Passage {
+		return Passage{
+			ChunkID: r.ChunkID, HeadingPath: r.HeadingPath, Snippet: r.Snippet,
+			StartLine: r.StartLine, EndLine: r.EndLine,
+		}
+	}
+	addEvidence := func(s *score, passages ...Passage) {
+		if passageCap == 0 {
+			return
+		}
+		for _, p := range passages {
+			if s.evidenceIDs[p.ChunkID] {
+				continue
+			}
+			if s.evidenceIDs == nil {
+				s.evidenceIDs = map[int64]bool{}
+			}
+			s.evidenceIDs[p.ChunkID] = true
+			s.evidence = append(s.evidence, p)
+		}
 	}
 
 	byDoc := map[int64]*score{}
-
 	for i, r := range bm25 {
-		if _, ok := byDoc[r.DocID]; ok {
+		s, ok := byDoc[r.DocID]
+		if ok {
+			addEvidence(s, r.Passages...)
 			continue // already counted at a better rank
 		}
 		rank := i + 1
-		byDoc[r.DocID] = &score{
+		s = &score{
 			result:   r,
 			rrfScore: 1.0 / float64(k+rank),
 			bm25Rank: rank,
 			bm25Sc:   r.Score,
 		}
+		byDoc[r.DocID] = s
+		addEvidence(s, primaryPassage(r))
+		addEvidence(s, r.Passages...)
 	}
 
 	for i, r := range vec {
@@ -77,23 +103,37 @@ func ReciprocalRankFusion(bm25 []Result, vec []Result, k int) []Result {
 			s = &score{result: r}
 			byDoc[r.DocID] = s
 		} else if s.vecRank > 0 {
+			addEvidence(s, r.Passages...)
 			continue // already counted at a better rank
 		} else if s.bm25Rank == 0 || rank < s.bm25Rank {
 			// Show the chunk the better-ranked list picked, or the snippet
 			// contradicts the ranks reported beside it.
 			s.result = r
 		}
+		addEvidence(s, primaryPassage(r))
+		addEvidence(s, r.Passages...)
 		s.rrfScore += 1.0 / float64(k+rank)
 		s.vecRank = rank
 		s.vecDist = 1.0/(r.Score+1e-9) - 1.0 // invert similarity back to distance
 	}
 
-	// Flatten and sort
+	// Flatten and sort. Remove the winning primary before applying the cap so
+	// the other route's primary can still fill the final evidence slots.
 	results := make([]Result, 0, len(byDoc))
 	for _, s := range byDoc {
 		r := s.result
 		r.Score = s.rrfScore
 		r.Scale = ScaleRRF
+		r.Passages = nil
+		for _, p := range s.evidence {
+			if p.ChunkID == r.ChunkID {
+				continue
+			}
+			r.Passages = append(r.Passages, p)
+			if len(r.Passages) >= passageCap {
+				break
+			}
+		}
 		if r.Explain != nil || s.bm25Rank > 0 || s.vecRank > 0 {
 			r.Explain = &ScoreExplain{
 				BM25Score:  s.bm25Sc,

--- a/internal/search/fusion_test.go
+++ b/internal/search/fusion_test.go
@@ -48,7 +48,7 @@ func TestApplyExtensionBoost_DefaultBoost(t *testing.T) {
 }
 
 func TestRRF_EmptyLists(t *testing.T) {
-	result := ReciprocalRankFusion(nil, nil, 60)
+	result := ReciprocalRankFusion(nil, nil, 60, 0)
 	if len(result) != 0 {
 		t.Errorf("expected empty result, got %d items", len(result))
 	}
@@ -60,7 +60,7 @@ func TestRRF_OnlyBM25(t *testing.T) {
 		makeResult(2, 2.0),
 		makeResult(3, 1.0),
 	}
-	results := ReciprocalRankFusion(bm25, nil, 60)
+	results := ReciprocalRankFusion(bm25, nil, 60, 0)
 	if len(results) != 3 {
 		t.Fatalf("expected 3 results, got %d", len(results))
 	}
@@ -74,7 +74,7 @@ func TestRRF_MergesLists(t *testing.T) {
 	bm25 := []Result{makeResult(1, 3.0), makeResult(2, 2.0)}
 	vec := []Result{makeResult(2, 0.9), makeResult(3, 0.8)}
 
-	results := ReciprocalRankFusion(bm25, vec, 60)
+	results := ReciprocalRankFusion(bm25, vec, 60, 0)
 
 	// chunk 2 appears in both → should score highest
 	if results[0].ChunkID != 2 {
@@ -85,11 +85,45 @@ func TestRRF_MergesLists(t *testing.T) {
 	}
 }
 
+func TestRRF_MergesPassagesWithoutChangingWinnerOrRank(t *testing.T) {
+	bm25 := []Result{{DocID: 99, ChunkID: 90, Score: 3}, {
+		DocID: 1, ChunkID: 10, Hash: "bm-hash", SourceURI: "qi://c/a.md", Score: 2,
+		Passages: []Passage{{ChunkID: 11, Snippet: "bm support"}, {ChunkID: 12, Snippet: "shared"}},
+	}}
+	vec := []Result{{
+		DocID: 1, ChunkID: 20, Hash: "vec-hash", SourceURI: "qi://c/a.md", Score: 1,
+		Passages: []Passage{{ChunkID: 12, Snippet: "shared"}, {ChunkID: 13, Snippet: "vec support"}},
+	}}
+	results := ReciprocalRankFusion(bm25, vec, 60, 3)
+	var winner Result
+	for _, r := range results {
+		if r.DocID == 1 {
+			winner = r
+		}
+	}
+	if winner.ChunkID != 20 || winner.Hash != "vec-hash" {
+		t.Fatalf("winner metadata = %+v, want vector winner", winner)
+	}
+	if len(winner.Passages) != 3 {
+		t.Fatalf("passages = %+v, want 3 unique supports", winner.Passages)
+	}
+	seen := map[int64]bool{}
+	for _, p := range winner.Passages {
+		if seen[p.ChunkID] {
+			t.Fatalf("passage chunk %d counted twice", p.ChunkID)
+		}
+		seen[p.ChunkID] = true
+	}
+	if winner.Explain == nil || winner.Explain.BM25Rank != 2 || winner.Explain.VectorRank != 1 {
+		t.Fatalf("rank explanation = %+v", winner.Explain)
+	}
+}
+
 func TestRRF_ScoresDescending(t *testing.T) {
 	bm25 := []Result{makeResult(1, 3.0), makeResult(2, 2.0), makeResult(3, 1.0)}
 	vec := []Result{makeResult(3, 0.9), makeResult(2, 0.8), makeResult(1, 0.7)}
 
-	results := ReciprocalRankFusion(bm25, vec, 60)
+	results := ReciprocalRankFusion(bm25, vec, 60, 0)
 	for i := 1; i < len(results); i++ {
 		if results[i].Score > results[i-1].Score {
 			t.Errorf("results not sorted descending at index %d: %.6f > %.6f",
@@ -102,7 +136,7 @@ func TestRRF_ArithmeticK60(t *testing.T) {
 	// Rank 1 in both lists with k=60 should give 2 * 1/(60+1)
 	bm25 := []Result{makeResult(1, 1.0)}
 	vec := []Result{makeResult(1, 1.0)}
-	results := ReciprocalRankFusion(bm25, vec, 60)
+	results := ReciprocalRankFusion(bm25, vec, 60, 0)
 	expected := 2.0 / 61.0
 	if len(results) == 0 {
 		t.Fatal("no results")
@@ -122,7 +156,7 @@ func TestRRF_FusesByDocument(t *testing.T) {
 		{DocID: 10, ChunkID: 1, Score: 2.0},
 		{DocID: 10, ChunkID: 2, Score: 1.0},
 	}
-	results := ReciprocalRankFusion(bm25, nil, 60)
+	results := ReciprocalRankFusion(bm25, nil, 60, 0)
 
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results (one per document), got %d", len(results))
@@ -149,7 +183,7 @@ func TestRRF_RepresentativeChunkComesFromTheBetterRankedList(t *testing.T) {
 	}
 	vec := []Result{{DocID: 10, ChunkID: 2}}
 
-	for _, r := range ReciprocalRankFusion(bm25, vec, 60) {
+	for _, r := range ReciprocalRankFusion(bm25, vec, 60, 0) {
 		if r.DocID != 10 {
 			continue
 		}

--- a/internal/search/hybrid.go
+++ b/internal/search/hybrid.go
@@ -93,7 +93,7 @@ func (h *Hybrid) Search(ctx context.Context, opts SearchOpts) ([]Result, error) 
 	if k <= 0 {
 		k = 60
 	}
-	fused := ReciprocalRankFusion(bm25Results, vecResults, k)
+	fused := ReciprocalRankFusion(bm25Results, vecResults, k, passageLimit(opts))
 
 	if !opts.Explain {
 		for i := range fused {

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -1,20 +1,50 @@
 package search
 
+import (
+	"net/url"
+	"strings"
+)
+
+// Passage is an additional matched chunk belonging to a search result.
+type Passage struct {
+	ChunkID     int64  `json:"chunk_id"`
+	HeadingPath string `json:"heading_path"`
+	Snippet     string `json:"snippet"`
+	StartLine   int    `json:"start_line"`
+	EndLine     int    `json:"end_line"`
+}
+
+// SourceURI returns a stable, URL-escaped source identity for a path in a
+// collection. Slashes delimit path segments; characters within a segment are
+// escaped using net/url semantics.
+func SourceURI(collection, path string) string {
+	segments := strings.Split(path, "/")
+	for i, segment := range segments {
+		segments[i] = url.PathEscape(segment)
+	}
+	return "qi://" + collection + "/" + strings.Join(segments, "/")
+}
+
 // Result is a single search hit.
 type Result struct {
 	DocID       int64   `json:"doc_id"`
 	ChunkID     int64   `json:"chunk_id"`
 	Collection  string  `json:"collection"`
 	Path        string  `json:"path"`
+	SourceURI   string  `json:"source_uri"`
+	Hash        string  `json:"hash"`
 	Title       string  `json:"title"`
 	HeadingPath string  `json:"heading_path"`
 	Snippet     string  `json:"snippet"`
+	StartLine   int     `json:"start_line"`
+	EndLine     int     `json:"end_line"`
 	Timestamp   string  `json:"timestamp"`
 	Score       float64 `json:"score"`
 	// Scale names the unit of Score. BM25 magnitudes and RRF scores differ by
 	// two orders of magnitude and are not comparable across commands.
-	Scale   string        `json:"scale"`
-	Explain *ScoreExplain `json:"explain,omitempty"`
+	Scale    string        `json:"scale"`
+	Explain  *ScoreExplain `json:"explain,omitempty"`
+	Passages []Passage     `json:"passages,omitempty"`
 }
 
 // ScoreExplain breaks down how a score was computed.
@@ -24,6 +54,13 @@ type ScoreExplain struct {
 	VectorDist float64 `json:"vector_distance,omitempty"`
 	VectorRank int     `json:"vector_rank,omitempty"`
 	RRFScore   float64 `json:"rrf_score,omitempty"`
+}
+
+// MaxPassages bounds the additional evidence returned per document.
+const MaxPassages = 5
+
+func passageLimit(opts SearchOpts) int {
+	return min(max(opts.Passages, 0), MaxPassages)
 }
 
 // SearchOpts configures a search operation.
@@ -37,4 +74,5 @@ type SearchOpts struct {
 	Since      string // YYYY-MM-DD, inclusive lower bound on document timestamp
 	Until      string // YYYY-MM-DD, inclusive upper bound
 	Sort       string // "" = relevance, "date" = newest first
+	Passages   int    // additional matched chunks per result, capped at 5
 }

--- a/internal/search/vector.go
+++ b/internal/search/vector.go
@@ -59,8 +59,11 @@ func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, top
 			c.id,
 			d.collection,
 			d.path,
+			d.content_hash,
 			COALESCE(d.title, d.path),
 			COALESCE(c.heading_path, ''),
+			COALESCE(c.start_line, 0),
+			COALESCE(c.end_line, 0),
 			COALESCE(d.doc_timestamp, ''),
 			c.text,
 			cv.vector
@@ -69,6 +72,7 @@ func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, top
 		JOIN documents d ON d.id = c.doc_id
 		JOIN embeddings em ON em.chunk_id = cv.chunk_id
 		WHERE d.active = 1
+		  AND c.start_line >= 1 AND c.end_line >= c.start_line
 		  AND em.fingerprint = ?
 		  %s
 	`, collectionFilter)
@@ -84,11 +88,13 @@ func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, top
 		var r Result
 		var blob []byte
 		if err := rows.Scan(
-			&r.DocID, &r.ChunkID, &r.Collection, &r.Path,
-			&r.Title, &r.HeadingPath, &r.Timestamp, &r.Snippet, &blob,
+			&r.DocID, &r.ChunkID, &r.Collection, &r.Path, &r.Hash,
+			&r.Title, &r.HeadingPath, &r.StartLine, &r.EndLine,
+			&r.Timestamp, &r.Snippet, &blob,
 		); err != nil {
 			return nil, err
 		}
+		r.SourceURI = SourceURI(r.Collection, r.Path)
 		if err := db.ValidateEmbeddingBlob(blob, len(queryEmbedding)); err != nil {
 			// Defense in depth: fingerprint matching should exclude stale
 			// dimensions, while shared validation also rejects malformed,
@@ -111,26 +117,45 @@ func (v *VectorSearch) Search(ctx context.Context, queryEmbedding []float32, top
 
 	// One chunk per document, for the same reason BM25 stops at poolSize
 	// distinct documents: a verbose file must not fill the pool with chunks
-	// that collapse to a single result later.
-	deduped := candidates[:0:0]
+	// that collapse to a single result later. Supporting passages are gathered
+	// only after this document pool is fixed.
+	selected := make([]vecCandidate, 0, topK)
 	seenDoc := map[int64]bool{}
 	for _, c := range candidates {
 		if seenDoc[c.DocID] {
 			continue
 		}
 		seenDoc[c.DocID] = true
-		deduped = append(deduped, c)
-		if len(deduped) >= topK {
+		selected = append(selected, c)
+		if len(selected) >= topK {
 			break
 		}
 	}
-	candidates = deduped
 
-	results := make([]Result, len(candidates))
-	for i, c := range candidates {
+	results := make([]Result, len(selected))
+	for i, c := range selected {
 		r := c.Result
 		r.Score = 1.0 / (1.0 + c.dist)
 		results[i] = r
+	}
+	if limit := passageLimit(opts); limit > 0 {
+		resultByDoc := make(map[int64]int, len(results))
+		primaryByDoc := make(map[int64]int64, len(results))
+		counts := make(map[int64]int, len(results))
+		for i, r := range results {
+			resultByDoc[r.DocID] = i
+			primaryByDoc[r.DocID] = r.ChunkID
+		}
+		for _, c := range candidates {
+			if _, ok := resultByDoc[c.DocID]; !ok || c.ChunkID == primaryByDoc[c.DocID] || counts[c.DocID] >= limit {
+				continue
+			}
+			results[resultByDoc[c.DocID]].Passages = append(results[resultByDoc[c.DocID]].Passages, Passage{
+				ChunkID: c.ChunkID, HeadingPath: c.HeadingPath, Snippet: c.Snippet,
+				StartLine: c.StartLine, EndLine: c.EndLine,
+			})
+			counts[c.DocID]++
+		}
 	}
 	return results, nil
 }

--- a/internal/search/vector_test.go
+++ b/internal/search/vector_test.go
@@ -13,13 +13,13 @@ func TestVectorSearch_FiltersByFingerprint(t *testing.T) {
 	if _, err := database.ExecContext(ctx, `
 		INSERT INTO content(hash, body) VALUES ('h1', 'b1');
 		INSERT INTO documents(collection, path, title, content_hash) VALUES ('test', 'a.md', 'A', 'h1');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('h1', 1, 0, 'chunk from current model', 'Intro', 0, 25);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('h1', 1, 0, 'chunk from current model', 'Intro', 0, 25, 1, 1);
 
 		INSERT INTO content(hash, body) VALUES ('h2', 'b2');
 		INSERT INTO documents(collection, path, title, content_hash) VALUES ('test', 'b.md', 'B', 'h2');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('h2', 2, 0, 'chunk from stale model', 'Intro', 0, 23);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('h2', 2, 0, 'chunk from stale model', 'Intro', 0, 23, 1, 1);
 	`); err != nil {
 		t.Fatalf("seeding documents/chunks: %v", err)
 	}
@@ -59,8 +59,8 @@ func TestVectorSearch_EmptyFingerprintReturnsNoResults(t *testing.T) {
 	if _, err := database.ExecContext(ctx, `
 		INSERT INTO content(hash, body) VALUES ('h1', 'b1');
 		INSERT INTO documents(collection, path, title, content_hash) VALUES ('test', 'a.md', 'A', 'h1');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('h1', 1, 0, 'chunk text', 'Intro', 0, 10);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('h1', 1, 0, 'chunk text', 'Intro', 0, 10, 1, 1);
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -100,8 +100,8 @@ func TestVectorSearch_SkipsMismatchedDimensionDefensively(t *testing.T) {
 	if _, err := database.ExecContext(ctx, `
 		INSERT INTO content(hash, body) VALUES ('h1', 'b1');
 		INSERT INTO documents(collection, path, title, content_hash) VALUES ('test', 'a.md', 'A', 'h1');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('h1', 1, 0, 'chunk text', 'Intro', 0, 10);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('h1', 1, 0, 'chunk text', 'Intro', 0, 10, 1, 1);
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -127,6 +127,46 @@ func TestVectorSearch_SkipsMismatchedDimensionDefensively(t *testing.T) {
 
 // A document with several near chunks must not occupy several slots: the pool
 // is bounded by documents, so its nearest chunk represents it.
+func TestVectorSearch_MetadataAndBoundedPassages(t *testing.T) {
+	database := openTestDB(t)
+	ctx := context.Background()
+	if _, err := database.ExecContext(ctx, `
+		INSERT INTO content(hash, body) VALUES ('vector-hash', 'source');
+		INSERT INTO documents(collection, path, title, content_hash)
+			VALUES ('test', 'notes/a b.md', 'A', 'vector-hash');
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('vector-hash', 1, 0, 'nearest', 'Intro', 0, 7, 2, 3);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('vector-hash', 1, 1, 'support one', 'Details', 20, 11, 6, 7);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('vector-hash', 1, 2, 'support two', 'More', 40, 11, 10, 11);
+	`); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	for id, vector := range map[int64][]float32{
+		1: {1, 0, 0, 0},
+		2: {0.99, 0.14, 0, 0},
+		3: {0.98, 0.2, 0, 0},
+	} {
+		if err := database.UpsertEmbedding(ctx, id, vector, "test", "model", 4, "fp"); err != nil {
+			t.Fatalf("embedding %d: %v", id, err)
+		}
+	}
+	results, err := NewVectorSearch(database, "fp").Search(ctx, []float32{1, 0, 0, 0}, 1, SearchOpts{Passages: 1})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 1 || results[0].Hash != "vector-hash" || results[0].SourceURI != "qi://test/notes/a%20b.md" {
+		t.Fatalf("result metadata = %+v", results)
+	}
+	if results[0].StartLine != 2 || results[0].EndLine != 3 {
+		t.Fatalf("primary range = %d-%d", results[0].StartLine, results[0].EndLine)
+	}
+	if len(results[0].Passages) != 1 || results[0].Passages[0].StartLine != 6 {
+		t.Fatalf("passages = %+v, want one bounded support", results[0].Passages)
+	}
+}
+
 func TestVectorSearch_OneChunkPerDocument(t *testing.T) {
 	database := openTestDB(t)
 	ctx := context.Background()
@@ -134,15 +174,15 @@ func TestVectorSearch_OneChunkPerDocument(t *testing.T) {
 	if _, err := database.ExecContext(ctx, `
 		INSERT INTO content(hash, body) VALUES ('h1', 'b1');
 		INSERT INTO documents(collection, path, title, content_hash) VALUES ('test', 'a.md', 'A', 'h1');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('h1', 1, 0, 'near', 'Intro', 0, 4);
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('h1', 1, 1, 'also near', 'Intro', 0, 9);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('h1', 1, 0, 'near', 'Intro', 0, 4, 1, 1);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('h1', 1, 1, 'also near', 'Intro', 0, 9, 2, 2);
 
 		INSERT INTO content(hash, body) VALUES ('h2', 'b2');
 		INSERT INTO documents(collection, path, title, content_hash) VALUES ('test', 'b.md', 'B', 'h2');
-		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length)
-			VALUES ('h2', 2, 0, 'further', 'Intro', 0, 7);
+		INSERT INTO chunks(content_hash, doc_id, seq, text, heading_path, ordinal, content_length, start_line, end_line)
+			VALUES ('h2', 2, 0, 'further', 'Intro', 0, 7, 1, 1);
 	`); err != nil {
 		t.Fatalf("seeding: %v", err)
 	}

--- a/skills/qi-cli/SKILL.md
+++ b/skills/qi-cli/SKILL.md
@@ -63,14 +63,16 @@ qi query "question" --explain               # show BM25/vector/RRF score breakdo
 With no `--mode`, the mode comes from `search.default_mode` in the config (`hybrid` by default).
 
 ### `qi get <id>`
-Retrieve a document by its 6-character hash prefix (shown in search results). An
-ambiguous prefix is an error listing the candidates, never a dump of all of them.
+Retrieve the indexed source snapshot by the full `hash` returned in search JSON
+(or an unambiguous hex prefix). Use the hit's `start_line:end_line` for its source
+passage. An ambiguous prefix is an error; identical content at multiple paths is
+returned once, with other locations in `also_at`.
 
 ```bash
 qi get abc123
 qi get abc123 --lines 40:80      # 1-indexed, inclusive; "40:" and ":80" also work
 qi get abc123 --max-bytes 4096   # truncate and say so (0 = unlimited)
-qi get abc123 --format json      # {collection, path, title, hash, body, truncated}
+qi get abc123 --format json      # indexed source body and citation metadata
 ```
 
 Prefer `--lines`/`--max-bytes` over reading whole documents: they are what keeps
@@ -117,6 +119,7 @@ These are per-command, not global.
 |---|---|
 | `-c, --collection <name>` | Limit to a specific collection |
 | `-n, --limit <N>` | Number of results (default: 10) |
+| `--passages <N>` | Additional supporting passages per document, 0–5 (default: 0) |
 | `--since YYYY-MM-DD` | Only documents dated on or after this day |
 | `--until YYYY-MM-DD` | Only documents dated on or before this day |
 | `--sort date` | Newest first instead of by relevance |
@@ -196,7 +199,24 @@ providers:
 
 ## Document references
 
-Search results show locations like `qi://notes/2024/jan.md [Section > Subsection]` and a 6-character ID. Use `qi get <id>` to view the full document.
+Search JSON includes `hash` (full SHA-256 retrieval handle/source version),
+`source_uri` (collection/path identity), and `start_line`/`end_line` (1-indexed,
+inclusive raw-source range). Text/Markdown output includes a ready-to-run
+`qi get <hash> --lines A:B` command. Do not pass integer `doc_id` or `chunk_id`
+to `get`. Reuse the same `--config` override when retrieving a hit.
+
+Cite the source URI, hash, and line range together. `--passages N` optionally
+attaches bounded supporting passages that inherit the parent hash and URI;
+it does not add ranking votes or result slots for the document.
+
+`get` returns the indexed snapshot even if the file has since changed on disk.
+The hash is not a claim of live-file freshness. Reindexing can remove old
+versions; qi is not a revision archive. For identical-content paths, retain the
+search hit's URI rather than substituting get's first location.
+
+Search skips chunks with missing or invalid source ranges. Repair older indexes
+with `qi index <collection>`, or `qi index /path/to/directory` if the collection
+is no longer in config.
 
 ---
 


### PR DESCRIPTION
## Summary

Search hits now identify the exact text that matched: a full content hash, an escaped `qi://` source URI, and an inclusive 1-indexed line range in the original file. Text and Markdown output print a ready-to-run `qi get <hash> --lines A:B` alongside each hit, so a result can be followed without translating internal IDs by hand. An opt-in `--passages 0–5` attaches bounded supporting evidence without giving a document extra result slots or ranking votes.

This implements finding 1 of the zvec-grep audit.

## Commits

- `feat(db)` record chunk source line ranges
- `feat(parser)` map retrieval text back to its raw source
- `feat(chunker)` resolve each chunk to a source line range
- `feat(indexer)` persist chunk line ranges and repair legacy rows
- `feat(search)` return citable hits and bounded supporting passages
- `fix(get)` resolve ambiguity by distinct hash, not by matched paths
- `feat(cmd)` print a runnable retrieval command with every hit
- `docs` describe citation fields, `--passages` and index repair
- `docs` record the zvec-grep audit and its first implemented finding

Each commit builds and vets independently (verified with `git rebase -x`).

## Changes

- Sections carry a `SourceMap` tying transformed bytes back to raw spans. Rendered Markdown is not reversible, so the mapping is emitted during parsing rather than reconstructed by searching prose afterward. Verbatim text clips precisely; synthesised text (list bullets, separators, frontmatter prose) keeps a conservative envelope.
- Frontmatter field spans come from YAML node line numbers, so a promoted title cites the line it was written on.
- Migration 007 adds nullable `chunks.start_line` / `end_line`.
- Both retrievers skip chunks whose range is unknown or invalid rather than citing lines that may not contain the match.
- `--passages` gathers extra chunks only after the document pool is fixed. Fusion keeps one ranking contribution per document per retriever; the sibling chunks it previously discarded become passages rather than votes.
- Oversized lines split on byte boundaries walked by rune instead of materialising a `[]rune`, keeping split points addressable in the source map.

## Breaking Changes

No CLI surface changes and the JSON additions are additive, so no major bump. **But there is a silent behavioral break on upgrade:** search now filters on `c.start_line >= 1`, and chunks indexed before this change hold NULL ranges. An existing index therefore returns **zero results with no error message** until it is rebuilt.

The fix is a normal `qi index <collection>`. The indexer detects legacy ranges once per collection and backfills them in place when the chunk layout is unchanged, so embeddings survive and the run reports `added=0 updated=0`. Only a changed layout forces a full rebuild. If the collection is no longer in config, index its directory directly: `qi index /path/to/directory`.

Returning nothing is deliberate over the alternative of inventing a plausible-looking range, which would produce citations pointing at the wrong text.

## Test Plan

- [x] `task check` passes (build, vet, full test suite)
- [x] Every commit compiles independently: `git rebase -x 'go build ./... && go vet ./...' main`
- [x] Manual search → get round trip on a fixture with frontmatter, headings and multiple sections:
  ```sh
  qi index notes --config qi.yaml
  qi search deployment --config qi.yaml --format json --passages 2
  qi get <hash> --config qi.yaml --lines 16:16
  ```
  Reported `#L16-L16` matches `sed -n '16p'` on the source exactly. Frontmatter passage maps to lines 2–3 (title + tags).
- [x] Upgrade path: nulling `start_line`/`end_line` yields `No results found.`; `qi index` repairs in place (`added=0 updated=0`); search returns hits again with identical BM25 scores to a from-scratch reindex.
- [x] Prefix validation: `qi get 'ab%'` is rejected rather than reaching the `LIKE` pattern as a wildcard.

New automated coverage: source-map round trips over Markdown/CRLF/Unicode/code fences, legacy-range repair, duplicate-content paths, bounded passages, and citation output formatting.

## Release Notes

Search and query results now tell you exactly where a match came from. Each hit carries the document's content hash, a `qi://` source URI, and the line range of the matching text, and text output prints the `qi get` command that retrieves precisely those lines. The new `--passages` flag (0–5) attaches additional matching excerpts from the same document as supporting evidence, without letting a verbose file take extra result slots.

`qi get` reads the indexed snapshot rather than the live file, so a matching hash confirms which version was indexed, not that the file on disk is unchanged.

After upgrading, run `qi index` on each collection once to add line ranges to existing chunks. Until you do, search returns no results.

## Checklist

- [x] Tests pass locally (`task check`)
- [x] Linting passes (`go vet`)
- [x] Documentation updated (README, `skills/qi-cli/SKILL.md`)
- [x] Breaking changes documented
- [x] Conventional commit format followed